### PR TITLE
Add reusable workflow for pushing Nix container images

### DIFF
--- a/.github/actions/push-nix-image/action.yml
+++ b/.github/actions/push-nix-image/action.yml
@@ -1,0 +1,43 @@
+name: 'Push Nix Image'
+description: 'Build and push a Nix container image to a registry'
+inputs:
+  package-name:
+    description: 'Nix package name (e.g., zeus-image, ci-image)'
+    required: true
+  registry:
+    description: 'Container registry'
+    required: false
+    default: 'ghcr.io'
+  namespace:
+    description: 'Registry namespace (e.g., org/repo)'
+    required: true
+  image-name:
+    description: 'Image name in registry (defaults to package-name without -image suffix)'
+    required: false
+  tags:
+    description: 'Comma-separated list of tags'
+    required: true
+  system:
+    description: 'Nix system'
+    required: false
+    default: 'x86_64-linux'
+  registry-username:
+    description: 'Registry username (defaults to github.actor)'
+    required: false
+  registry-password:
+    description: 'Registry password/token'
+    required: true
+runs:
+  using: "composite"
+  steps:
+    - shell: bash
+      env:
+        INPUT_PACKAGE_NAME: ${{ inputs.package-name }}
+        INPUT_REGISTRY: ${{ inputs.registry }}
+        INPUT_NAMESPACE: ${{ inputs.namespace }}
+        INPUT_IMAGE_NAME: ${{ inputs.image-name }}
+        INPUT_TAGS: ${{ inputs.tags }}
+        INPUT_SYSTEM: ${{ inputs.system }}
+        INPUT_REGISTRY_USERNAME: ${{ inputs.registry-username }}
+        INPUT_REGISTRY_PASSWORD: ${{ inputs.registry-password }}
+      run: $GITHUB_ACTION_PATH/main.sh

--- a/.github/actions/push-nix-image/main.sh
+++ b/.github/actions/push-nix-image/main.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Required env vars:
+# INPUT_PACKAGE_NAME
+# INPUT_REGISTRY
+# INPUT_NAMESPACE
+# INPUT_TAGS
+# INPUT_SYSTEM
+# INPUT_REGISTRY_PASSWORD
+
+# Optional env vars:
+# INPUT_IMAGE_NAME
+# INPUT_REGISTRY_USERNAME (default: github.actor)
+
+REGISTRY="${INPUT_REGISTRY:-ghcr.io}"
+NAMESPACE="${INPUT_NAMESPACE}"
+PACKAGE="${INPUT_PACKAGE_NAME}"
+SYSTEM="${INPUT_SYSTEM:-x86_64-linux}"
+TAGS="${INPUT_TAGS}"
+# Use GITHUB_ACTOR if username not provided
+USERNAME="${INPUT_REGISTRY_USERNAME:-${GITHUB_ACTOR:-}}"
+PASSWORD="${INPUT_REGISTRY_PASSWORD}"
+
+# Determine image name
+if [ -n "${INPUT_IMAGE_NAME:-}" ]; then
+  IMAGE_NAME="${INPUT_IMAGE_NAME}"
+else
+  # Strip -image suffix if present
+  IMAGE_NAME="${PACKAGE%-image}"
+fi
+
+if [ -z "$TAGS" ]; then
+  echo "❌ No tags provided. Aborting." >&2
+  exit 1
+fi
+
+echo "Building Nix package: ${PACKAGE}"
+# Build the image once
+nix build ".#packages.${SYSTEM}.${PACKAGE}" -L
+
+IFS=',' read -ra TAG_ARRAY <<< "$TAGS"
+PUSHED_COUNT=0
+
+for tag in "${TAG_ARRAY[@]}"; do
+  # Trim whitespace
+  tag="$(echo "$tag" | xargs)"
+  if [ -z "$tag" ]; then
+    continue
+  fi
+
+  dest="docker://${REGISTRY}/${NAMESPACE}/${IMAGE_NAME}:${tag}"
+  echo "Pushing to: ${dest}"
+
+  nix run ".#packages.${SYSTEM}.${PACKAGE}.passthru.copyTo" -- \
+    "${dest}" \
+    --dest-creds "${USERNAME}:${PASSWORD}"
+  
+  PUSHED_COUNT=$((PUSHED_COUNT + 1))
+done
+
+if [ "$PUSHED_COUNT" -eq 0 ]; then
+  echo "❌ No valid tags found. No images were pushed." >&2
+  exit 1
+fi
+
+echo "✅ Successfully pushed image '${IMAGE_NAME}' with ${PUSHED_COUNT} tags."

--- a/.github/workflows/push-nix-image.yml
+++ b/.github/workflows/push-nix-image.yml
@@ -1,5 +1,4 @@
 name: '🚀 Push Nix Image to Registry'
-
 on:
   workflow_call:
     inputs:
@@ -41,7 +40,6 @@ on:
         description: 'Git ref to checkout'
         required: true
         type: string
-
     secrets:
       REGISTRY_USERNAME:
         description: 'Registry username (defaults to github.actor)'
@@ -49,72 +47,30 @@ on:
       REGISTRY_PASSWORD:
         description: 'Registry password/token (usually GITHUB_TOKEN)'
         required: true
-
 jobs:
   push-image:
     runs-on: ${{ inputs.runs-on }}
     permissions:
       contents: read
       packages: write
-
     steps:
       - name: Checkout repository
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           repository: ${{ inputs.repository }}
           ref: ${{ inputs.ref }}
-
       - name: Install Nix
         uses: jmmaloney4/toolbox/.github/actions/nix-setup@main
         with:
           runs-on: ${{ inputs.runs-on }}
-
-      - name: Determine image name
-        id: image-name
-        run: |
-          set -euo pipefail
-          if [ -n "${{ inputs.image-name }}" ]; then
-            IMAGE_NAME="${{ inputs.image-name }}"
-          else
-            IMAGE_NAME="${{ inputs.package-name }}"
-            IMAGE_NAME="${IMAGE_NAME%-image}"
-          fi
-          echo "name=${IMAGE_NAME}" >> "$GITHUB_OUTPUT"
-
-      - name: Build and push image
-        env:
-          REGISTRY: ${{ inputs.registry }}
-          NAMESPACE: ${{ inputs.namespace }}
-          IMAGE_NAME: ${{ steps.image-name.outputs.name }}
-          TAGS: ${{ inputs.tags }}
-          PACKAGE: ${{ inputs.package-name }}
-          SYSTEM: ${{ inputs.system }}
-          USERNAME: ${{ secrets.REGISTRY_USERNAME || github.actor }}
-          PASSWORD: ${{ secrets.REGISTRY_PASSWORD }}
-        run: |
-          set -euo pipefail
-
-          if [ -z "$TAGS" ]; then
-            echo "No tags provided. Aborting push." >&2
-            exit 1
-          fi
-
-          IFS=',' read -ra TAG_ARRAY <<< "$TAGS"
-
-          echo "Building Nix package: ${PACKAGE}"
-          nix build ".#packages.${SYSTEM}.${PACKAGE}" -L
-
-          for tag in "${TAG_ARRAY[@]}"; do
-            tag="$(echo "$tag" | xargs)"
-            if [ -z "$tag" ]; then
-              continue
-            fi
-            dest="docker://${REGISTRY}/${NAMESPACE}/${IMAGE_NAME}:${tag}"
-            echo "Pushing to: ${dest}"
-
-            nix run ".#packages.${SYSTEM}.${PACKAGE}.passthru.copyTo" -- \
-              "${dest}" \
-              --dest-creds "${USERNAME}:${PASSWORD}"
-          done
-
-          echo "✅ Successfully pushed image with tags: ${TAGS}"
+      - name: Push Nix Image
+        uses: jmmaloney4/toolbox/.github/actions/push-nix-image@main
+        with:
+          package-name: ${{ inputs.package-name }}
+          registry: ${{ inputs.registry }}
+          namespace: ${{ inputs.namespace }}
+          image-name: ${{ inputs.image-name }}
+          tags: ${{ inputs.tags }}
+          system: ${{ inputs.system }}
+          registry-username: ${{ secrets.REGISTRY_USERNAME || github.actor }}
+          registry-password: ${{ secrets.REGISTRY_PASSWORD }}


### PR DESCRIPTION
## Summary
- add a reusable workflow to build and push nix2container images with configurable tagging
- include inputs for runner, registry settings, and repository/ref checkout
- add safeguards for empty tags and reuse existing nix setup action

## Testing
- not run (workflow definition change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69335b2cdb38832b9018c7bb480cad95)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add a reusable GitHub Actions workflow to build Nix packages and push container images to a registry with configurable inputs and tagging.
> 
> - **CI / GitHub Actions**:
>   - **Reusable workflow** `/.github/workflows/push-nix-image.yml` to build a Nix package and push container images to a registry.
>     - Inputs: `runs-on`, `package-name`, `registry` (default `ghcr.io`), `namespace`, `image-name`, `tags`, `system` (default `x86_64-linux`), `repository`, `ref`.
>     - Secrets: `REGISTRY_USERNAME` (optional), `REGISTRY_PASSWORD` (required).
>     - Steps: checkout, install Nix via `jmmaloney4/toolbox/.github/actions/nix-setup@main`, derive `image-name` (defaults to `package-name` sans `-image`), build `.#packages.${system}.${package-name}`, and push per tag using `passthru.copyTo` with credentials; aborts on empty `tags`.
>     - Permissions: `contents: read`, `packages: write`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit db47407763107f132f26568620f187d83317028c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->