### PR TITLE
chore: allow jsonfmt to format json5 files

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -36,6 +36,10 @@
       ];
 
       jackpkgs.pulumi.enable = false;
+      jackpkgs.fmt.jsonfmt.includes = [
+        "*.json"
+        "*.json5"
+      ];
 
       perSystem = {
         config,


### PR DESCRIPTION
## Summary
- include the `.json5` extension in the jsonfmt formatter configuration so JSON5 files are formatted consistently

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d77145433c832bb920467767c9aeaa