### PR TITLE
fix: remove global includePaths from pulumi preset

### DIFF
--- a/renovate/pulumi.json
+++ b/renovate/pulumi.json
@@ -1,7 +1,6 @@
 {
 	"$schema": "https://docs.renovatebot.com/renovate-schema.json",
 	"description": "Pulumi-specific Renovate configuration with regex managers for custom dependency extraction",
-	"includePaths": ["**/Pulumi.yaml", "**/Pulumi.*.yaml"],
 	"regexManagers": [
 		{
 			"fileMatch": ["(^|.*\\/)?Pulumi(\\..+)?\\.yaml$"],


### PR DESCRIPTION
## Summary

- Removes the top-level `includePaths` property from `renovate/pulumi.json` that was restricting Renovate to only scan Pulumi YAML files
- This fixes the issue where extending this preset would break all other package managers (npm, pip, cargo, etc.)

## Problem

The global `includePaths` configuration acts as an allowlist for the **entire** Renovate run. When `pulumi.json` is extended (e.g., via `all.json`), Renovate would only process files matching `**/Pulumi.yaml` patterns and ignore all other dependency files.

## Solution

Remove the `includePaths` property. The `regexManagers[].fileMatch` already correctly scopes the Pulumi manager to the intended files without affecting global file discovery.

Fixes #90
Related: cavinsresearch/zeus#308