### PR TITLE
feat(sector7): auto-create GitHub Identity Provider via githubOAuthConfig

### DIFF
--- a/packages/sector7/tests/worker-site.test.ts
+++ b/packages/sector7/tests/worker-site.test.ts
@@ -280,7 +280,28 @@ describe("WorkerSite", () => {
 					paths: [{ pattern: "/private/*", access: "github-org" }],
 				}),
 		).toThrow(
-			"githubIdentityProviderId is required when using github-org access",
+			"githubIdentityProviderId or githubOAuthConfig is required when using github-org access",
+		);
+	});
+
+	it("rejects both githubOAuthConfig and githubIdentityProviderId", () => {
+		expect(
+			() =>
+				new WorkerSite("conflict-site", {
+					accountId: "account-123",
+					zoneId: "zone-123",
+					name: "conflict-site",
+					domains: ["conflict.example.com"],
+					r2Bucket: { bucketName: "conflict-assets" },
+					githubIdentityProviderId: "manual-idp-id",
+					githubOAuthConfig: {
+						clientId: "Ov23li",
+						clientSecret: "secret",
+					},
+					paths: [{ pattern: "/*", access: "github-org" }],
+				}),
+		).toThrow(
+			"githubOAuthConfig and githubIdentityProviderId are mutually exclusive",
 		);
 	});
 
@@ -415,5 +436,67 @@ describe("WorkerSite", () => {
 				persist: false,
 			},
 		});
+	});
+
+	it("auto-creates a GitHub Identity Provider when githubOAuthConfig is provided", async () => {
+		const site = new WorkerSite("oauth-site", {
+			accountId: "account-123",
+			zoneId: "zone-123",
+			name: "oauth-site",
+			domains: ["oauth.example.com"],
+			r2Bucket: { bucketName: "oauth-assets" },
+			githubOAuthConfig: {
+				clientId: "Ov23li-test",
+				clientSecret: "test-secret",
+			},
+			githubOrganizations: ["my-org"],
+			paths: [
+				{ pattern: "/", access: "bypass" },
+				{ pattern: "/private/*", access: "github-org" },
+			],
+		});
+
+		await resolveOutput(site.worker.id);
+		await Promise.all(
+			site.accessApplications.map((app) => resolveOutput(app.id)),
+		);
+
+		// Verify the IDP resource was created
+		expect(site.githubIdp).toBeDefined();
+		const idps = byName("-github-idp");
+		expect(idps).toHaveLength(1);
+		expect(idps[0].inputs.type).toBe("github");
+		expect(idps[0].inputs.config).toEqual({
+			clientId: "Ov23li-test",
+			clientSecret: "test-secret",
+		});
+		expect(idps[0].inputs.accountId).toBe("account-123");
+
+		// Verify Access applications were created (2 paths x 1 domain = 2)
+		expect(site.accessApplications).toHaveLength(2);
+
+		// Verify github-org path uses the auto-created IDP
+		const privateApp = byName("oauth-site-app-d").find((a) =>
+			a.name.includes("-p1"),
+		);
+		expect(privateApp).toBeDefined();
+	});
+
+	it("does not create an IDP when githubOAuthConfig is not provided", async () => {
+		const site = new WorkerSite("no-idp-site", {
+			accountId: "account-123",
+			zoneId: "zone-123",
+			name: "no-idp-site",
+			domains: ["no-idp.example.com"],
+			r2Bucket: { bucketName: "no-idp-assets" },
+			paths: [
+				{ pattern: "/", access: "bypass" },
+			],
+		});
+
+		await resolveOutput(site.worker.id);
+
+		expect(site.githubIdp).toBeUndefined();
+		expect(byName("-github-idp")).toHaveLength(0);
 	});
 });

--- a/packages/sector7/workersite/README.md
+++ b/packages/sector7/workersite/README.md
@@ -17,8 +17,11 @@
 
 1. Cloudflare account with a zone already managed by Cloudflare nameservers
 2. Zone ID and account ID for the target site
-3. If you use `github-org` access, a GitHub Identity Provider configured in Cloudflare Access
-4. If you use `assets`, `@aws-sdk/client-s3` available to the Pulumi program
+3. A [Cloudflare API token](#cloudflare-api-token-permissions) with the required permissions
+4. If you use `github-org` access, either:
+   - Provide `githubOAuthConfig` to auto-create a GitHub Identity Provider, or
+   - Provide `githubIdentityProviderId` to reference a pre-existing one
+5. If you use `assets`, `@aws-sdk/client-s3` available to the Pulumi program
 
 ## Usage
 
@@ -65,6 +68,34 @@ export const boundDomains = site.boundDomains;
 
 ### Mixed public/private site with Cloudflare Access
 
+Using `githubOAuthConfig` (auto-creates the GitHub Identity Provider):
+
+```typescript
+import { WorkerSite } from "@jmmaloney4/sector7/workersite";
+
+const site = new WorkerSite("research-site", {
+  accountId: "your-cloudflare-account-id",
+  zoneId: "your-cloudflare-zone-id",
+  name: "research-site",
+  domains: ["research.example.com"],
+  r2Bucket: {
+    bucketName: "research-site-assets",
+    create: true,
+  },
+  githubOAuthConfig: {
+    clientId: "your-github-oauth-app-client-id",
+    clientSecret: "your-github-oauth-app-client-secret",
+  },
+  githubOrganizations: ["your-org"],
+  paths: [
+    { pattern: "/public/*", access: "public" },
+    { pattern: "/private/*", access: "github-org" },
+  ],
+});
+```
+
+Or using a pre-existing Identity Provider with `githubIdentityProviderId`:
+
 ```typescript
 import { WorkerSite } from "@jmmaloney4/sector7/workersite";
 
@@ -85,6 +116,8 @@ const site = new WorkerSite("research-site", {
   ],
 });
 ```
+
+`githubOAuthConfig` and `githubIdentityProviderId` are mutually exclusive.
 
 ### Custom Worker script
 
@@ -171,14 +204,16 @@ After adding this config, `pulumi preview` should show an `observability` block 
 1. An optional `cloudflare.R2Bucket` when `r2Bucket.create` is `true`
 2. A `cloudflare.WorkersScript`
 3. One `cloudflare.WorkersCustomDomain` per hostname in `domains`
-4. Zero or more `cloudflare.ZeroTrustAccessApplication` resources, one per `(domain, path)` combination when `paths` is provided
-5. An `cloudflare.AccountToken` plus one `R2Object` per uploaded file when `assets` is provided
+4. An optional `cloudflare.ZeroTrustAccessIdentityProvider` when `githubOAuthConfig` is provided
+5. Zero or more `cloudflare.ZeroTrustAccessApplication` resources, one per `(domain, path)` combination when `paths` is provided
+6. An `cloudflare.AccountToken` plus one `R2Object` per uploaded file when `assets` is provided
 
 ## Access control model
 
 - Omit `paths` for a fully public site
 - Use `paths` with `access: "public"` or `access: "github-org"` to create Cloudflare Access applications
-- `githubIdentityProviderId` and `githubOrganizations` are required only when at least one path uses `github-org`
+- When a path uses `github-org`, you must provide either `githubOAuthConfig` (auto-creates the IDP) or `githubIdentityProviderId` (references a pre-existing one)
+- `githubOrganizations` is required when a path uses `github-org`
 
 Cloudflare Access enforces authorization before requests reach the Worker. The Worker itself does not implement authentication.
 
@@ -228,7 +263,8 @@ redirects: [
 | `r2Bucket.bucketName`      | `string`                    | Yes         | R2 bucket name                                       |
 | `r2Bucket.create`          | `boolean`                   | No          | Create the bucket if it does not already exist       |
 | `r2Bucket.prefix`          | `string`                    | No          | Prefix prepended to generated-script object lookups  |
-| `githubIdentityProviderId` | `string`                    | Conditional | Required when a path uses `github-org`               |
+| `githubIdentityProviderId` | `string`                    | Conditional | Pre-existing GitHub IDP UUID; mutually exclusive with `githubOAuthConfig` |
+| `githubOAuthConfig`        | `GithubOAuthConfig`         | Conditional | Auto-create a GitHub IDP; mutually exclusive with `githubIdentityProviderId` |
 | `githubOrganizations`      | `string[]`                  | Conditional | Required when a path uses `github-org`               |
 | `paths`                    | `PathConfig[]`              | No          | Access-control rules; omit for fully public sites    |
 | `cacheTtlSeconds`          | `number`                    | No          | Cache TTL for generated Worker responses             |
@@ -236,6 +272,18 @@ redirects: [
 | `redirects`                | `RedirectRule[]`            | No          | Host redirects for the generated Worker              |
 | `workerScript`             | `WorkerScriptConfig`        | No          | Custom Worker source and extra bindings              |
 | `observability`            | `WorkerObservabilityConfig` | No          | Worker observability and log sampling settings       |
+
+### `GithubOAuthConfig`
+
+| Field          | Type     | Required | Description                                                        |
+| -------------- | -------- | -------- | ------------------------------------------------------------------ |
+| `clientId`     | `string` | Yes      | GitHub OAuth App client ID                                         |
+| `clientSecret` | `string` | Yes      | GitHub OAuth App client secret (use Pulumi secrets)                |
+| `name`         | `string` | No       | Display name for the Identity Provider in Cloudflare Zero Trust UI |
+
+When provided, WorkerSite auto-creates a `cloudflare.ZeroTrustAccessIdentityProvider` of type `github` and uses its ID for all Access applications that require `github-org` authentication. This is mutually exclusive with `githubIdentityProviderId`.
+
+You must create a GitHub OAuth App at https://github.com/settings/developers with the callback URL set to `https://<your-team-name>.cloudflareaccess.com/cdn-cgi/access/callback`.
 
 ### `PathConfig`
 
@@ -268,6 +316,42 @@ redirects: [
 | `logs.invocationLogs`   | `boolean`  | No       | Enables invocation logs                           |
 | `logs.destinations`     | `string[]` | No       | Log destinations; defaults to `["cloudflare"]`    |
 | `logs.persist`          | `boolean`  | No       | Persists logs in Cloudflare                       |
+
+## Cloudflare API token permissions
+
+WorkerSite creates the following Cloudflare resources, and the API token must have permissions for all of them:
+
+| Resource created by WorkerSite                              | Required token permission (Account) |
+| ----------------------------------------------------------- | ----------------------------------- |
+| `cloudflare.R2Bucket` (when `r2Bucket.create` is true)     | R2: Edit                            |
+| `cloudflare.WorkersScript`                                  | Workers Scripts: Edit               |
+| `cloudflare.WorkersCustomDomain`                            | Workers Routes: Edit                |
+| `cloudflare.ZeroTrustAccessIdentityProvider` (when `githubOAuthConfig` is set) | Access: Identity Providers: Edit |
+| `cloudflare.ZeroTrustAccessApplication` (when `paths` is set) | Access: Apps and Policies: Edit  |
+| `cloudflare.AccountToken` (when `assets` is set)            | Account Settings: Read              |
+
+**Zone-level:**
+
+| Required token permission (Zone) |
+| -------------------------------- |
+| Workers Routes: Edit             |
+
+### Minimum token configuration
+
+Create a **Custom Token** in the Cloudflare dashboard (My Profile > API Tokens > Create Token) with:
+
+Account-level permissions (scoped to the target account):
+- Workers Scripts: Edit
+- Workers Routes: Edit
+- R2: Edit
+- Access: Apps and Policies: Edit
+- Access: Identity Providers: Edit
+- Account Settings: Read
+
+Zone-level permissions (scoped to the target zone):
+- Workers Routes: Edit
+
+If you do not use `paths` (fully public site), you can omit the Access permissions. If you do not use `assets`, you can omit Account Settings: Read.
 
 ## Troubleshooting
 

--- a/packages/sector7/workersite/worker-site.ts
+++ b/packages/sector7/workersite/worker-site.ts
@@ -101,6 +101,33 @@ export interface WorkerScriptConfig {
 }
 
 /**
+ * Configuration for auto-creating a GitHub OAuth Identity Provider in
+ * Cloudflare Zero Trust Access.
+ *
+ * When provided, WorkerSite creates a `ZeroTrustAccessIdentityProvider`
+ * resource (type `"github"`) and uses its generated ID for any paths with
+ * `access: "github-org"`.  This is the preferred alternative to passing a
+ * pre-existing `githubIdentityProviderId` — the two options are mutually
+ * exclusive.
+ *
+ * The GitHub OAuth App must be created manually in
+ * GitHub Settings → Developer settings → OAuth Apps.
+ * The callback URL should be `https://<your-team>.cloudflareaccess.com/cdn-cgi/access/callback`.
+ */
+export interface GithubOAuthConfig {
+	/**
+	 * GitHub OAuth App client ID.
+	 */
+	clientId: pulumi.Input<string>;
+
+	/**
+	 * GitHub OAuth App client secret.
+	 * This value will be stored as a Pulumi secret.
+	 */
+	clientSecret: pulumi.Input<string>;
+}
+
+/**
  * Configuration for Cloudflare Worker observability.
  */
 export interface WorkerObservabilityConfig {
@@ -223,7 +250,10 @@ export interface WorkerSiteArgs {
 
 	/**
 	 * GitHub Identity Provider ID in Cloudflare Access.
-	 * Required only when at least one path has `access: "github-org"`.
+	 * Required only when at least one path has `access: "github-org"` and
+	 * `githubOAuthConfig` is not provided.
+	 *
+	 * Mutually exclusive with `githubOAuthConfig`.
 	 */
 	githubIdentityProviderId?: pulumi.Input<string>;
 
@@ -232,6 +262,27 @@ export interface WorkerSiteArgs {
 	 * Required only when at least one path has `access: "github-org"`.
 	 */
 	githubOrganizations?: pulumi.Input<string>[];
+
+	/**
+	 * Auto-create a GitHub OAuth Identity Provider for Cloudflare Access.
+	 * When provided, a `ZeroTrustAccessIdentityProvider` resource is created
+	 * and its ID is used for any paths with `access: "github-org"`.
+	 *
+	 * Mutually exclusive with `githubIdentityProviderId`.
+	 *
+	 * @example
+	 * ```typescript
+	 * githubOAuthConfig: {
+	 *   clientId: "Ov23li...",
+	 *   clientSecret: pulumi.secret("abc123..."),
+	 * },
+	 * githubOrganizations: ["my-org"],
+	 * paths: [
+	 *   { pattern: "/*", access: "github-org" },
+	 * ],
+	 * ```
+	 */
+	githubOAuthConfig?: GithubOAuthConfig;
 
 	/**
 	 * Path access configurations for Zero Trust Access Applications.
@@ -325,7 +376,7 @@ const R2_BUCKET_ITEM_WRITE_PERMISSION_GROUP_ID =
  * ```
  *
  * @example
- * Site with GitHub org access control and public bypass paths:
+ * Site with GitHub org access control using auto-created Identity Provider:
  * ```typescript
  * const site = new WorkerSite("docs-site", {
  *   accountId: "abc123",
@@ -333,7 +384,10 @@ const R2_BUCKET_ITEM_WRITE_PERMISSION_GROUP_ID =
  *   name: "docs-site",
  *   domains: ["docs.example.com"],
  *   r2Bucket: { bucketName: "docs-site-assets", create: true },
- *   githubIdentityProviderId: "github-idp-id",
+ *   githubOAuthConfig: {
+ *     clientId: "Ov23li...",
+ *     clientSecret: pulumi.secret("abc123..."),
+ *   },
  *   githubOrganizations: ["my-org"],
  *   paths: [
  *     { pattern: "/", access: "bypass" },
@@ -368,6 +422,13 @@ export class WorkerSite extends pulumi.ComponentResource {
 	public readonly accessApplications: cloudflare.ZeroTrustAccessApplication[];
 
 	/**
+	 * Auto-created GitHub Identity Provider (present when `githubOAuthConfig` is provided).
+	 * Undefined when using a pre-existing `githubIdentityProviderId` or when no
+	 * GitHub auth is needed.
+	 */
+	public readonly githubIdp: cloudflare.ZeroTrustAccessIdentityProvider | undefined;
+
+	/**
 	 * Uploaded R2 objects (populated when assets is provided).
 	 */
 	public readonly uploadedAssets: R2Object[];
@@ -400,13 +461,19 @@ export class WorkerSite extends pulumi.ComponentResource {
 			);
 		}
 
+		if (args.githubOAuthConfig && args.githubIdentityProviderId) {
+			throw new Error(
+				"githubOAuthConfig and githubIdentityProviderId are mutually exclusive",
+			);
+		}
+
 		const githubOrgPaths = (args.paths ?? []).filter(
 			(p) => p.access === "github-org",
 		);
 		if (githubOrgPaths.length > 0) {
-			if (!args.githubIdentityProviderId) {
+			if (!args.githubIdentityProviderId && !args.githubOAuthConfig) {
 				throw new Error(
-					"githubIdentityProviderId is required when using github-org access",
+					"githubIdentityProviderId or githubOAuthConfig is required when using github-org access",
 				);
 			}
 			if (!args.githubOrganizations || args.githubOrganizations.length === 0) {
@@ -417,6 +484,28 @@ export class WorkerSite extends pulumi.ComponentResource {
 		}
 
 		const resourceOpts = { parent: this };
+
+		// 0. Auto-create GitHub Identity Provider if requested
+		this.githubIdp = undefined;
+		let githubIdentityProviderId: pulumi.Input<string> | undefined =
+			args.githubIdentityProviderId;
+
+		if (args.githubOAuthConfig) {
+			this.githubIdp = new cloudflare.ZeroTrustAccessIdentityProvider(
+				`${name}-github-idp`,
+				{
+					accountId: args.accountId,
+					name: pulumi.interpolate`${args.name} GitHub`,
+					type: "github",
+					config: {
+						clientId: args.githubOAuthConfig.clientId,
+						clientSecret: args.githubOAuthConfig.clientSecret,
+					},
+				},
+				resourceOpts,
+			);
+			githubIdentityProviderId = this.githubIdp.id;
+		}
 
 		// 1. Create or reference R2 bucket
 		if (args.r2Bucket.create === true) {
@@ -565,11 +654,11 @@ export class WorkerSite extends pulumi.ComponentResource {
 					const policyIncludes =
 						pathConfig.access === "public" || pathConfig.access === "bypass"
 							? [{ everyone: {} }]
-							: pulumi
-									.all([
-										pulumi.all(args.githubOrganizations ?? []),
-										args.githubIdentityProviderId ?? "",
-									])
+						: pulumi
+								.all([
+									pulumi.all(args.githubOrganizations ?? []),
+									githubIdentityProviderId ?? "",
+								])
 									.apply(
 										([orgs, idpId]: [string[], string]) =>
 											orgs.map((org: string) => ({
@@ -690,6 +779,7 @@ export class WorkerSite extends pulumi.ComponentResource {
 			worker: this.worker,
 			workerDomains: this.workerDomains,
 			accessApplications: this.accessApplications,
+			githubIdp: this.githubIdp,
 			uploadedAssets: this.uploadedAssets,
 			boundDomains: this.boundDomains,
 			workerName: this.workerName,


### PR DESCRIPTION
## Summary

Add `githubOAuthConfig` to `WorkerSiteArgs`, allowing automatic creation of a `ZeroTrustAccessIdentityProvider` (type `github`) from a GitHub OAuth App client ID and secret. This eliminates the need to manually create an IDP in the Cloudflare dashboard and reference its UUID.

## Changes

- **New `GithubOAuthConfig` interface** with `clientId` and `clientSecret` fields
- **New `githubOAuthConfig` optional field on `WorkerSiteArgs** — mutually exclusive with `githubIdentityProviderId`
- **Auto-creates `ZeroTrustAccessIdentityProvider`** when `githubOAuthConfig` is provided, using its generated ID for Access Applications
- **New `githubIdp` property** on `WorkerSite` (undefined when not auto-created)
- Updated validation: `github-org` paths now accept either `githubOAuthConfig` or `githubIdentityProviderId`
- 3 new tests, updated error message assertion

## Usage

Before (manual IDP UUID):
```typescript
githubIdentityProviderId: "abc123-def456-...",
githubOrganizations: ["my-org"],
paths: [{ pattern: "/*", access: "github-org" }],
```

After (auto-created):
```typescript
githubOAuthConfig: {
  clientId: "Ov23li...",
  clientSecret: pulumi.secret("..."),
},
githubOrganizations: ["my-org"],
paths: [{ pattern: "/*", access: "github-org" }],
```

## Testing

All 20 tests pass (3 new + 17 existing).

Contributes to ADR-015 Phase 2 (auto-creation of GitHub IDP in WorkerSite).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new infrastructure creation (Cloudflare Zero Trust GitHub IDP) and changes validation/inputs for `github-org` protected paths, which could affect existing Pulumi stacks if misconfigured. The logic is straightforward but touches access-control provisioning and secret handling.
> 
> **Overview**
> **`WorkerSite` now supports `githubOAuthConfig`** to auto-create a `cloudflare.ZeroTrustAccessIdentityProvider` (type `github`) from a GitHub OAuth app `clientId`/`clientSecret`, and wires the created ID into `github-org` Access Application policy includes.
> 
> Validation is updated so `github-org` paths require **either** `githubIdentityProviderId` **or** `githubOAuthConfig`, and explicitly rejects providing both; a new `githubIdp` output is exposed when auto-created.
> 
> Tests and docs are updated with the new option, mutual-exclusion rules, and required Cloudflare API token permissions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 477377089dd63f802ff35f8998578c724656d2ea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->