### PR TITLE
deps(renovate): skip stability days for internal toolbox actions

### DIFF
--- a/renovate/default.json
+++ b/renovate/default.json
@@ -35,5 +35,12 @@
 	},
 	"nix": {
 		"enabled": true
-	}
+	},
+	"packageRules": [
+		{
+			"description": "Skip stability days for internal toolbox actions (own repo)",
+			"matchPackageNames": ["jmmaloney4/toolbox"],
+			"minimumReleaseAge": null
+		}
+	]
 }


### PR DESCRIPTION
Adds a `packageRules` entry in `renovate/default.json` that sets `minimumReleaseAge: null` for `jmmaloney4/toolbox`.

This is our own repo — no reason to wait 4 days for stability on self-published actions. All other deps still get the standard stability window.

Context: jackpkgs#230 was blocked for days on a toolbox digest bump that had already passed the stability window, just waiting for Renovate to re-evaluate.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: Renovate config-only change that affects update timing for a single internal dependency and does not touch runtime code.
> 
> **Overview**
> Renovate will now **skip the global `minimumReleaseAge` stability window** for updates to `jmmaloney4/toolbox` by adding a `packageRules` override (`minimumReleaseAge: null`) in `renovate/default.json`.
> 
> All other dependencies continue to use the existing `4 days` release-age delay.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ebe626a7e4f1a38a9010b10e6d1533e9e2aa9db0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->