### PR TITLE
fix: configure npm authentication for GitHub registry

### DIFF
--- a/.github/workflows/pnpm.yml
+++ b/.github/workflows/pnpm.yml
@@ -109,6 +109,10 @@ jobs:
           echo "Configuring npm for GitHub registry authentication..."
           echo "//npm.pkg.github.com/:_authToken=${NODE_AUTH_TOKEN}" > ${{ matrix.package_path }}/.npmrc
           echo "@${{ github.repository_owner }}:registry=https://npm.pkg.github.com" >> ${{ matrix.package_path }}/.npmrc
+          if [ ! -f "${{ matrix.package_path }}/.npmrc" ]; then
+            echo "❌ Failed to create .npmrc file"
+            exit 1
+          fi
           echo "✅ Authentication configured for ${{ github.repository_owner }} packages"
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pnpm.yml
+++ b/.github/workflows/pnpm.yml
@@ -103,9 +103,19 @@ jobs:
           echo "- **Published:** \`${{ matrix.published_version }}\`" >> $GITHUB_STEP_SUMMARY
           echo "- **Change:** \`${{ matrix.release_type }}\`" >> $GITHUB_STEP_SUMMARY
           echo "- **Action:** \`${{ matrix.action }}\`" >> $GITHUB_STEP_SUMMARY
+      - name: Configure npm authentication
+        if: inputs.dry_run != true && matrix.action == 'publish'
+        run: |
+          echo "Configuring npm for GitHub registry authentication..."
+          echo "//npm.pkg.github.com/:_authToken=\${NODE_AUTH_TOKEN}" > ${{ matrix.package_path }}/.npmrc
+          echo "registry=https://npm.pkg.github.com" >> ${{ matrix.package_path }}/.npmrc
+          echo "Contents of .npmrc:"
+          cat ${{ matrix.package_path }}/.npmrc
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Publish package
         if: inputs.dry_run != true && matrix.action == 'publish'
-        run: nix develop --command pnpm publish --registry=https://npm.pkg.github.com --no-git-checks
+        run: nix develop --command pnpm publish --no-git-checks
         working-directory: ${{ matrix.package_path }}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pnpm.yml
+++ b/.github/workflows/pnpm.yml
@@ -107,10 +107,9 @@ jobs:
         if: inputs.dry_run != true && matrix.action == 'publish'
         run: |
           echo "Configuring npm for GitHub registry authentication..."
-          echo "//npm.pkg.github.com/:_authToken=\${NODE_AUTH_TOKEN}" > ${{ matrix.package_path }}/.npmrc
-          echo "registry=https://npm.pkg.github.com" >> ${{ matrix.package_path }}/.npmrc
-          echo "Contents of .npmrc:"
-          cat ${{ matrix.package_path }}/.npmrc
+          echo "//npm.pkg.github.com/:_authToken=${NODE_AUTH_TOKEN}" > ${{ matrix.package_path }}/.npmrc
+          echo "@${{ github.repository_owner }}:registry=https://npm.pkg.github.com" >> ${{ matrix.package_path }}/.npmrc
+          echo "✅ Authentication configured for ${{ github.repository_owner }} packages"
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Publish package
@@ -119,3 +118,9 @@ jobs:
         working-directory: ${{ matrix.package_path }}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Cleanup authentication
+        if: inputs.dry_run != true && matrix.action == 'publish'
+        run: |
+          echo "Cleaning up authentication files..."
+          rm -f ${{ matrix.package_path }}/.npmrc
+          echo "✅ Cleanup completed"


### PR DESCRIPTION
Add npm authentication configuration step before publishing to GitHub registry. Creates .npmrc file with NODE_AUTH_TOKEN and registry configuration to resolve ENEEDAUTH errors.

- Add 'Configure npm authentication' step that creates .npmrc in each package directory
- Configure registry and auth token for npm.pkg.github.com
- Simplify publish command to rely on .npmrc configuration
- Fixes authentication issues in dogfood publishing workflow