### PR TITLE
fix(renovate): remove top-level includePaths from nix.json

### DIFF
--- a/renovate/nix.json
+++ b/renovate/nix.json
@@ -4,7 +4,6 @@
 	"nix": {
 		"enabled": true
 	},
-	"includePaths": ["flake.nix", "flake.lock", "nix/**/*.nix"],
 	"regexManagers": [
 		{
 			"description": "Update fetchPypi packages in Nix files",


### PR DESCRIPTION
Fixes #79

Removes top-level `includePaths` from `renovate/nix.json`. The nix manager and regex managers use their own scoped `fileMatch` patterns, so this allows other managers (npm, python, cargo, etc.) to detect dependencies in this repository.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes the top-level `includePaths` from `renovate/nix.json` so Renovate no longer restricts updates to Nix files only.
> 
> - Keeps `nix` manager enabled and relies on each `regexManagers` entry’s `fileMatch` for Nix patterns
> - Allows other Renovate managers (e.g., npm, Python, Cargo) to detect and update dependencies elsewhere in the repo
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5dba1477853172672fc72a02aba17e77a6e54d31. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->