### PR TITLE
fix(sector7): simplify AccountTokenPolicy.resources and tighten cloudflare peer dep

### DIFF
--- a/packages/sector7/package.json
+++ b/packages/sector7/package.json
@@ -35,7 +35,7 @@
 	},
 	"peerDependencies": {
 		"@pulumi/pulumi": "^3.0.0",
-		"@pulumi/cloudflare": "^5.0.0 || ^6.0.0",
+		"@pulumi/cloudflare": "^6.0.0",
 		"@pulumi/gcp": "^9.0.0",
 		"@aws-sdk/client-s3": "^3.0.0"
 	},

--- a/packages/sector7/workersite/worker-site.ts
+++ b/packages/sector7/workersite/worker-site.ts
@@ -534,13 +534,10 @@ export class WorkerSite extends pulumi.ComponentResource {
 									bucketName,
 									this.bucket?.location ?? args.r2Bucket.location ?? "default",
 								])
-								.apply(
-									([acctId, bktName, loc]: [string, string, string]) =>
-										({
-											[`com.cloudflare.edge.r2.bucket.${acctId}_${loc.toLowerCase()}_${bktName}`]:
-												"*",
-										}) as Record<string, string>,
-								),
+								.apply(([acctId, bktName, loc]: [string, string, string]) => ({
+									[`com.cloudflare.edge.r2.bucket.${acctId}_${loc.toLowerCase()}_${bktName}`]:
+										"*",
+								})),
 						},
 					],
 				},


### PR DESCRIPTION
## Summary

Clean up the `AccountTokenPolicy.resources` assignment in `WorkerSite` and tighten the `@pulumi/cloudflare` peer dependency.

## Changes

1. **Remove redundant `as Record<string, string>` type assertion** from the `.apply()` callback in `worker-site.ts`. The provider's `AccountTokenPolicy.resources` type is `pulumi.Input<{[key: string]: pulumi.Input<string>}>` — returning the object literal directly satisfies this type without a cast.

2. **Tighten `@pulumi/cloudflare` peer dep from `^5.0.0 || ^6.0.0` to `^6.0.0`**. The workersite module uses `AccountToken` and `WorkersCustomDomain`, neither of which exist in `@pulumi/cloudflare` v5. No consumer uses v5.

## Testing

- Type-checks cleanly when consumed by zeus via `nix build .#checks.aarch64-darwin.tsc -L`

---

> [!NOTE]
> **Low Risk**
> Removes a redundant type assertion (no runtime behavior change) and tightens a peer dependency range that was already only satisfied by v6 in practice.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: dependency range is tightened to a version already required by used resources, and the `resources` change only removes a redundant type assertion with no behavior change.
> 
> **Overview**
> Tightens the `@pulumi/cloudflare` peer dependency in `packages/sector7/package.json` to `^6.0.0`, dropping the previously allowed v5 range.
> 
> Simplifies `WorkerSite`’s R2 upload token policy by returning the `resources` object literal directly from the `.apply()` (removing the redundant `as Record<string, string>` cast) with no intended runtime change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 26f878dbac6c9401ef12eb4ab4c316faf6b821c7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->