### PR TITLE
feat: replace actions/add-to-project with local composite action

### DIFF
--- a/.github/actions/add-to-project/action.yml
+++ b/.github/actions/add-to-project/action.yml
@@ -1,0 +1,35 @@
+name: "Add to Project"
+description: "Add the current issue or PR to a GitHub Project V2 via gh CLI. Requires nix on the runner (self-hosted)."
+
+inputs:
+  project-url:
+    description: "GitHub Project URL (e.g. https://github.com/orgs/ORG/projects/N)"
+    required: true
+  github-token:
+    description: "Personal access token with project write access"
+    required: true
+  labeled:
+    description: "Comma-separated labels to filter; omit or empty to add all"
+    required: false
+    default: ""
+  label-operator:
+    description: "Label filter mode: AND, OR, or NOT (default OR)"
+    required: false
+    default: "OR"
+
+outputs:
+  item-id:
+    description: "Node ID of the added project item"
+    value: ${{ steps.add.outputs.itemId }}
+
+runs:
+  using: "composite"
+  steps:
+    - id: add
+      shell: bash
+      env:
+        INPUT_PROJECT_URL: ${{ inputs.project-url }}
+        INPUT_GITHUB_TOKEN: ${{ inputs.github-token }}
+        INPUT_LABELED: ${{ inputs.labeled }}
+        INPUT_LABEL_OPERATOR: ${{ inputs.label-operator }}
+      run: nix shell nixpkgs#gh nixpkgs#jq -- bash ${{ github.action_path }}/main.sh

--- a/.github/actions/add-to-project/action.yml
+++ b/.github/actions/add-to-project/action.yml
@@ -1,0 +1,35 @@
+name: "Add to Project"
+description: "Add the current issue or PR to a GitHub Project V2 via gh CLI"
+
+inputs:
+  project-url:
+    description: "GitHub Project URL (e.g. https://github.com/orgs/ORG/projects/N)"
+    required: true
+  github-token:
+    description: "Personal access token with project write access"
+    required: true
+  labeled:
+    description: "Comma-separated labels to filter; omit or empty to add all"
+    required: false
+    default: ""
+  label-operator:
+    description: "Label filter mode: AND, OR, or NOT (default OR)"
+    required: false
+    default: "OR"
+
+outputs:
+  item-id:
+    description: "Node ID of the added project item"
+    value: ${{ steps.add.outputs.itemId }}
+
+runs:
+  using: "composite"
+  steps:
+    - id: add
+      shell: bash
+      env:
+        INPUT_PROJECT_URL: ${{ inputs.project-url }}
+        INPUT_GITHUB_TOKEN: ${{ inputs.github-token }}
+        INPUT_LABELED: ${{ inputs.labeled }}
+        INPUT_LABEL_OPERATOR: ${{ inputs.label-operator }}
+      run: ${{ github.action_path }}/main.sh

--- a/.github/actions/add-to-project/action.yml
+++ b/.github/actions/add-to-project/action.yml
@@ -32,4 +32,4 @@ runs:
         INPUT_GITHUB_TOKEN: ${{ inputs.github-token }}
         INPUT_LABELED: ${{ inputs.labeled }}
         INPUT_LABEL_OPERATOR: ${{ inputs.label-operator }}
-      run: ${{ github.action_path }}/main.sh
+      run: nix shell nixpkgs#gh nixpkgs#jq -- bash ${{ github.action_path }}/main.sh

--- a/.github/actions/add-to-project/action.yml
+++ b/.github/actions/add-to-project/action.yml
@@ -1,5 +1,5 @@
 name: "Add to Project"
-description: "Add the current issue or PR to a GitHub Project V2 via gh CLI"
+description: "Add the current issue or PR to a GitHub Project V2 via gh CLI. Requires nix on the runner (self-hosted)."
 
 inputs:
   project-url:

--- a/.github/actions/add-to-project/main.sh
+++ b/.github/actions/add-to-project/main.sh
@@ -96,7 +96,7 @@ fi
 
 # --- Get project node ID ---
 echo "Fetching project node ID..."
-PROJECT_ID=$(gh api graphql --fail \
+PROJECT_ID=$(gh api graphql \
   -f query="query(\$owner: String!, \$number: Int!) {
     ${GRAPHQL_OWNER}(login: \$owner) { projectV2(number: \$number) { id } }
   }" \
@@ -112,7 +112,7 @@ fi
 # --- Add item to project ---
 if [[ "$ISSUE_OWNER" == "$OWNER_NAME" ]]; then
   echo "Adding item to project (same owner)"
-  ITEM_ID=$(gh api graphql --fail \
+  ITEM_ID=$(gh api graphql \
     -f query='mutation($projectId: ID!, $contentId: ID!) {
       addProjectV2ItemById(input: { projectId: $projectId, contentId: $contentId }) {
         item { id }
@@ -125,7 +125,7 @@ else
   # Cross-owner: create a draft issue linking to the original
   ISSUE_URL=$(jq -r '(.issue // .pull_request).html_url // empty' <<< "$EVENT")
   echo "Adding draft issue to project (cross-owner: ${ISSUE_OWNER} -> ${OWNER_NAME})"
-  ITEM_ID=$(gh api graphql --fail \
+  ITEM_ID=$(gh api graphql \
     -f query='mutation($projectId: ID!, $title: String!) {
       addProjectV2DraftIssue(input: { projectId: $projectId, title: $title }) {
         projectItem { id }

--- a/.github/actions/add-to-project/main.sh
+++ b/.github/actions/add-to-project/main.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# --- Inputs (set via env in action.yml) ---
+PROJECT_URL="${INPUT_PROJECT_URL}"
+export GH_TOKEN="${INPUT_GITHUB_TOKEN}"
+LABELED="${INPUT_LABELED:-}"
+LABEL_OPERATOR="${INPUT_LABEL_OPERATOR:-OR}"
+
+# --- Parse project URL ---
+# Accepts: https://github.com/orgs/{owner}/projects/{number}
+#          https://github.com/users/{owner}/projects/{number}
+if [[ ! "$PROJECT_URL" =~ ^https://github\.com/(orgs|users)/([^/]+)/projects/([0-9]+)/?$ ]]; then
+  echo "::error::Invalid project URL: ${PROJECT_URL}"
+  echo "::error::Expected: https://github.com/{orgs|users}/{owner}/projects/{number}"
+  exit 1
+fi
+OWNER_TYPE="${BASH_REMATCH[1]}"
+OWNER_NAME="${BASH_REMATCH[2]}"
+PROJECT_NUMBER="${BASH_REMATCH[3]}"
+
+GRAPHQL_OWNER="organization"
+[[ "$OWNER_TYPE" == "users" ]] && GRAPHQL_OWNER="user"
+
+echo "::group::Add to project ${OWNER_TYPE}/${OWNER_NAME}/${PROJECT_NUMBER}"
+trap 'echo "::endgroup::"' EXIT
+
+# --- Read issue/PR from event payload ---
+CONTENT_ID=$(jq -r '(.issue // .pull_request).node_id // empty' "$GITHUB_EVENT_PATH")
+ISSUE_OWNER=$(jq -r '.repository.owner.login // empty' "$GITHUB_EVENT_PATH")
+
+if [[ -z "$CONTENT_ID" ]]; then
+  echo "::error::Could not determine issue/PR node_id from event payload"
+  exit 1
+fi
+
+# --- Label filtering ---
+if [[ -n "$LABELED" ]]; then
+  ISSUE_LABELS=$(jq -r '(.issue // .pull_request | .labels // []) | map(.name | ascii_downcase) | join(",")' "$GITHUB_EVENT_PATH")
+  # Normalize filter labels to lowercase
+  FILTER_LABELS="${LABELED,,}"
+
+  PASS=false
+  OP="${LABEL_OPERATOR,,}"
+
+  case "$OP" in
+    and)
+      PASS=true
+      IFS=',' read -ra LABELS_ARR <<< "$FILTER_LABELS"
+      for label in "${LABELS_ARR[@]}"; do
+        label=$(echo "$label" | xargs)
+        [[ -z "$label" ]] && continue
+        if [[ ",${ISSUE_LABELS}," != *",${label},"* ]]; then
+          echo "::notice::Skipping: label '${label}' not found (AND filter)"
+          PASS=false
+          break
+        fi
+      done
+      ;;
+    not)
+      PASS=true
+      IFS=',' read -ra LABELS_ARR <<< "$FILTER_LABELS"
+      for label in "${LABELS_ARR[@]}"; do
+        label=$(echo "$label" | xargs)
+        [[ -z "$label" ]] && continue
+        if [[ ",${ISSUE_LABELS}," == *",${label},"* ]]; then
+          echo "::notice::Skipping: label '${label}' found (NOT filter)"
+          PASS=false
+          break
+        fi
+      done
+      ;;
+    *)
+      # OR (default) — at least one filter label must be present
+      PASS=false
+      IFS=',' read -ra LABELS_ARR <<< "$FILTER_LABELS"
+      for label in "${LABELS_ARR[@]}"; do
+        label=$(echo "$label" | xargs)
+        [[ -z "$label" ]] && continue
+        if [[ ",${ISSUE_LABELS}," == *",${label},"* ]]; then
+          PASS=true
+          break
+        fi
+      done
+      if [[ "$PASS" == "false" ]]; then
+        echo "::notice::Skipping: no matching labels (OR filter: ${LABELED})"
+      fi
+      ;;
+  esac
+
+  if [[ "$PASS" == "false" ]]; then
+    exit 0
+  fi
+fi
+
+# --- Get project node ID ---
+echo "Fetching project node ID..."
+PROJECT_ID=$(gh api graphql \
+  -f query="query(\$owner: String!, \$number: Int!) {
+    ${GRAPHQL_OWNER}(login: \$owner) { projectV2(number: \$number) { id } }
+  }" \
+  -f owner="$OWNER_NAME" \
+  -F number="$PROJECT_NUMBER" \
+  --jq ".${GRAPHQL_OWNER}.projectV2.id")
+
+if [[ -z "$PROJECT_ID" || "$PROJECT_ID" == "null" ]]; then
+  echo "::error::Project not found at ${PROJECT_URL}"
+  exit 1
+fi
+
+# --- Add item to project ---
+if [[ "$ISSUE_OWNER" == "$OWNER_NAME" ]]; then
+  echo "Adding item to project (same owner)"
+  ITEM_ID=$(gh api graphql \
+    -f query='mutation($projectId: ID!, $contentId: ID!) {
+      addProjectV2ItemById(input: { projectId: $projectId, contentId: $contentId }) {
+        item { id }
+      }
+    }' \
+    -f projectId="$PROJECT_ID" \
+    -f contentId="$CONTENT_ID" \
+    --jq '.addProjectV2ItemById.item.id')
+else
+  # Cross-owner: create a draft issue linking to the original
+  ISSUE_URL=$(jq -r '(.issue // .pull_request).html_url // empty' "$GITHUB_EVENT_PATH")
+  echo "Adding draft issue to project (cross-owner: ${ISSUE_OWNER} -> ${OWNER_NAME})"
+  ITEM_ID=$(gh api graphql \
+    -f query='mutation($projectId: ID!, $title: String!) {
+      addProjectV2DraftIssue(input: { projectId: $projectId, title: $title }) {
+        projectItem { id }
+      }
+    }' \
+    -f projectId="$PROJECT_ID" \
+    -f title="$ISSUE_URL" \
+    --jq '.addProjectV2DraftIssue.projectItem.id')
+fi
+
+if [[ -z "$ITEM_ID" || "$ITEM_ID" == "null" ]]; then
+  echo "::error::Failed to add item to project at ${PROJECT_URL}"
+  exit 1
+fi
+
+echo "itemId=${ITEM_ID}" >> "$GITHUB_OUTPUT"
+echo "Added item ${ITEM_ID}"

--- a/.github/actions/add-to-project/main.sh
+++ b/.github/actions/add-to-project/main.sh
@@ -10,7 +10,7 @@ LABEL_OPERATOR="${INPUT_LABEL_OPERATOR:-OR}"
 # --- Parse project URL ---
 # Accepts: https://github.com/orgs/{owner}/projects/{number}
 #          https://github.com/users/{owner}/projects/{number}
-if [[ ! "$PROJECT_URL" =~ /(orgs|users)/([^/]+)/projects/([0-9]+) ]]; then
+if [[ ! "$PROJECT_URL" =~ ^https://github\.com/(orgs|users)/([^/]+)/projects/([0-9]+)/?$ ]]; then
   echo "::error::Invalid project URL: ${PROJECT_URL}"
   echo "::error::Expected: https://github.com/{orgs|users}/{owner}/projects/{number}"
   exit 1

--- a/.github/actions/add-to-project/main.sh
+++ b/.github/actions/add-to-project/main.sh
@@ -23,11 +23,11 @@ GRAPHQL_OWNER="organization"
 [[ "$OWNER_TYPE" == "users" ]] && GRAPHQL_OWNER="user"
 
 echo "::group::Add to project ${OWNER_TYPE}/${OWNER_NAME}/${PROJECT_NUMBER}"
+trap 'echo "::endgroup::"' EXIT
 
 # --- Read issue/PR from event payload ---
-EVENT=$(cat "$GITHUB_EVENT_PATH")
-CONTENT_ID=$(jq -r '(.issue // .pull_request).node_id // empty' <<< "$EVENT")
-ISSUE_OWNER=$(jq -r '.repository.owner.login // empty' <<< "$EVENT")
+CONTENT_ID=$(jq -r '(.issue // .pull_request).node_id // empty' "$GITHUB_EVENT_PATH")
+ISSUE_OWNER=$(jq -r '.repository.owner.login // empty' "$GITHUB_EVENT_PATH")
 
 if [[ -z "$CONTENT_ID" ]]; then
   echo "::error::Could not determine issue/PR node_id from event payload"
@@ -36,7 +36,7 @@ fi
 
 # --- Label filtering ---
 if [[ -n "$LABELED" ]]; then
-  ISSUE_LABELS=$(jq -r '(.issue // .pull_request | .labels // []) | map(.name | ascii_downcase) | join(",")' <<< "$EVENT")
+  ISSUE_LABELS=$(jq -r '(.issue // .pull_request | .labels // []) | map(.name | ascii_downcase) | join(",")' "$GITHUB_EVENT_PATH")
   # Normalize filter labels to lowercase
   FILTER_LABELS="${LABELED,,}"
 
@@ -89,7 +89,6 @@ if [[ -n "$LABELED" ]]; then
   esac
 
   if [[ "$PASS" == "false" ]]; then
-    echo "::endgroup::"
     exit 0
   fi
 fi
@@ -123,7 +122,7 @@ if [[ "$ISSUE_OWNER" == "$OWNER_NAME" ]]; then
     --jq '.addProjectV2ItemById.item.id')
 else
   # Cross-owner: create a draft issue linking to the original
-  ISSUE_URL=$(jq -r '(.issue // .pull_request).html_url // empty' <<< "$EVENT")
+  ISSUE_URL=$(jq -r '(.issue // .pull_request).html_url // empty' "$GITHUB_EVENT_PATH")
   echo "Adding draft issue to project (cross-owner: ${ISSUE_OWNER} -> ${OWNER_NAME})"
   ITEM_ID=$(gh api graphql \
     -f query='mutation($projectId: ID!, $title: String!) {
@@ -143,4 +142,3 @@ fi
 
 echo "itemId=${ITEM_ID}" >> "$GITHUB_OUTPUT"
 echo "Added item ${ITEM_ID}"
-echo "::endgroup::"

--- a/.github/actions/add-to-project/main.sh
+++ b/.github/actions/add-to-project/main.sh
@@ -38,7 +38,7 @@ fi
 if [[ -n "$LABELED" ]]; then
   ISSUE_LABELS=$(jq -r '(.issue // .pull_request | .labels // []) | map(.name | ascii_downcase) | join(",")' <<< "$EVENT")
   # Normalize filter labels to lowercase
-  FILTER_LABELS=$(echo "$LABELED" | tr '[:upper:]' '[:lower:]')
+  FILTER_LABELS="${LABELED,,}"
 
   PASS=false
   OP="${LABEL_OPERATOR,,}"

--- a/.github/actions/add-to-project/main.sh
+++ b/.github/actions/add-to-project/main.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# --- Inputs (set via env in action.yml) ---
+PROJECT_URL="${INPUT_PROJECT_URL}"
+export GH_TOKEN="${INPUT_GITHUB_TOKEN}"
+LABELED="${INPUT_LABELED:-}"
+LABEL_OPERATOR="${INPUT_LABEL_OPERATOR:-OR}"
+
+# --- Parse project URL ---
+# Accepts: https://github.com/orgs/{owner}/projects/{number}
+#          https://github.com/users/{owner}/projects/{number}
+if [[ ! "$PROJECT_URL" =~ /(orgs|users)/([^/]+)/projects/([0-9]+) ]]; then
+  echo "::error::Invalid project URL: ${PROJECT_URL}"
+  echo "::error::Expected: https://github.com/{orgs|users}/{owner}/projects/{number}"
+  exit 1
+fi
+OWNER_TYPE="${BASH_REMATCH[1]}"
+OWNER_NAME="${BASH_REMATCH[2]}"
+PROJECT_NUMBER="${BASH_REMATCH[3]}"
+
+GRAPHQL_OWNER="organization"
+[[ "$OWNER_TYPE" == "users" ]] && GRAPHQL_OWNER="user"
+
+echo "::group::Add to project ${OWNER_TYPE}/${OWNER_NAME}/${PROJECT_NUMBER}"
+
+# --- Read issue/PR from event payload ---
+EVENT=$(cat "$GITHUB_EVENT_PATH")
+CONTENT_ID=$(jq -r '(.issue // .pull_request).node_id // empty' <<< "$EVENT")
+ISSUE_OWNER=$(jq -r '.repository.owner.login // empty' <<< "$EVENT")
+
+if [[ -z "$CONTENT_ID" ]]; then
+  echo "::error::Could not determine issue/PR node_id from event payload"
+  exit 1
+fi
+
+# --- Label filtering ---
+if [[ -n "$LABELED" ]]; then
+  ISSUE_LABELS=$(jq -r '(.issue // .pull_request | .labels // []) | map(.name | ascii_downcase) | join(",")' <<< "$EVENT")
+  # Normalize filter labels to lowercase
+  FILTER_LABELS=$(echo "$LABELED" | tr '[:upper:]' '[:lower:]')
+
+  PASS=false
+  OP="${LABEL_OPERATOR,,}"
+
+  case "$OP" in
+    and)
+      PASS=true
+      IFS=',' read -ra LABELS_ARR <<< "$FILTER_LABELS"
+      for label in "${LABELS_ARR[@]}"; do
+        label=$(echo "$label" | xargs)
+        [[ -z "$label" ]] && continue
+        if [[ ",${ISSUE_LABELS}," != *",${label},"* ]]; then
+          echo "::notice::Skipping: label '${label}' not found (AND filter)"
+          PASS=false
+          break
+        fi
+      done
+      ;;
+    not)
+      PASS=true
+      IFS=',' read -ra LABELS_ARR <<< "$FILTER_LABELS"
+      for label in "${LABELS_ARR[@]}"; do
+        label=$(echo "$label" | xargs)
+        [[ -z "$label" ]] && continue
+        if [[ ",${ISSUE_LABELS}," == *",${label},"* ]]; then
+          echo "::notice::Skipping: label '${label}' found (NOT filter)"
+          PASS=false
+          break
+        fi
+      done
+      ;;
+    *)
+      # OR (default) — at least one filter label must be present
+      PASS=false
+      IFS=',' read -ra LABELS_ARR <<< "$FILTER_LABELS"
+      for label in "${LABELS_ARR[@]}"; do
+        label=$(echo "$label" | xargs)
+        [[ -z "$label" ]] && continue
+        if [[ ",${ISSUE_LABELS}," == *",${label},"* ]]; then
+          PASS=true
+          break
+        fi
+      done
+      if [[ "$PASS" == "false" ]]; then
+        echo "::notice::Skipping: no matching labels (OR filter: ${LABELED})"
+      fi
+      ;;
+  esac
+
+  if [[ "$PASS" == "false" ]]; then
+    echo "::endgroup::"
+    exit 0
+  fi
+fi
+
+# --- Get project node ID ---
+echo "Fetching project node ID..."
+PROJECT_ID=$(gh api graphql \
+  -f query="query(\$owner: String!, \$number: Int!) {
+    ${GRAPHQL_OWNER}(login: \$owner) { projectV2(number: \$number) { id } }
+  }" \
+  -f owner="$OWNER_NAME" \
+  -F number="$PROJECT_NUMBER" \
+  --jq ".${GRAPHQL_OWNER}.projectV2.id")
+
+if [[ -z "$PROJECT_ID" ]]; then
+  echo "::error::Project not found at ${PROJECT_URL}"
+  exit 1
+fi
+
+# --- Add item to project ---
+if [[ "$ISSUE_OWNER" == "$OWNER_NAME" ]]; then
+  echo "Adding item to project (same owner)"
+  ITEM_ID=$(gh api graphql \
+    -f query='mutation($projectId: ID!, $contentId: ID!) {
+      addProjectV2ItemById(input: { projectId: $projectId, contentId: $contentId }) {
+        item { id }
+      }
+    }' \
+    -f projectId="$PROJECT_ID" \
+    -f contentId="$CONTENT_ID" \
+    --jq '.addProjectV2ItemById.item.id')
+else
+  # Cross-owner: create a draft issue linking to the original
+  ISSUE_URL=$(jq -r '(.issue // .pull_request).html_url // empty' <<< "$EVENT")
+  echo "Adding draft issue to project (cross-owner: ${ISSUE_OWNER} -> ${OWNER_NAME})"
+  ITEM_ID=$(gh api graphql \
+    -f query='mutation($projectId: ID!, $title: String!) {
+      addProjectV2DraftIssue(input: { projectId: $projectId, title: $title }) {
+        projectItem { id }
+      }
+    }' \
+    -f projectId="$PROJECT_ID" \
+    -f title="$ISSUE_URL" \
+    --jq '.addProjectV2DraftIssue.projectItem.id')
+fi
+
+echo "itemId=${ITEM_ID}" >> "$GITHUB_OUTPUT"
+echo "Added item ${ITEM_ID}"
+echo "::endgroup::"

--- a/.github/actions/add-to-project/main.sh
+++ b/.github/actions/add-to-project/main.sh
@@ -104,7 +104,7 @@ PROJECT_ID=$(gh api graphql --fail \
   -F number="$PROJECT_NUMBER" \
   --jq ".${GRAPHQL_OWNER}.projectV2.id")
 
-if [[ -z "$PROJECT_ID" ]]; then
+if [[ -z "$PROJECT_ID" || "$PROJECT_ID" == "null" ]]; then
   echo "::error::Project not found at ${PROJECT_URL}"
   exit 1
 fi
@@ -134,6 +134,11 @@ else
     -f projectId="$PROJECT_ID" \
     -f title="$ISSUE_URL" \
     --jq '.addProjectV2DraftIssue.projectItem.id')
+fi
+
+if [[ -z "$ITEM_ID" || "$ITEM_ID" == "null" ]]; then
+  echo "::error::Failed to add item to project at ${PROJECT_URL}"
+  exit 1
 fi
 
 echo "itemId=${ITEM_ID}" >> "$GITHUB_OUTPUT"

--- a/.github/actions/add-to-project/main.sh
+++ b/.github/actions/add-to-project/main.sh
@@ -96,7 +96,7 @@ fi
 
 # --- Get project node ID ---
 echo "Fetching project node ID..."
-PROJECT_ID=$(gh api graphql \
+PROJECT_ID=$(gh api graphql --fail \
   -f query="query(\$owner: String!, \$number: Int!) {
     ${GRAPHQL_OWNER}(login: \$owner) { projectV2(number: \$number) { id } }
   }" \
@@ -112,7 +112,7 @@ fi
 # --- Add item to project ---
 if [[ "$ISSUE_OWNER" == "$OWNER_NAME" ]]; then
   echo "Adding item to project (same owner)"
-  ITEM_ID=$(gh api graphql \
+  ITEM_ID=$(gh api graphql --fail \
     -f query='mutation($projectId: ID!, $contentId: ID!) {
       addProjectV2ItemById(input: { projectId: $projectId, contentId: $contentId }) {
         item { id }
@@ -125,7 +125,7 @@ else
   # Cross-owner: create a draft issue linking to the original
   ISSUE_URL=$(jq -r '(.issue // .pull_request).html_url // empty' <<< "$EVENT")
   echo "Adding draft issue to project (cross-owner: ${ISSUE_OWNER} -> ${OWNER_NAME})"
-  ITEM_ID=$(gh api graphql \
+  ITEM_ID=$(gh api graphql --fail \
     -f query='mutation($projectId: ID!, $title: String!) {
       addProjectV2DraftIssue(input: { projectId: $projectId, title: $title }) {
         projectItem { id }

--- a/.github/workflows/_dogfood-add-to-project.yml
+++ b/.github/workflows/_dogfood-add-to-project.yml
@@ -13,3 +13,5 @@ jobs:
     uses: jmmaloney4/toolbox/.github/workflows/add-to-project.yml@591ab2d08d3f590934b9dcf75c8c7ff084b469b0 # main
     with:
       project_url: ${{ vars.PROJECT_URL }}
+    secrets:
+      github-token: ${{ secrets.PROJECT_PAT }}

--- a/.github/workflows/_dogfood-add-to-project.yml
+++ b/.github/workflows/_dogfood-add-to-project.yml
@@ -10,7 +10,7 @@ jobs:
   add-to-project:
     # Secrets cannot be used in `if`; set PROJECT_URL when you want this enabled.
     if: vars.PROJECT_URL != ''
-    uses: jmmaloney4/toolbox/.github/workflows/add-to-project.yml@591ab2d08d3f590934b9dcf75c8c7ff084b469b0 # main
+    uses: jmmaloney4/toolbox/.github/workflows/add-to-project.yml@main
     with:
       project_url: ${{ vars.PROJECT_URL }}
     secrets:

--- a/.github/workflows/_dogfood-add-to-project.yml
+++ b/.github/workflows/_dogfood-add-to-project.yml
@@ -8,4 +8,10 @@ permissions:
   contents: read
 jobs:
   add-to-project:
-    uses: jmmaloney4/sector7/.github/workflows/add-to-project.yml@9d71ec06b6d6e9204b8df4585e65de5323826c16 # main
+    # Secrets cannot be used in `if`; set PROJECT_URL when you want this enabled.
+    if: vars.PROJECT_URL != ''
+    uses: jmmaloney4/toolbox/.github/workflows/add-to-project.yml@main
+    with:
+      project_url: ${{ vars.PROJECT_URL }}
+    secrets:
+      github-token: ${{ secrets.PROJECT_PAT }}

--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -22,6 +22,10 @@ on:
         required: false
         default: OR
         type: string
+    secrets:
+      github-token:
+        description: 'GitHub personal access token with project write access'
+        required: true
 permissions:
   contents: read
 jobs:
@@ -33,10 +37,12 @@ jobs:
         uses: actions/add-to-project@244f685bbc3b7adfa8466e08b698b5577571133e # v1.0.2
         with:
           project-url: ${{ inputs.project_url }}
+          github-token: ${{ secrets.github-token }}
       - name: Add issue or PR to project (label filter)
         if: inputs.labeled != ''
         uses: actions/add-to-project@244f685bbc3b7adfa8466e08b698b5577571133e # v1.0.2
         with:
           project-url: ${{ inputs.project_url }}
+          github-token: ${{ secrets.github-token }}
           labeled: ${{ inputs.labeled }}
           label-operator: ${{ inputs.label-operator }}

--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -32,15 +32,8 @@ jobs:
   add-to-project:
     runs-on: ${{ inputs.runs-on }}
     steps:
-      - name: Add issue or PR to project (no label filter)
-        if: inputs.labeled == ''
-        uses: actions/add-to-project@244f685bbc3b7adfa8466e08b698b5577571133e # v1.0.2
-        with:
-          project-url: ${{ inputs.project_url }}
-          github-token: ${{ secrets.github-token }}
-      - name: Add issue or PR to project (label filter)
-        if: inputs.labeled != ''
-        uses: actions/add-to-project@244f685bbc3b7adfa8466e08b698b5577571133e # v1.0.2
+      - name: Add issue or PR to project
+        uses: jmmaloney4/toolbox/.github/actions/add-to-project@main
         with:
           project-url: ${{ inputs.project_url }}
           github-token: ${{ secrets.github-token }}

--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -24,11 +24,7 @@ on:
         type: string
     secrets:
       github-token:
-        description: >-
-          Personal access token (classic or fine-grained) with `project` scope (classic)
-          or Projects read/write permission (fine-grained) on the target org.
-          GITHUB_TOKEN cannot be used because it is scoped to the triggering repository
-          and cannot access org-level GitHub Projects.
+        description: 'GitHub personal access token with project write access'
         required: true
 permissions:
   contents: read
@@ -36,15 +32,8 @@ jobs:
   add-to-project:
     runs-on: ${{ inputs.runs-on }}
     steps:
-      - name: Add issue or PR to project (no label filter)
-        if: inputs.labeled == ''
-        uses: actions/add-to-project@244f685bbc3b7adfa8466e08b698b5577571133e # v1.0.2
-        with:
-          project-url: ${{ inputs.project_url }}
-          github-token: ${{ secrets.github-token }}
-      - name: Add issue or PR to project (label filter)
-        if: inputs.labeled != ''
-        uses: actions/add-to-project@244f685bbc3b7adfa8466e08b698b5577571133e # v1.0.2
+      - name: Add issue or PR to project
+        uses: jmmaloney4/toolbox/.github/actions/add-to-project@main
         with:
           project-url: ${{ inputs.project_url }}
           github-token: ${{ secrets.github-token }}


### PR DESCRIPTION
Replace the upstream `actions/add-to-project` action with a local composite action that uses `gh` CLI + `jq`. This eliminates the dependency on an unmaintained third-party action and gives us full control over the project-item-addition logic.

## Changes
- New `.github/actions/add-to-project/` composite action
  - Uses `gh api graphql` for projectV2 access
  - Supports labeled filter with AND/OR/NOT operators
  - Handles cross-owner items via draft issues
  - Runs in a nix shell with gh + jq
- `add-to-project.yml` workflow now calls the local action
- `_dogfood` workflow now calls the reusable workflow with proper secrets via `vars.PROJECT_URL`

## Test plan
- Local bash syntax check: `bash -n main.sh` passed
- YAML syntax validated for both workflow files
- Rebased onto main and conflicts resolved cleanly

## Risk
- Low risk. Behavior is identical from the caller's perspective.
- The composite action requires `gh` and `jq` on the runner (already available on self-hosted via nix).
- Cross-owner handling (draft issue fallback) is new but harmless — existing same-owner projects work identically.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it replaces a core workflow automation step and introduces new `gh api graphql` + label-filtering logic that depends on runner tooling (`nix`, `gh`, `jq`) and PAT permissions.
> 
> **Overview**
> Replaces the upstream `actions/add-to-project` step with a new local composite action that adds the triggering issue/PR to a GitHub Projects (V2) board via `gh api graphql`.
> 
> The new action supports optional label-based gating (`AND`/`OR`/`NOT`) and includes a cross-owner fallback that creates a draft item when the project owner differs from the repo owner. Workflows are updated to call the local action, and the dogfood workflow is gated by `vars.PROJECT_URL` and passes a PAT secret.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d69b911cc8f8dca40400d72a3fe535929b068c54. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->