### PR TITLE
feat(workersite): decouple R2 upload from WorkerSite + native S3 signing (ADR-014, ADR-015)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,3 +1,19 @@
+## Barrel exports and package import surfaces
+
+Barrel files (`index.ts` with re-exports) are fine for internal cohesion but require intentionality about what you surface to consumers.
+
+1. **Use explicit named re-exports, not `export *`.**
+   Write `export { WorkerSite, type WorkerSiteArgs } from "./worker-site.ts"` instead of `export * from "./worker-site.ts"`. This forces you to acknowledge every symbol you expose and makes it trivial to grep for "what public surface depends on X".
+
+2. **Group by dependency boundary, not by file system layout.**
+   If a module carries a heavy or optional dependency (e.g. `@aws-sdk/client-s3`), put it behind a separate sub-path export (`package.json` `exports["./workersite/r2"]`) rather than mixing it into the main barrel. The barrel should reflect the dependency graph.
+
+3. **Every re-export is a commitment.**
+   If you put something in the barrel, you are signing up for keeping its transitive type closure clean for all consumers. Optional peer deps, platform-specific types, or heavy type-only deps that not every consumer needs do not belong in the main barrel.
+
+4. **Guard the boundary with `@ts-expect-error`.**
+   When a type is intentionally excluded from a barrel, add a `barrel-guard.ts` file in the same directory that asserts the exclusion. Example: `// @ts-expect-error — R2Object lives on the ./r2 sub-path`. If someone re-adds the export, tsc fails on the unused directive. The file is picked up by the default `tsconfig.json` (`include: ["**/*.ts"]`), so the jackpkgs nix tsc check validates it automatically.
+
 ## Making a workflow reusable with `workflow_call`
 
 This guide shows how to convert an existing workflow into a callable (reusable) workflow that other repositories can invoke via `uses:`.

--- a/docs/internal/designs/014-decouple-r2-from-workersite.md
+++ b/docs/internal/designs/014-decouple-r2-from-workersite.md
@@ -1,7 +1,7 @@
 ---
 id: ADR-014
 title: Decouple R2 Upload from WorkerSite
-status: Proposed
+status: Accepted
 date: 2026-04-24
 deciders: [platform]
 consulted: []
@@ -127,11 +127,12 @@ the dynamic import to it, avoiding the module resolution requirement entirely.
 
 # Security / Privacy / Compliance
 
-- R2 credentials (access key ID, secret access key) are currently generated
-  inside WorkerSite and passed to R2Object. After decoupling, these credentials
-  MUST be exposed as WorkerSite outputs so the upload helper can receive them.
-  These are Pulumi `Output<string>` (secret-wrapped by default), so the
-  security posture is unchanged.
+- `uploadAssets` creates its own scoped `AccountToken` with write access to the
+  specific bucket only. Credentials are derived per Cloudflare's spec:
+  `accessKeyId = token.id`, `secretAccessKey = SHA-256(token.value)`.
+- WorkerSite does not expose any R2 credentials — it no longer creates an upload
+  token. This is a net improvement: the token is only created when assets are
+  actually being uploaded, and its lifetime is managed by Pulumi as a resource.
 
 # Operational Notes
 
@@ -143,7 +144,7 @@ the dynamic import to it, avoiding the module resolution requirement entirely.
 
 # Status Transitions
 
-- Proposed → Accepted: pending review of implementation plan.
+- Proposed → Accepted: 2026-04-24, implementation completed.
 
 # Implementation Notes
 

--- a/docs/internal/designs/014-decouple-r2-from-workersite.md
+++ b/docs/internal/designs/014-decouple-r2-from-workersite.md
@@ -12,6 +12,7 @@ links:
   - adr-005: ./005-cloudflare-workersite.md
   - adr-011: ./011-workersite-extensions.md
   - adr-013: ./013-workersite-esm-resources-fix.md
+  - adr-015: ./015-replace-aws-sdk-with-native-s3-signing.md
   - pr-156: https://github.com/jmmaloney4/toolbox/pull/156
   - issue-155: https://github.com/jmmaloney4/toolbox/issues/155
 ---
@@ -71,11 +72,9 @@ concerns that happen to share a bucket reference.
    `r2object.ts` or the new `r2` sub-path. The barrel-guard type test
    (already in place) validates this at compile time.
 
-5. The `typeof import("@aws-sdk/client-s3")` casts in `r2object.ts` MAY be
-   replaced with plain static imports at the top of the file, since the
-   sub-path makes the dependency requirement explicit. Dynamic imports were
-   used to defer the module resolution, but they add complexity without
-   benefit when the dep is a required peer for the sub-path.
+5. The `typeof import("...")` casts and the `@aws-sdk/client-s3` dependency
+   have been replaced with native AWS Signature Version 4 signing via
+   `node:crypto` + `fetch()`. No external SDK dependency is required (ADR-015).
 
 # Consequences
 

--- a/docs/internal/designs/014-decouple-r2-from-workersite.md
+++ b/docs/internal/designs/014-decouple-r2-from-workersite.md
@@ -1,0 +1,156 @@
+---
+id: ADR-014
+title: Decouple R2 Upload from WorkerSite
+status: Proposed
+date: 2026-04-24
+deciders: [platform]
+consulted: []
+tags: [design, adr, cloudflare, pulumi, workers, sector7, r2]
+supersedes: []
+superseded_by: []
+links:
+  - adr-005: ./005-cloudflare-workersite.md
+  - adr-011: ./011-workersite-extensions.md
+  - adr-013: ./013-workersite-esm-resources-fix.md
+  - pr-156: https://github.com/jmmaloney4/toolbox/pull/156
+  - issue-155: https://github.com/jmmaloney4/toolbox/issues/155
+---
+
+# Context
+
+`WorkerSite` (ADR-005, extended by ADR-011, ADR-013) manages Cloudflare Workers,
+R2 buckets, DNS records, and Zero Trust access policies. It also includes an
+R2 upload capability via the `R2Object` dynamic resource, which uses
+`@aws-sdk/client-s3` (S3-compatible API) to upload static assets to R2 at
+Pulumi deploy time.
+
+The package ships raw `.ts` source (no build step, `noEmit: true`). This means
+TypeScript consumers type-check the package's source files directly, following
+all transitive imports.
+
+**Problem:** `R2Object` uses `typeof import("@aws-sdk/client-s3")` casts inside
+function bodies to get type safety on dynamically-imported S3 client symbols.
+When a consumer imports `WorkerSite` from the main barrel, TypeScript follows
+the chain:
+
+```
+index.ts → worker-site.ts → r2object.ts → typeof import("@aws-sdk/client-s3")
+```
+
+This produces `TS2307: Cannot find module '@aws-sdk/client-s3'` for any
+consumer that does not have the optional peer dependency installed — even if
+they never use R2 upload functionality.
+
+Issue #155 was opened for this. PR #156 attempted to fix it by moving
+`R2Object` to a sub-path export (`@jmmaloney4/sector7/workersite/r2`), but
+reviewers correctly identified that this is insufficient: `WorkerSite` still
+statically imports `R2Object`, so the transitive chain remains unbroken from
+the main barrel.
+
+The root cause is **architectural coupling**: WorkerSite (infrastructure
+orchestration) is entangled with R2Object (asset upload). These are separate
+concerns that happen to share a bucket reference.
+
+# Decision
+
+1. WorkerSite MUST NOT import R2Object. The `uploadedAssets` property, the
+   `new R2Object()` constructor call, and the R2 asset-upload loop MUST be
+   extracted out of WorkerSite.
+
+2. A new function (e.g. `uploadAssets` or a factory helper) in the
+   `./workersite/r2` sub-path MUST handle R2 uploads. It takes the bucket
+   name/credentials (available as WorkerSite outputs) and the file list, and
+   returns the created R2Object resources.
+
+3. `@aws-sdk/client-s3` becomes an **honest required peer dependency** of the
+   `./workersite/r2` sub-path. Consumers who want R2 upload MUST install it.
+   Consumers who only need WorkerSite infrastructure (Worker, bucket, DNS,
+   Zero Trust) do not need it and will not encounter TS2307.
+
+4. The main barrel (`./workersite/index.ts`) MUST NOT re-export anything from
+   `r2object.ts` or the new `r2` sub-path. The barrel-guard type test
+   (already in place) validates this at compile time.
+
+5. The `typeof import("@aws-sdk/client-s3")` casts in `r2object.ts` MAY be
+   replaced with plain static imports at the top of the file, since the
+   sub-path makes the dependency requirement explicit. Dynamic imports were
+   used to defer the module resolution, but they add complexity without
+   benefit when the dep is a required peer for the sub-path.
+
+# Consequences
+
+## Positive
+
+- Consumers of the main barrel get zero `@aws-sdk/client-s3` type-check
+  exposure, regardless of their dependency tree.
+- WorkerSite's API surface shrinks — it owns infrastructure, not upload.
+- The R2 upload concern is independently testable and evolvable.
+- Eliminates the `typeof import()` / dynamic-import pattern that was the root
+  cause of TS2307.
+
+## Negative
+
+- Breaking change: consumers that use `WorkerSite.uploadedAssets` or pass
+  `assets` to `WorkerSiteArgs` must migrate to the new `uploadAssets` helper.
+- Two-step consumption: create WorkerSite, then call uploadAssets separately.
+  This is slightly more verbose but makes the dependency boundary explicit.
+
+# Alternatives
+
+## A. Static import, honest required dependency (for the sub-path only)
+
+Make `@aws-sdk/client-s3` a required peer dep for the `./workersite/r2`
+sub-path with a plain `import` at the top of `r2object.ts`. Consumers of the
+main barrel are unaffected.
+
+- Pros: simple, no dynamic import complexity.
+- Cons: does not fix the `WorkerSite → R2Object` coupling; WorkerSite still
+  imports R2Object and the transitive chain remains.
+
+## B. Decouple WorkerSite from R2Object (chosen)
+
+Extract the upload concern into a standalone function in the r2 sub-path.
+
+- Pros: clean separation of concerns, breaks the transitive chain at the
+  architectural level, honest dependency declaration.
+- Cons: breaking API change, requires consumer migration.
+
+## C. Local interface shim
+
+Define a minimal interface (`S3ClientLike`, `PutObjectCommandLike`) and cast
+the dynamic import to it, avoiding the module resolution requirement entirely.
+
+- Pros: no dep required for any consumer.
+- Cons: parallel type stubs that silently drift from the real SDK. Maintenance
+  liability. The same problem that caused the original bug (types that don't
+  match runtime behavior) could recur.
+
+# Security / Privacy / Compliance
+
+- R2 credentials (access key ID, secret access key) are currently generated
+  inside WorkerSite and passed to R2Object. After decoupling, these credentials
+  MUST be exposed as WorkerSite outputs so the upload helper can receive them.
+  These are Pulumi `Output<string>` (secret-wrapped by default), so the
+  security posture is unchanged.
+
+# Operational Notes
+
+- No runtime behavior change — the same Pulumi resources are created in the
+  same order. The difference is which function orchestrates the `new R2Object()`
+  calls.
+- Deployment rollback is straightforward: revert to the old API by importing
+  from the r2 sub-path inline.
+
+# Status Transitions
+
+- Proposed → Accepted: pending review of implementation plan.
+
+# Implementation Notes
+
+See `docs/internal/plans/2026-04-24-decouple-r2-from-workersite.md`.
+
+# References
+
+- Issue #155: https://github.com/jmmaloney4/toolbox/issues/155
+- PR #156 (partial fix, identified the deeper architectural issue):
+  https://github.com/jmmaloney4/toolbox/pull/156

--- a/docs/internal/designs/015-replace-aws-sdk-with-native-s3-signing.md
+++ b/docs/internal/designs/015-replace-aws-sdk-with-native-s3-signing.md
@@ -1,0 +1,167 @@
+---
+id: ADR-015
+title: Replace @aws-sdk/client-s3 with Native S3 Signing
+status: Accepted
+date: 2026-04-24
+deciders: [platform]
+consulted: []
+tags: [design, adr, cloudflare, pulumi, workers, sector7, r2]
+supersedes: []
+superseded_by: []
+links:
+  - adr-014: ./014-decouple-r2-from-workersite.md
+  - pr-156: https://github.com/jmmaloney4/toolbox/pull/156
+  - issue-155: https://github.com/jmmaloney4/toolbox/issues/155
+---
+
+# Context
+
+ADR-014 decoupled `R2Object` from `WorkerSite` by extracting it to a
+`./workersite/r2` sub-path. This eliminated the transitive import chain that
+caused TS2307 for consumers who don't use R2 upload.
+
+However, `r2object.ts` still depends on `@aws-sdk/client-s3` — a ~200-package
+dependency with native bindings — for exactly two operations:
+
+1. **PUT Object** — upload a file to R2 via the S3-compatible endpoint
+2. **DELETE Object** — remove a file from R2 via the S3-compatible endpoint
+
+Both operations are single authenticated HTTP requests. The AWS SDK provides
+no value beyond AWS Signature V4 header generation and response parsing.
+
+This dependency causes two ongoing problems:
+
+1. **Pulumi serialization**: Top-level `import { S3Client }` is captured by
+   Pulumi's V8 source capture for dynamic providers. The SDK's dependency chain
+   contains non-serializable native code, causing runtime failures during
+   `pulumi up`. The previous workaround was `await import()` inside provider
+   callbacks — a pattern that fights the runtime model instead of fixing the
+   root cause.
+
+2. **Dependency weight**: Pulling in the entire AWS SDK for two HTTP requests
+   is disproportionate. The `@aws-sdk/client-s3` package transitively installs
+   ~200 npm packages, many with optional native bindings.
+
+The existing code already dynamically imports `node:crypto` (for MD5 ETag
+computation) and `node:fs` (for file reading). Node 18+'s built-in `fetch()` and
+`crypto.createHmac()` provide every primitive needed to sign S3 requests
+natively — zero external dependencies.
+
+# Decision
+
+1. `r2object.ts` MUST NOT depend on `@aws-sdk/client-s3`. The package MUST be
+   removed from both `devDependencies` and `peerDependencies`.
+
+2. S3 request signing MUST be implemented natively using `node:crypto` (already
+   dynamically imported). The signing scope is limited to exactly two operations:
+   `PUT /{bucket}/{key}` and `DELETE /{bucket}/{key}` against the R2
+   S3-compatible endpoint.
+
+3. HTTP requests MUST use Node's built-in `fetch()` (Node 18+, already our
+   minimum). No external HTTP library.
+
+4. The signing implementation MUST be a self-contained helper function within
+   `r2object.ts` (or a co-located module). No shared "S3 client" abstraction —
+   the two operations are simple enough to inline.
+
+5. The `R2Object` dynamic resource and `uploadAssets` function signatures
+   MUST NOT change. This is an internal implementation detail, not an API
+   change.
+
+# Consequences
+
+## Positive
+
+- Eliminates `@aws-sdk/client-s3` entirely — no peer dep, no dev dep, no
+  serialization workarounds, no version pinning concerns.
+- Removes the Pulumi dynamic provider serialization issue at its root. No more
+  `await import()` workarounds for AWS SDK symbols.
+- Zero external dependencies for R2 operations. Only `node:crypto`, `node:fs`,
+  and global `fetch()` — all built into Node 18+.
+- Faster `npm install` / `pnpm install` for consumers of the `r2` sub-path
+  (~200 fewer packages).
+- Simpler mental model: file upload is an authenticated HTTP PUT, not an SDK
+  operation.
+
+## Negative
+
+- Owns ~80 lines of AWS Signature V4 signing code. This is well-documented
+  (AWS docs, numerous implementations) and the surface is tiny (2 operations),
+  but it is code we maintain.
+- If R2 operations expand beyond PUT/DELETE in the future (multipart upload,
+  presigned URLs, etc.), the signing helper may need extension. At that point,
+  re-evaluating whether to adopt a lightweight signing library is appropriate.
+
+# Alternatives
+
+## A. Keep @aws-sdk/client-s3 with dynamic imports (status quo post ADR-014)
+
+Wrap the SDK import in `await import()` inside every provider callback to avoid
+V8 source capture.
+
+- Pros: no new code, uses a battle-tested SDK.
+- Cons: perpetuates the serialization workaround pattern; heavyweight dependency
+  for two HTTP requests; version churn across the ~200-package dependency tree.
+
+## B. Replace @aws-sdk/client-s3 with native S3 signing (chosen)
+
+Implement AWS Sig V4 signing using `node:crypto` + `fetch()`.
+
+- Pros: zero external deps, no serialization issues, simpler dependency tree,
+  ~80 lines of well-understood code for exactly the operations we need.
+- Cons: owns signing code; must maintain if S3 API usage expands.
+
+## C. Remove R2Object as a Pulumi resource
+
+Make asset upload a post-`pulumi up` step (script, CLI, CI job).
+
+- Pros: cleanest separation of concerns; Pulumi manages infra, not blobs.
+- Cons: loses declarative asset management; static website assets are closely
+  coupled to infrastructure (they're the site content); introduces a separate
+  deployment step that must be coordinated with Pulumi lifecycle.
+
+# Security / Privacy / Compliance
+
+- No change to the authentication model. The existing `cloudflare.AccountToken`
+  (created by `uploadAssets`) still provides the Access Key ID and Secret
+  Access Key used for signing. These are derived per Cloudflare's spec:
+  `accessKeyId = token.id`, `secretAccessKey = SHA-256(token.value)`.
+- The signing key is derived per-request from the Secret Access Key using
+  HMAC-SHA256. It is never persisted or logged.
+- Request signing happens entirely in-process using Node's `crypto` module.
+  No credentials leave the Pulumi process except in the signed Authorization
+  header sent to the R2 endpoint over HTTPS.
+
+# Operational Notes
+
+- No change to the Pulumi resource model or deployment workflow. The same
+  `R2Object` resources are created with the same inputs and outputs.
+- The signing implementation uses the same AWS Signature Version 4 algorithm
+  that the SDK uses. R2's S3-compatible endpoint validates signatures
+  identically regardless of whether they come from the SDK or a manual
+  implementation.
+- ETag computation remains unchanged (MD5 hash of the object body).
+
+# Status Transitions
+
+- Proposed → Accepted: 2026-04-24, implementation completed in same PR.
+
+# Implementation Notes
+
+- Add `signV4(request, credentials, region, service)` helper to `r2object.ts`.
+- Replace `S3Client` / `PutObjectCommand` with a `fetch()` PUT to
+  `https://{accountId}.r2.cloudflarestorage.com/{bucket}/{key}` with signed
+  headers.
+- Replace `S3Client` / `DeleteObjectCommand` with a `fetch()` DELETE to the
+  same endpoint pattern.
+- Remove `@aws-sdk/client-s3` from `devDependencies` and `peerDependencies`.
+- Remove any `await import("@aws-sdk/client-s3")` calls.
+- Update barrel-guard and README to reflect the dependency removal.
+
+# References
+
+- AWS Signature Version 4: https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_sigv.html
+- Cloudflare R2 S3 API compatibility: https://developers.cloudflare.com/r2/api/s3/api/
+- ADR-014 (decouple R2 from WorkerSite): ./014-decouple-r2-from-workersite.md
+- Issue #155: https://github.com/jmmaloney4/toolbox/issues/155
+- PR #156: https://github.com/jmmaloney4/toolbox/pull/156

--- a/docs/internal/plans/2026-04-24-decouple-r2-from-workersite.md
+++ b/docs/internal/plans/2026-04-24-decouple-r2-from-workersite.md
@@ -1,0 +1,230 @@
+# Decouple R2 Upload from WorkerSite
+
+**Date:** 2026-04-24\
+**Author:** jack\
+**Status:** Draft\
+**Related ADR:** [ADR-014](../designs/014-decouple-r2-from-workersite.md)\
+**Related issues:** toolbox#155\
+**Related PRs:** toolbox#156 (partial fix, review identified deeper issue)
+
+______________________________________________________________________
+
+## Context
+
+PR #156 moved `R2Object` to a sub-path export but left `WorkerSite` statically
+importing it. Three reviewers (Gemini, Copilot, Cursor) all identified that the
+transitive import chain `index.ts → worker-site.ts → r2object.ts → @aws-sdk/client-s3`
+remains unbroken. The real fix is architectural: decouple R2 upload from
+WorkerSite entirely, as documented in ADR-014.
+
+This plan covers the implementation of that decoupling. All consumers are
+internal (garden repo), so breaking changes are acceptable.
+
+______________________________________________________________________
+
+## PR Sequence
+
+### PR 1 — Extract `uploadAssets` helper to r2 sub-path
+
+**Goal:** WorkerSite no longer imports R2Object. A new `uploadAssets` function
+in the `./workersite/r2` sub-path handles R2 uploads using WorkerSite outputs.
+
+**Background:**
+
+Currently `WorkerSite` does three things related to R2:
+
+1. Creates an R2 bucket (via `cloudflare.R2Bucket`) when `r2Bucket.create: true`
+2. Creates an R2 API token (via `R2Token` dynamic resource) when `assets` is provided
+3. Loops over `assets.files`, creating `new R2Object(...)` for each file
+
+Steps 2 and 3 are the upload concern. Step 1 (bucket creation) is
+infrastructure and stays in WorkerSite.
+
+**Steps for the analyst:**
+
+1. **Audit WorkerSite for R2Object coupling:**
+
+   ```sh
+   cd packages/sector7/workersite
+   grep -n 'R2Object\|uploadedAssets\|assets' worker-site.ts
+   ```
+
+   Key locations:
+   - Line 4: `import { R2Object } from "./r2object.ts"`
+   - `WorkerSiteArgs.assets` property (the `AssetConfig` input)
+   - Line 434: `public readonly uploadedAssets: R2Object[]`
+   - Lines 730-770: R2 token creation + `new R2Object()` loop
+   - Line 783: `registerOutputs({ uploadedAssets: this.uploadedAssets })`
+
+2. **Add output properties to WorkerSite for R2 credentials:**
+
+   WorkerSite already creates the R2 token internally. Expose the token's
+   outputs so the upload helper can use them:
+
+   ```ts
+   // New outputs on WorkerSite
+   public readonly r2AccessKeyId: pulumi.Output<string> | undefined;
+   public readonly r2SecretAccessKey: pulumi.Output<string> | undefined;
+   public readonly r2BucketName: pulumi.Output<string> | undefined;
+   ```
+
+   These are `undefined` when no bucket is created. The R2 token creation
+   stays inside WorkerSite for now (it's tied to the bucket lifecycle), but
+   the upload loop moves out.
+
+3. **Remove `assets` from `WorkerSiteArgs`:**
+
+   Move `AssetConfig` (file list) to be a parameter of the new `uploadAssets`
+   function instead. Remove `assets` from `WorkerSiteArgs`.
+
+4. **Remove R2Object import and upload loop from WorkerSite:**
+
+   - Delete `import { R2Object } from "./r2object.ts"`
+   - Delete `public readonly uploadedAssets: R2Object[]`
+   - Delete the R2 token creation + upload loop (lines ~730-770)
+   - Delete `uploadedAssets` from `registerOutputs`
+
+5. **Create `uploadAssets` function in `r2object.ts` (or new file):**
+
+   ```ts
+   // packages/sector7/workersite/r2.ts (or r2object.ts)
+
+   export interface UploadAssetsArgs {
+     accountId: pulumi.Input<string>;
+     bucketName: pulumi.Input<string>;
+     accessKeyId: pulumi.Input<string>;
+     secretAccessKey: pulumi.Input<string>;
+     files: AssetFile[];
+     dependsOn?: pulumi.Resource[];
+   }
+
+   export function uploadAssets(
+     name: string,
+     args: UploadAssetsArgs,
+     opts?: pulumi.ComponentResourceOptions,
+   ): R2Object[] { ... }
+   ```
+
+   This function takes the outputs from WorkerSite (bucket name, credentials)
+   and the file list, creates `new R2Object()` for each file, returns the array.
+
+6. **Replace dynamic `typeof import` with static import:**
+
+   Since `r2object.ts` is now behind the r2 sub-path with an honest required
+   peer dep, the dynamic import + `typeof import()` cast can be simplified:
+
+   ```ts
+   // Before (r2object.ts)
+   const { S3Client, PutObjectCommand } = (await import(
+     "@aws-sdk/client-s3"
+   )) as typeof import("@aws-sdk/client-s3");
+
+   // After — static import at top of file
+   import { S3Client, PutObjectCommand, DeleteObjectCommand } from "@aws-sdk/client-s3";
+   ```
+
+   This is cleaner and gets full type safety without the cast complexity.
+   The dep is required for the sub-path, so there's no reason to defer the
+   import.
+
+7. **Update `r2.ts` barrel to use named re-exports:**
+
+   ```ts
+   // r2.ts
+   export {
+     R2Object,
+     type R2ObjectInputs,
+     uploadAssets,
+     type UploadAssetsArgs,
+   } from "./r2object.ts";
+   ```
+
+8. **Update `barrel-guard.ts`** to remove stale `tsconfig.barrel-guard.json`
+   reference and add guards for `uploadAssets`/`UploadAssetsArgs`.
+
+9. **Verify:**
+
+   ```sh
+   cd packages/sector7 && pnpm tsc --noEmit
+   ```
+
+   Confirm:
+   - `worker-site.ts` has zero references to `R2Object`
+   - `r2object.ts` uses static imports, no `typeof import()` casts
+   - Main barrel does not re-export anything from r2 sub-path
+
+**Acceptance criteria:**
+
+- `grep -r 'R2Object' packages/sector7/workersite/worker-site.ts` returns empty
+- `grep -r 'typeof import' packages/sector7/workersite/r2object.ts` returns empty
+- `pnpm tsc --noEmit` passes in `packages/sector7`
+- Importing `WorkerSite` from `@jmmaloney4/sector7/workersite` does not require
+  `@aws-sdk/client-s3` in `node_modules`
+
+______________________________________________________________________
+
+### PR 2 — Migrate consumers (garden repo)
+
+**Goal:** Update all consumers in the garden repo to use the new `uploadAssets`
+API.
+
+**Background:**
+
+Theoretical Edge and other consumers in `garden` currently pass `assets` to
+`WorkerSiteArgs` and read `site.uploadedAssets`. They need to call
+`uploadAssets()` separately.
+
+**Steps for the analyst:**
+
+1. Search garden repo for `uploadedAssets` and `assets:` in WorkerSite
+   instantiations.
+
+2. For each consumer:
+   - Remove `assets` from `WorkerSiteArgs`
+   - Add `import { uploadAssets } from "@jmmaloney4/sector7/workersite/r2"`
+   - After WorkerSite creation, call:
+     ```ts
+     const uploadedAssets = uploadAssets(`${name}-assets`, {
+       accountId: args.accountId,
+       bucketName: site.r2BucketName!,
+       accessKeyId: site.r2AccessKeyId!,
+       secretAccessKey: site.r2SecretAccessKey!,
+       files: assetFiles,
+       dependsOn: [site],
+     });
+     ```
+
+3. Add `@aws-sdk/client-s3` as a dependency in the consumer's `package.json`
+   (required for the r2 sub-path).
+
+4. Verify with `pnpm tsc --noEmit`.
+
+**Acceptance criteria:**
+
+- No consumer references `WorkerSiteArgs.assets` or `site.uploadedAssets`
+- All consumers using R2 upload import from `./workersite/r2`
+- `pnpm tsc --noEmit` passes in each consumer package
+
+______________________________________________________________________
+
+## Suggested Merge Order
+
+```
+PR 1 (toolbox: extract uploadAssets)  →  PR 2 (garden: migrate consumers)
+```
+
+PR 1 is self-contained and can be merged independently. PR 2 can happen in
+parallel since garden references sector7 from the registry, but should be
+coordinated so both land before the next deployment.
+
+______________________________________________________________________
+
+## Definition of Done
+
+- [ ] `WorkerSite` has zero imports from `r2object.ts`
+- [ ] `r2object.ts` uses static imports for `@aws-sdk/client-s3` (no `typeof import` casts)
+- [ ] `uploadAssets` function exported from `./workersite/r2` sub-path
+- [ ] Main barrel (`./workersite/index.ts`) has no transitive path to `@aws-sdk/client-s3`
+- [ ] Barrel-guard type test passes (R2Object not on main barrel)
+- [ ] All garden consumers migrated
+- [ ] Issue #155 closed

--- a/packages/sector7/package.json
+++ b/packages/sector7/package.json
@@ -40,13 +40,7 @@
 	"peerDependencies": {
 		"@pulumi/pulumi": "^3.0.0",
 		"@pulumi/cloudflare": "^6.0.0",
-		"@pulumi/gcp": "^9.0.0",
-		"@aws-sdk/client-s3": "^3.0.0"
-	},
-	"peerDependenciesMeta": {
-		"@aws-sdk/client-s3": {
-			"optional": true
-		}
+		"@pulumi/gcp": "^9.0.0"
 	},
 	"devDependencies": {
 		"@aws-sdk/client-s3": "3.1009.0",

--- a/packages/sector7/package.json
+++ b/packages/sector7/package.json
@@ -43,7 +43,6 @@
 		"@pulumi/gcp": "^9.0.0"
 	},
 	"devDependencies": {
-		"@aws-sdk/client-s3": "3.1009.0",
 		"@pulumi/pulumi": "3.230.0",
 		"@pulumi/cloudflare": "6.14.0",
 		"@pulumi/gcp": "9.19.0",

--- a/packages/sector7/package.json
+++ b/packages/sector7/package.json
@@ -22,6 +22,10 @@
 		"./workersite": {
 			"types": "./workersite/index.ts",
 			"default": "./workersite/index.ts"
+		},
+		"./workersite/r2": {
+			"types": "./workersite/r2.ts",
+			"default": "./workersite/r2.ts"
 		}
 	},
 	"files": [
@@ -45,6 +49,7 @@
 		}
 	},
 	"devDependencies": {
+		"@aws-sdk/client-s3": "3.1009.0",
 		"@pulumi/pulumi": "3.230.0",
 		"@pulumi/cloudflare": "6.14.0",
 		"@pulumi/gcp": "9.19.0",

--- a/packages/sector7/workersite/README.md
+++ b/packages/sector7/workersite/README.md
@@ -21,7 +21,7 @@
 4. If you use `github-org` access, either:
    - Provide `githubOAuthConfig` to auto-create a GitHub Identity Provider, or
    - Provide `githubIdentityProviderId` to reference a pre-existing one
-5. If you use `uploadAssets`, `@aws-sdk/client-s3` must be installed in the consuming project
+5. If you use `uploadAssets`, no additional dependencies are needed — S3 signing is implemented natively
 
 ## Usage
 
@@ -242,7 +242,7 @@ Cloudflare Access enforces authorization before requests reach the Worker. The W
 
 ## Asset uploads
 
-R2 asset uploads are managed via `uploadAssets` from the `./workersite/r2` sub-path, decoupled from `WorkerSite` (ADR-014). This isolates the `@aws-sdk/client-s3` dependency from consumers that only need infrastructure.
+R2 asset uploads are managed via `uploadAssets` from the `./workersite/r2` sub-path, decoupled from `WorkerSite` (ADR-014). S3-compatible signing is implemented natively via `node:crypto` + `fetch` — no external SDK required (ADR-015).
 
 ```typescript
 import { uploadAssets } from "@jmmaloney4/sector7/workersite/r2";
@@ -261,7 +261,7 @@ uploadAssets("my-site", {
 - Change detection uses MD5/ETag comparison
 - `uploadAssets` creates a scoped `AccountToken` for R2 object writes automatically
 - The token scope is limited to the configured bucket
-- `@aws-sdk/client-s3` is required when using this sub-path
+- No external dependencies — S3 signing uses `node:crypto` + `fetch` natively (ADR-015)
 
 ## Redirects
 

--- a/packages/sector7/workersite/README.md
+++ b/packages/sector7/workersite/README.md
@@ -1,6 +1,6 @@
 # WorkerSite
 
-`WorkerSite` is a Pulumi `ComponentResource` for hosting static sites on Cloudflare Workers with R2 storage, optional Cloudflare Access protection, declarative asset uploads, and custom-domain bindings.
+`WorkerSite` is a Pulumi `ComponentResource` for hosting static sites on Cloudflare Workers with R2 storage, optional Cloudflare Access protection, and custom-domain bindings. R2 asset uploads are available via the separate `./workersite/r2` sub-path (ADR-014).
 
 ## Features
 
@@ -8,7 +8,7 @@
 - Multiple domains via `WorkersCustomDomain`
 - DNS managed automatically by Cloudflare custom-domain bindings
 - Optional path-level Cloudflare Access policies
-- Optional declarative R2 uploads during `pulumi up`
+- Optional declarative R2 uploads via the `./workersite/r2` sub-path during `pulumi up`
 - Optional host redirects in the generated Worker script
 - Optional custom Worker script with extra plain-text bindings
 - Default Cloudflare Worker observability with configurable request/log sampling
@@ -21,11 +21,11 @@
 4. If you use `github-org` access, either:
    - Provide `githubOAuthConfig` to auto-create a GitHub Identity Provider, or
    - Provide `githubIdentityProviderId` to reference a pre-existing one
-5. If you use `assets`, `@aws-sdk/client-s3` available to the Pulumi program
+5. If you use `uploadAssets`, `@aws-sdk/client-s3` must be installed in the consuming project
 
 ## Usage
 
-### Public site with declarative uploads and redirect
+### Public site with redirect
 
 ```typescript
 import { WorkerSite } from "@jmmaloney4/sector7/workersite";
@@ -46,24 +46,46 @@ const site = new WorkerSite("docs-site", {
       statusCode: 301,
     },
   ],
-  assets: {
-    files: [
-      {
-        key: "index.html",
-        filePath: "/absolute/path/to/dist/index.html",
-        contentType: "text/html; charset=utf-8",
-      },
-      {
-        key: "styles.css",
-        filePath: "/absolute/path/to/dist/styles.css",
-        contentType: "text/css; charset=utf-8",
-      },
-    ],
-  },
 });
 
 export const workerName = site.workerName;
 export const boundDomains = site.boundDomains;
+```
+
+### Public site with declarative uploads
+
+```typescript
+import { WorkerSite } from "@jmmaloney4/sector7/workersite";
+import { uploadAssets } from "@jmmaloney4/sector7/workersite/r2";
+
+const site = new WorkerSite("docs-site", {
+  accountId: "your-cloudflare-account-id",
+  zoneId: "your-cloudflare-zone-id",
+  name: "docs-site",
+  domains: ["docs.example.com"],
+  r2Bucket: {
+    bucketName: "docs-site-assets",
+    create: true,
+  },
+});
+
+uploadAssets("docs-site", {
+  accountId: "your-cloudflare-account-id",
+  bucketName: "docs-site-assets",
+  files: [
+    {
+      key: "index.html",
+      filePath: "/absolute/path/to/dist/index.html",
+      contentType: "text/html; charset=utf-8",
+    },
+    {
+      key: "styles.css",
+      filePath: "/absolute/path/to/dist/styles.css",
+      contentType: "text/css; charset=utf-8",
+    },
+  ],
+  dependsOn: [site.worker],
+}, { parent: site });
 ```
 
 ### Mixed public/private site with Cloudflare Access
@@ -206,7 +228,8 @@ After adding this config, `pulumi preview` should show an `observability` block 
 3. One `cloudflare.WorkersCustomDomain` per hostname in `domains`
 4. An optional `cloudflare.ZeroTrustAccessIdentityProvider` when `githubOAuthConfig` is provided
 5. Zero or more `cloudflare.ZeroTrustAccessApplication` resources, one per `(domain, path)` combination when `paths` is provided
-6. An `cloudflare.AccountToken` plus one `R2Object` per uploaded file when `assets` is provided
+
+When using `uploadAssets` from the `./workersite/r2` sub-path, an additional `cloudflare.AccountToken` and one `R2Object` per file are created.
 
 ## Access control model
 
@@ -219,14 +242,26 @@ Cloudflare Access enforces authorization before requests reach the Worker. The W
 
 ## Asset uploads
 
-If you pass `assets`, `WorkerSite` uploads files declaratively as part of `pulumi up`.
+R2 asset uploads are managed via `uploadAssets` from the `./workersite/r2` sub-path, decoupled from `WorkerSite` (ADR-014). This isolates the `@aws-sdk/client-s3` dependency from consumers that only need infrastructure.
+
+```typescript
+import { uploadAssets } from "@jmmaloney4/sector7/workersite/r2";
+
+uploadAssets("my-site", {
+  accountId: "your-account-id",
+  bucketName: "my-site-assets",
+  files: [
+    { key: "index.html", filePath: "/dist/index.html", contentType: "text/html" },
+  ],
+  dependsOn: [site.worker],
+}, { parent: site });
+```
 
 - Each file becomes a separate `R2Object` dynamic resource
 - Change detection uses MD5/ETag comparison
-- The component creates a scoped `AccountToken` for R2 object writes automatically
+- `uploadAssets` creates a scoped `AccountToken` for R2 object writes automatically
 - The token scope is limited to the configured bucket
-
-If you do not pass `assets`, you can still upload files by another workflow and let `WorkerSite` only manage the Worker and domains.
+- `@aws-sdk/client-s3` is required when using this sub-path
 
 ## Redirects
 
@@ -268,7 +303,6 @@ redirects: [
 | `githubOrganizations`      | `string[]`                  | Conditional | Required when a path uses `github-org`               |
 | `paths`                    | `PathConfig[]`              | No          | Access-control rules; omit for fully public sites    |
 | `cacheTtlSeconds`          | `number`                    | No          | Cache TTL for generated Worker responses             |
-| `assets`                   | `AssetConfig`               | No          | Declarative upload configuration                     |
 | `redirects`                | `RedirectRule[]`            | No          | Host redirects for the generated Worker              |
 | `workerScript`             | `WorkerScriptConfig`        | No          | Custom Worker source and extra bindings              |
 | `observability`            | `WorkerObservabilityConfig` | No          | Worker observability and log sampling settings       |
@@ -292,7 +326,9 @@ You must create a GitHub OAuth App at https://github.com/settings/developers wit
 | `pattern` | `string`                   | Yes      | Path pattern such as `/blog/*` |
 | `access`  | `"public" \| "github-org"` | Yes      | Access mode for the path       |
 
-### `AssetConfig`
+### `AssetConfig` (via `./workersite/r2`)
+
+See [Asset uploads](#asset-uploads) for usage. Available from `@jmmaloney4/sector7/workersite/r2`.
 
 | Field   | Type          | Required | Description                            |
 | ------- | ------------- | -------- | -------------------------------------- |
@@ -328,7 +364,12 @@ WorkerSite creates the following Cloudflare resources, and the API token must ha
 | `cloudflare.WorkersCustomDomain`                            | Workers Routes: Edit                |
 | `cloudflare.ZeroTrustAccessIdentityProvider` (when `githubOAuthConfig` is set) | Access: Identity Providers: Edit |
 | `cloudflare.ZeroTrustAccessApplication` (when `paths` is set) | Access: Apps and Policies: Edit  |
-| `cloudflare.AccountToken` (when `assets` is set)            | Account Settings: Read              |
+
+When using `uploadAssets` from the `./workersite/r2` sub-path:
+
+| Resource created by uploadAssets         | Required token permission (Account) |
+| ---------------------------------------- | ----------------------------------- |
+| `cloudflare.AccountToken`                | Account Settings: Read              |
 
 **Zone-level:**
 
@@ -351,7 +392,7 @@ Account-level permissions (scoped to the target account):
 Zone-level permissions (scoped to the target zone):
 - Workers Routes: Edit
 
-If you do not use `paths` (fully public site), you can omit the Access permissions. If you do not use `assets`, you can omit Account Settings: Read.
+If you do not use `paths` (fully public site), you can omit the Access permissions. Account Settings: Read is only needed when using `uploadAssets` from the `./workersite/r2` sub-path.
 
 ## Troubleshooting
 

--- a/packages/sector7/workersite/barrel-guard.ts
+++ b/packages/sector7/workersite/barrel-guard.ts
@@ -1,0 +1,14 @@
+/**
+ * Type-level regression guard: R2Object must NOT be re-exported from the main
+ * workersite barrel.  This file is type-checked by its own tsconfig
+ * (tsconfig.barrel-guard.json) as part of CI.
+ *
+ * If someone adds `export * from "./r2object.ts"` back to index.ts, the
+ * @ts-expect-error directives become unused and tsc fails.
+ */
+
+// @ts-expect-error — R2Object lives on the ./r2 sub-path, not the main barrel
+import type { R2Object } from "./index.ts";
+
+// @ts-expect-error — R2ObjectInputs lives on the ./r2 sub-path
+import type { R2ObjectInputs } from "./index.ts";

--- a/packages/sector7/workersite/barrel-guard.ts
+++ b/packages/sector7/workersite/barrel-guard.ts
@@ -1,14 +1,16 @@
-/**
- * Type-level regression guard: R2Object must NOT be re-exported from the main
- * workersite barrel.  This file is type-checked by its own tsconfig
- * (tsconfig.barrel-guard.json) as part of CI.
- *
- * If someone adds `export * from "./r2object.ts"` back to index.ts, the
- * @ts-expect-error directives become unused and tsc fails.
- */
+// Barrel guard: ensure R2Object and related types are NOT re-exported from
+// the main workersite barrel.  They live on the ./r2 sub-path (ADR-014).
+// If someone re-adds them to index.ts, the @ts-expect-error directives
+// will produce "Unused '@ts-expect-error' directive" errors and fail CI.
 
-// @ts-expect-error — R2Object lives on the ./r2 sub-path, not the main barrel
-import type { R2Object } from "./index.ts";
+// @ts-expect-error — R2Object lives on ./workersite/r2 sub-path only
+import { R2Object } from "./index.ts";
 
-// @ts-expect-error — R2ObjectInputs lives on the ./r2 sub-path
-import type { R2ObjectInputs } from "./index.ts";
+// @ts-expect-error — AssetFile lives on ./workersite/r2 sub-path only
+import { type AssetFile } from "./index.ts";
+
+// @ts-expect-error — AssetConfig lives on ./workersite/r2 sub-path only
+import { type AssetConfig } from "./index.ts";
+
+// @ts-expect-error — uploadAssets lives on ./workersite/r2 sub-path only
+import { uploadAssets } from "./index.ts";

--- a/packages/sector7/workersite/index.ts
+++ b/packages/sector7/workersite/index.ts
@@ -1,7 +1,5 @@
 export {
 	type PathConfig,
-	type AssetFile,
-	type AssetConfig,
 	type WorkerScriptConfig,
 	type GithubOAuthConfig,
 	type WorkerObservabilityConfig,

--- a/packages/sector7/workersite/index.ts
+++ b/packages/sector7/workersite/index.ts
@@ -1,4 +1,3 @@
-export * from "./r2object.ts";
 export * from "./worker-site.ts";
 export {
 	generateWorkerScript,

--- a/packages/sector7/workersite/index.ts
+++ b/packages/sector7/workersite/index.ts
@@ -1,4 +1,13 @@
-export * from "./worker-site.ts";
+export {
+	type PathConfig,
+	type AssetFile,
+	type AssetConfig,
+	type WorkerScriptConfig,
+	type GithubOAuthConfig,
+	type WorkerObservabilityConfig,
+	type WorkerSiteArgs,
+	WorkerSite,
+} from "./worker-site.ts";
 export {
 	generateWorkerScript,
 	type RedirectRule,

--- a/packages/sector7/workersite/r2.ts
+++ b/packages/sector7/workersite/r2.ts
@@ -1,0 +1,1 @@
+export * from "./r2object.ts";

--- a/packages/sector7/workersite/r2.ts
+++ b/packages/sector7/workersite/r2.ts
@@ -1,1 +1,8 @@
-export * from "./r2object.ts";
+export {
+	type AssetFile,
+	type AssetConfig,
+	type UploadAssetsArgs,
+	uploadAssets,
+	R2Object,
+	type R2ObjectInputs,
+} from "./r2object.ts";

--- a/packages/sector7/workersite/r2object.ts
+++ b/packages/sector7/workersite/r2object.ts
@@ -1,13 +1,13 @@
+import * as cloudflare from "@pulumi/cloudflare";
+import * as pulumi from "@pulumi/pulumi";
 import {
+	type ComponentResourceOptions,
 	type CustomResourceOptions,
 	dynamic,
 	type Input,
 	type Output,
-	type ComponentResourceOptions,
 	type Resource,
 } from "@pulumi/pulumi";
-import * as pulumi from "@pulumi/pulumi";
-import * as cloudflare from "@pulumi/cloudflare";
 
 // ---------------------------------------------------------------------------
 // AWS Signature Version 4 — minimal implementation for S3 PUT/DELETE only.
@@ -55,12 +55,17 @@ const signedFetch = async (
 	body?: Buffer,
 	contentType?: string,
 ): Promise<Response> => {
-	const nodeCrypto = (await import("node:crypto")) as typeof import("node:crypto");
+	const nodeCrypto = (await import(
+		"node:crypto"
+	)) as typeof import("node:crypto");
 
 	const parsed = new URL(url);
 	const host = parsed.host;
 	const now = new Date();
-	const amzDate = now.toISOString().replace(/[-:]/g, "").replace(/\.\d+Z$/, "Z");
+	const amzDate = now
+		.toISOString()
+		.replace(/[-:]/g, "")
+		.replace(/\.\d+Z$/, "Z");
 	const dateStamp = amzDate.slice(0, 8);
 	const region = "auto";
 	const service = "s3";
@@ -83,10 +88,11 @@ const signedFetch = async (
 	}
 
 	const signedHeaderNames = Object.keys(headers).sort().join(";");
-	const canonicalHeaders = Object.keys(headers)
-		.sort()
-		.map((k) => `${k}:${headers[k].trim()}`)
-		.join("\n") + "\n";
+	const canonicalHeaders =
+		Object.keys(headers)
+			.sort()
+			.map((k) => `${k}:${headers[k].trim()}`)
+			.join("\n") + "\n";
 
 	// Canonical request
 	const canonicalQueryString = "";
@@ -286,21 +292,41 @@ const tryReadFileSync = (
 /** Upload a file to R2 and return the normalized ETag. */
 const uploadObjectToR2 = async (args: R2ObjectArgs): Promise<string> => {
 	const fs = (await import("node:fs")) as typeof import("node:fs");
-	const nodeCrypto = (await import("node:crypto")) as typeof import("node:crypto");
+	const nodeCrypto = (await import(
+		"node:crypto"
+	)) as typeof import("node:crypto");
 
-	const { accountId, bucketName, key, filePath, contentType, accessKeyId, secretAccessKey } = args;
+	const {
+		accountId,
+		bucketName,
+		key,
+		filePath,
+		contentType,
+		accessKeyId,
+		secretAccessKey,
+	} = args;
 	const body = fs.readFileSync(filePath);
 	const url = `https://${accountId}.r2.cloudflarestorage.com/${bucketName}/${key}`;
 
-	const response = await signedFetch("PUT", url, { accessKeyId, secretAccessKey }, body, contentType);
+	const response = await signedFetch(
+		"PUT",
+		url,
+		{ accessKeyId, secretAccessKey },
+		body,
+		contentType,
+	);
 
 	if (!response.ok) {
 		const text = await response.text();
-		throw new Error(`R2 PUT ${key} failed: ${response.status} ${response.statusText}\n${text}`);
+		throw new Error(
+			`R2 PUT ${key} failed: ${response.status} ${response.statusText}\n${text}`,
+		);
 	}
 
 	const etag = response.headers.get("ETag");
-	return (etag ?? nodeCrypto.createHash("md5").update(body).digest("hex")).replace(/"/g, "");
+	return (
+		etag ?? nodeCrypto.createHash("md5").update(body).digest("hex")
+	).replace(/"/g, "");
 };
 
 /** Delete an object from R2. */
@@ -320,7 +346,9 @@ const deleteObjectFromR2 = async (args: {
 	// R2 returns 204 on successful delete; tolerate 404 (already gone)
 	if (response.status !== 204 && response.status !== 404) {
 		const text = await response.text();
-		throw new Error(`R2 DELETE ${args.key} failed: ${response.status} ${response.statusText}\n${text}`);
+		throw new Error(
+			`R2 DELETE ${args.key} failed: ${response.status} ${response.statusText}\n${text}`,
+		);
 	}
 };
 
@@ -511,7 +539,13 @@ export function uploadAssets(
 							bucketName: args.bucketName,
 						})
 						.apply(
-							({ accountId, bucketName }: { accountId: string; bucketName: string }) => {
+							({
+								accountId,
+								bucketName,
+							}: {
+								accountId: string;
+								bucketName: string;
+							}) => {
 								const key = `com.cloudflare.edge.r2.bucket.${accountId}_default_${bucketName}`;
 								return JSON.stringify({ [key]: "*" });
 							},
@@ -526,15 +560,17 @@ export function uploadAssets(
 	const secretAccessKey = r2Token.value.apply(async (v: string) => {
 		// crypto is safe here — this runs in the Pulumi host process
 		// (not inside a serialized dynamic provider closure).
-		const nodeCrypto = (await import("node:crypto")) as typeof import("node:crypto");
+		const nodeCrypto = (await import(
+			"node:crypto"
+		)) as typeof import("node:crypto");
 		return nodeCrypto.createHash("sha256").update(v).digest("hex");
 	});
 
 	const assets: R2Object[] = [];
-	for (const file of args.files) {
-		const safeKey = file.key.toString().replace(/[^a-zA-Z0-9-_]/g, "-");
+	for (const [index, file] of args.files.entries()) {
+		const safeKey = String(file.key).replace(/[^a-zA-Z0-9-_]/g, "-");
 		const r2obj = new R2Object(
-			`${name}-asset-${safeKey}`,
+			`${name}-asset-${index}-${safeKey}`,
 			{
 				accountId: args.accountId,
 				bucketName: args.bucketName,

--- a/packages/sector7/workersite/r2object.ts
+++ b/packages/sector7/workersite/r2object.ts
@@ -70,16 +70,16 @@ const signedFetch = async (
 		? nodeCrypto.createHash("sha256").update(body).digest("hex")
 		: nodeCrypto.createHash("sha256").update("").digest("hex");
 
-	// Canonical headers — must be sorted by lowercase name
+	// Canonical headers — must be sorted by lowercase name.
+	// Only include content-type when it has a value so the signed
+	// headers match the actual fetch headers exactly.
 	const headers: Record<string, string> = {
-		"content-type": contentType ?? "",
 		host,
 		"x-amz-content-sha256": payloadHash,
 		"x-amz-date": amzDate,
 	};
-	// Drop empty content-type for DELETE
-	if (method === "DELETE") {
-		delete headers["content-type"];
+	if (contentType) {
+		headers["content-type"] = contentType;
 	}
 
 	const signedHeaderNames = Object.keys(headers).sort().join(";");
@@ -486,8 +486,10 @@ export function uploadAssets(
 	args: UploadAssetsArgs,
 	opts?: ComponentResourceOptions,
 ): R2Object[] {
-	const parent = opts?.parent;
-	const resourceOpts = parent ? { parent } : {};
+	// Use caller-provided opts as the base for child resources so that
+	// options like `protect`, `provider`, `aliases` etc. are forwarded.
+	const tokenOpts = { ...opts };
+	const r2ObjectOpts = { ...opts, dependsOn: args.dependsOn };
 
 	// Create a scoped R2 API token for uploads.
 	const r2Token = new cloudflare.AccountToken(
@@ -517,22 +519,22 @@ export function uploadAssets(
 				},
 			],
 		},
-		resourceOpts,
+		tokenOpts,
 	);
 
 	const accessKeyId = r2Token.id;
-	const secretAccessKey = r2Token.value.apply((v: string) => {
-		// crypto is safe at the top level here — this runs in the Pulumi
-		// host process (not inside a serialized dynamic provider closure).
-		const nodeCrypto = require("node:crypto") as typeof import("node:crypto");
+	const secretAccessKey = r2Token.value.apply(async (v: string) => {
+		// crypto is safe here — this runs in the Pulumi host process
+		// (not inside a serialized dynamic provider closure).
+		const nodeCrypto = (await import("node:crypto")) as typeof import("node:crypto");
 		return nodeCrypto.createHash("sha256").update(v).digest("hex");
 	});
 
 	const assets: R2Object[] = [];
-	for (let index = 0; index < args.files.length; index++) {
-		const file = args.files[index];
+	for (const file of args.files) {
+		const safeKey = file.key.toString().replace(/[^a-zA-Z0-9-_]/g, "-");
 		const r2obj = new R2Object(
-			`${name}-asset-${index}`,
+			`${name}-asset-${safeKey}`,
 			{
 				accountId: args.accountId,
 				bucketName: args.bucketName,
@@ -543,8 +545,7 @@ export function uploadAssets(
 				secretAccessKey,
 			},
 			{
-				...resourceOpts,
-				dependsOn: args.dependsOn,
+				...r2ObjectOpts,
 			},
 		);
 		assets.push(r2obj);

--- a/packages/sector7/workersite/r2object.ts
+++ b/packages/sector7/workersite/r2object.ts
@@ -3,7 +3,55 @@ import {
 	dynamic,
 	type Input,
 	type Output,
+	type ComponentResourceOptions,
+	type Resource,
 } from "@pulumi/pulumi";
+import * as crypto from "node:crypto";
+import * as pulumi from "@pulumi/pulumi";
+import * as cloudflare from "@pulumi/cloudflare";
+import { S3Client, PutObjectCommand, DeleteObjectCommand } from "@aws-sdk/client-s3";
+
+/**
+ * A single static file to upload to R2 as a Pulumi-managed resource.
+ */
+export interface AssetFile {
+	/**
+	 * Absolute path to the local file on disk.
+	 */
+	filePath: Input<string>;
+
+	/**
+	 * R2 object key (e.g., "index.html", "styles/main.css").
+	 */
+	key: Input<string>;
+
+	/**
+	 * MIME content type (e.g., "text/html; charset=utf-8").
+	 */
+	contentType: Input<string>;
+}
+
+/**
+ * Configuration for declarative R2 asset uploads.
+ *
+ * When provided, `uploadAssets` creates a scoped R2 API token and uploads each
+ * listed file as a separate Pulumi dynamic resource.  Content changes are
+ * detected via MD5 comparison against the stored ETag — no external binary
+ * required.
+ *
+ * Notes
+ * -----
+ * The generated AccountToken is scoped to R2_BUCKET_ITEM_WRITE on the specific
+ * bucket only.  Credentials are derived per Cloudflare's spec:
+ *   accessKeyId     = token.id
+ *   secretAccessKey = SHA-256(token.value)
+ */
+export interface AssetConfig {
+	/**
+	 * Files to upload.  Each file becomes a separate Pulumi R2Object resource.
+	 */
+	files: AssetFile[];
+}
 
 /**
  * Inputs accepted at the call site.  Pulumi resolves all `Input<T>` values
@@ -29,6 +77,20 @@ export interface R2ObjectInputs {
 	accessKeyId: Input<string>;
 	/** R2 API token secret access key (= SHA-256 of AccountToken.value). Store as a Pulumi secret. */
 	secretAccessKey: Input<string>;
+}
+
+/**
+ * Arguments for `uploadAssets`.
+ */
+export interface UploadAssetsArgs {
+	/** Cloudflare account ID. */
+	accountId: Input<string>;
+	/** Name of the R2 bucket to upload to. */
+	bucketName: Input<string>;
+	/** Files to upload. */
+	files: AssetFile[];
+	/** Resource dependencies (e.g. the Worker and bucket). */
+	dependsOn?: Input<Input<Resource>[]>;
 }
 
 /**
@@ -81,10 +143,7 @@ const tryReadFileSync = (
 /** Upload a file to R2 and return the normalized ETag. */
 const uploadObjectToR2 = async (args: R2ObjectArgs): Promise<string> => {
 	const fs = (await import("node:fs")) as typeof import("node:fs");
-	const crypto = (await import("node:crypto")) as typeof import("node:crypto");
-	const { S3Client, PutObjectCommand } = (await import(
-		"@aws-sdk/client-s3"
-	)) as typeof import("@aws-sdk/client-s3");
+	const nodeCrypto = (await import("node:crypto")) as typeof import("node:crypto");
 
 	const {
 		accountId,
@@ -110,7 +169,7 @@ const uploadObjectToR2 = async (args: R2ObjectArgs): Promise<string> => {
 		}),
 	);
 	return (
-		result.ETag ?? crypto.createHash("md5").update(body).digest("hex")
+		result.ETag ?? nodeCrypto.createHash("md5").update(body).digest("hex")
 	).replace(/"/g, "");
 };
 
@@ -120,15 +179,18 @@ const uploadObjectToR2 = async (args: R2ObjectArgs): Promise<string> => {
  *
  * Notes
  * -----
- * All imports are intentionally inlined as dynamic import() calls inside
- * provider callbacks rather than imported at module top level.  Pulumi
+ * Node built-in imports (fs, crypto) are inlined as dynamic import() calls
+ * inside provider callbacks rather than imported at module top level.  Pulumi
  * serializes the provider object via V8 source capture; top-level ES module
- * imports of Node built-ins (fs, crypto) or large CJS packages capture
- * native-code functions that cannot be serialized, causing a
- * "Function code: function () { [native code] }" error.
+ * imports of Node built-ins capture native-code functions that cannot be
+ * serialized, causing a "Function code: function () { [native code] }" error.
  * Dynamic import() calls are emitted verbatim and evaluated at runtime after
  * deserialization.  See the Pulumi dynamic provider serialization docs:
  * https://www.pulumi.com/docs/concepts/resources/dynamic-providers/#how-dynamic-providers-are-serialized
+ *
+ * The `@aws-sdk/client-s3` import IS static because this module lives behind
+ * the `./workersite/r2` sub-path — consumers who need R2 upload must install
+ * it as a required dependency.
  *
  * Lifecycle
  * ---------
@@ -169,7 +231,7 @@ const r2ObjectProvider: dynamic.ResourceProvider = {
 		news: R2ObjectArgs,
 	): Promise<dynamic.DiffResult> {
 		const fs = (await import("node:fs")) as typeof import("node:fs");
-		const crypto = (await import(
+		const nodeCrypto = (await import(
 			"node:crypto"
 		)) as typeof import("node:crypto");
 
@@ -183,7 +245,7 @@ const r2ObjectProvider: dynamic.ResourceProvider = {
 
 		const currentFile = tryReadFileSync(fs, news.filePath);
 		const currentEtag = currentFile
-			? crypto.createHash("md5").update(currentFile).digest("hex")
+			? nodeCrypto.createHash("md5").update(currentFile).digest("hex")
 			: // Missing files should force a change without crashing refresh/diff.
 				"";
 		const changed =
@@ -210,10 +272,6 @@ const r2ObjectProvider: dynamic.ResourceProvider = {
 	},
 
 	async delete(_id: string, props: R2ObjectState): Promise<void> {
-		const { S3Client, DeleteObjectCommand } = (await import(
-			"@aws-sdk/client-s3"
-		)) as typeof import("@aws-sdk/client-s3");
-
 		const { accountId, bucketName, key, accessKeyId, secretAccessKey } = props;
 		const client = new S3Client({
 			region: "auto",
@@ -253,4 +311,94 @@ export class R2Object extends dynamic.Resource {
 	) {
 		super(r2ObjectProvider, name, { etag: undefined, ...args }, opts);
 	}
+}
+
+// Cloudflare permission group ID for R2 bucket item write access.
+// Used to scope the API token created for asset uploads.
+const R2_BUCKET_ITEM_WRITE_PERMISSION_GROUP_ID =
+	"2efd5506f9c8494dacb1fa10a3e7d5b6";
+
+/**
+ * Upload static assets to R2 as Pulumi-managed resources.
+ *
+ * Creates a scoped R2 API token and uploads each file as a separate
+ * `R2Object` dynamic resource with MD5-based change detection.
+ * Returns the created `R2Object` instances.
+ *
+ * This function lives on the `./workersite/r2` sub-path to isolate the
+ * `@aws-sdk/client-s3` dependency from consumers that only need
+ * `WorkerSite` infrastructure (ADR-014).
+ *
+ * @param name - Pulumi resource name prefix.
+ * @param args - Upload configuration (account, bucket, files).
+ * @param opts - Pulumi component resource options (set `parent` to the WorkerSite).
+ * @returns Array of created R2Object resources.
+ */
+export function uploadAssets(
+	name: string,
+	args: UploadAssetsArgs,
+	opts?: ComponentResourceOptions,
+): R2Object[] {
+	const parent = opts?.parent;
+	const resourceOpts = parent ? { parent } : {};
+
+	// Create a scoped R2 API token for uploads.
+	const r2Token = new cloudflare.AccountToken(
+		`${name}-r2-token`,
+		{
+			accountId: args.accountId,
+			name: `${name}-r2-upload`,
+			policies: [
+				{
+					effect: "allow",
+					permissionGroups: [
+						{
+							id: R2_BUCKET_ITEM_WRITE_PERMISSION_GROUP_ID,
+						},
+					],
+					resources: pulumi
+						.output({
+							accountId: args.accountId,
+							bucketName: args.bucketName,
+						})
+						.apply(
+							({ accountId, bucketName }: { accountId: string; bucketName: string }) => {
+								const key = `com.cloudflare.edge.r2.bucket.${accountId}_default_${bucketName}`;
+								return JSON.stringify({ [key]: "*" });
+							},
+						),
+				},
+			],
+		},
+		resourceOpts,
+	);
+
+	const accessKeyId = r2Token.id;
+	const secretAccessKey = r2Token.value.apply((v: string) =>
+		crypto.createHash("sha256").update(v).digest("hex"),
+	);
+
+	const assets: R2Object[] = [];
+	for (let index = 0; index < args.files.length; index++) {
+		const file = args.files[index];
+		const r2obj = new R2Object(
+			`${name}-asset-${index}`,
+			{
+				accountId: args.accountId,
+				bucketName: args.bucketName,
+				key: file.key,
+				filePath: file.filePath,
+				contentType: file.contentType,
+				accessKeyId,
+				secretAccessKey,
+			},
+			{
+				...resourceOpts,
+				dependsOn: args.dependsOn,
+			},
+		);
+		assets.push(r2obj);
+	}
+
+	return assets;
 }

--- a/packages/sector7/workersite/r2object.ts
+++ b/packages/sector7/workersite/r2object.ts
@@ -6,10 +6,145 @@ import {
 	type ComponentResourceOptions,
 	type Resource,
 } from "@pulumi/pulumi";
-import * as crypto from "node:crypto";
 import * as pulumi from "@pulumi/pulumi";
 import * as cloudflare from "@pulumi/cloudflare";
-import { S3Client, PutObjectCommand, DeleteObjectCommand } from "@aws-sdk/client-s3";
+
+// ---------------------------------------------------------------------------
+// AWS Signature Version 4 — minimal implementation for S3 PUT/DELETE only.
+// Uses node:crypto (dynamically imported) and global fetch(). No external deps.
+// See: https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_sigv.html
+// ---------------------------------------------------------------------------
+
+interface SigV4Credentials {
+	accessKeyId: string;
+	secretAccessKey: string;
+}
+
+/**
+ * Derive the signing key for a given date/region/service.
+ * HMAC chain: (secret) → dateKey → regionKey → serviceKey → signingKey
+ */
+const deriveSigningKey = async (
+	nodeCrypto: typeof import("node:crypto"),
+	secretAccessKey: string,
+	dateStamp: string,
+	region: string,
+	service: string,
+): Promise<Buffer> => {
+	const hmac = (key: Buffer | string, data: string) =>
+		nodeCrypto.createHmac("sha256", key).update(data).digest();
+	const dateKey = hmac(`AWS4${secretAccessKey}`, dateStamp);
+	const regionKey = hmac(dateKey, region);
+	const serviceKey = hmac(regionKey, service);
+	return hmac(serviceKey, "aws4_request");
+};
+
+/**
+ * Build an AWS Sig V4 signed request and execute it via fetch().
+ *
+ * This is deliberately scoped to the two operations we need:
+ *   - PUT    (upload object body)
+ *   - DELETE (remove object)
+ *
+ * No query strings, no multipart, no chunked encoding.
+ */
+const signedFetch = async (
+	method: "PUT" | "DELETE",
+	url: string,
+	creds: SigV4Credentials,
+	body?: Buffer,
+	contentType?: string,
+): Promise<Response> => {
+	const nodeCrypto = (await import("node:crypto")) as typeof import("node:crypto");
+
+	const parsed = new URL(url);
+	const host = parsed.host;
+	const now = new Date();
+	const amzDate = now.toISOString().replace(/[-:]/g, "").replace(/\.\d+Z$/, "Z");
+	const dateStamp = amzDate.slice(0, 8);
+	const region = "auto";
+	const service = "s3";
+
+	// Payload hash
+	const payloadHash = body
+		? nodeCrypto.createHash("sha256").update(body).digest("hex")
+		: nodeCrypto.createHash("sha256").update("").digest("hex");
+
+	// Canonical headers — must be sorted by lowercase name
+	const headers: Record<string, string> = {
+		"content-type": contentType ?? "",
+		host,
+		"x-amz-content-sha256": payloadHash,
+		"x-amz-date": amzDate,
+	};
+	// Drop empty content-type for DELETE
+	if (method === "DELETE") {
+		delete headers["content-type"];
+	}
+
+	const signedHeaderNames = Object.keys(headers).sort().join(";");
+	const canonicalHeaders = Object.keys(headers)
+		.sort()
+		.map((k) => `${k}:${headers[k].trim()}`)
+		.join("\n") + "\n";
+
+	// Canonical request
+	const canonicalQueryString = "";
+	const canonicalRequest = [
+		method,
+		parsed.pathname,
+		canonicalQueryString,
+		canonicalHeaders,
+		signedHeaderNames,
+		payloadHash,
+	].join("\n");
+
+	// String to sign
+	const credentialScope = `${dateStamp}/${region}/${service}/aws4_request`;
+	const stringToSign = [
+		"AWS4-HMAC-SHA256",
+		amzDate,
+		credentialScope,
+		nodeCrypto.createHash("sha256").update(canonicalRequest).digest("hex"),
+	].join("\n");
+
+	// Sign
+	const signingKey = await deriveSigningKey(
+		nodeCrypto,
+		creds.secretAccessKey,
+		dateStamp,
+		region,
+		service,
+	);
+	const signature = nodeCrypto
+		.createHmac("sha256", signingKey)
+		.update(stringToSign)
+		.digest("hex");
+
+	const authorization =
+		`AWS4-HMAC-SHA256 Credential=${creds.accessKeyId}/${credentialScope}, ` +
+		`SignedHeaders=${signedHeaderNames}, Signature=${signature}`;
+
+	// Build fetch headers (must match canonical exactly)
+	const fetchHeaders: Record<string, string> = {
+		Authorization: authorization,
+		"X-Amz-Content-Sha256": payloadHash,
+		"X-Amz-Date": amzDate,
+	};
+	if (contentType) {
+		fetchHeaders["Content-Type"] = contentType;
+	}
+
+	return fetch(url, {
+		method,
+		headers: fetchHeaders,
+		body: body ? new Uint8Array(body) : undefined,
+	});
+};
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
 
 /**
  * A single static file to upload to R2 as a Pulumi-managed resource.
@@ -116,6 +251,10 @@ interface R2ObjectState extends R2ObjectArgs {
 	etag: string;
 }
 
+// ---------------------------------------------------------------------------
+// File helpers
+// ---------------------------------------------------------------------------
+
 const tryStatFileSync = (
 	fs: typeof import("node:fs"),
 	filePath: string,
@@ -140,38 +279,54 @@ const tryReadFileSync = (
 	}
 };
 
+// ---------------------------------------------------------------------------
+// R2 operations via native S3 signing (no AWS SDK)
+// ---------------------------------------------------------------------------
+
 /** Upload a file to R2 and return the normalized ETag. */
 const uploadObjectToR2 = async (args: R2ObjectArgs): Promise<string> => {
 	const fs = (await import("node:fs")) as typeof import("node:fs");
 	const nodeCrypto = (await import("node:crypto")) as typeof import("node:crypto");
 
-	const {
-		accountId,
-		bucketName,
-		key,
-		filePath,
-		contentType,
-		accessKeyId,
-		secretAccessKey,
-	} = args;
-	const client = new S3Client({
-		region: "auto",
-		endpoint: `https://${accountId}.r2.cloudflarestorage.com`,
-		credentials: { accessKeyId, secretAccessKey },
-	});
+	const { accountId, bucketName, key, filePath, contentType, accessKeyId, secretAccessKey } = args;
 	const body = fs.readFileSync(filePath);
-	const result = await client.send(
-		new PutObjectCommand({
-			Bucket: bucketName,
-			Key: key,
-			Body: body,
-			ContentType: contentType,
-		}),
-	);
-	return (
-		result.ETag ?? nodeCrypto.createHash("md5").update(body).digest("hex")
-	).replace(/"/g, "");
+	const url = `https://${accountId}.r2.cloudflarestorage.com/${bucketName}/${key}`;
+
+	const response = await signedFetch("PUT", url, { accessKeyId, secretAccessKey }, body, contentType);
+
+	if (!response.ok) {
+		const text = await response.text();
+		throw new Error(`R2 PUT ${key} failed: ${response.status} ${response.statusText}\n${text}`);
+	}
+
+	const etag = response.headers.get("ETag");
+	return (etag ?? nodeCrypto.createHash("md5").update(body).digest("hex")).replace(/"/g, "");
 };
+
+/** Delete an object from R2. */
+const deleteObjectFromR2 = async (args: {
+	accountId: string;
+	bucketName: string;
+	key: string;
+	accessKeyId: string;
+	secretAccessKey: string;
+}): Promise<void> => {
+	const url = `https://${args.accountId}.r2.cloudflarestorage.com/${args.bucketName}/${args.key}`;
+	const response = await signedFetch("DELETE", url, {
+		accessKeyId: args.accessKeyId,
+		secretAccessKey: args.secretAccessKey,
+	});
+
+	// R2 returns 204 on successful delete; tolerate 404 (already gone)
+	if (response.status !== 204 && response.status !== 404) {
+		const text = await response.text();
+		throw new Error(`R2 DELETE ${args.key} failed: ${response.status} ${response.statusText}\n${text}`);
+	}
+};
+
+// ---------------------------------------------------------------------------
+// Pulumi dynamic provider
+// ---------------------------------------------------------------------------
 
 /**
  * Pulumi dynamic resource provider that manages a single object in a
@@ -188,17 +343,16 @@ const uploadObjectToR2 = async (args: R2ObjectArgs): Promise<string> => {
  * deserialization.  See the Pulumi dynamic provider serialization docs:
  * https://www.pulumi.com/docs/concepts/resources/dynamic-providers/#how-dynamic-providers-are-serialized
  *
- * The `@aws-sdk/client-s3` import IS static because this module lives behind
- * the `./workersite/r2` sub-path — consumers who need R2 upload must install
- * it as a required dependency.
+ * S3 requests are signed natively using AWS Signature Version 4 (node:crypto +
+ * fetch) — no @aws-sdk/client-s3 dependency required (ADR-015).
  *
  * Lifecycle
  * ---------
  * - check  : verify the local file exists
  * - diff   : compare MD5(file) to stored etag; replace on key/bucket/account change
- * - create : PutObject with body + content-type; store etag
- * - update : re-upload via PutObject; store new etag
- * - delete : DeleteObject
+ * - create : PUT with body + content-type; store etag
+ * - update : re-upload via PUT; store new etag
+ * - delete : DELETE
  */
 const r2ObjectProvider: dynamic.ResourceProvider = {
 	async check(
@@ -272,24 +426,16 @@ const r2ObjectProvider: dynamic.ResourceProvider = {
 	},
 
 	async delete(_id: string, props: R2ObjectState): Promise<void> {
-		const { accountId, bucketName, key, accessKeyId, secretAccessKey } = props;
-		const client = new S3Client({
-			region: "auto",
-			endpoint: `https://${accountId}.r2.cloudflarestorage.com`,
-			credentials: { accessKeyId, secretAccessKey },
-		});
-		await client.send(
-			new DeleteObjectCommand({ Bucket: bucketName, Key: key }),
-		);
+		await deleteObjectFromR2(props);
 	},
 };
 
 /**
  * A single object stored in a Cloudflare R2 bucket.
  *
- * Uses the S3-compatible API for all CRUD operations.  Content changes are
- * detected via MD5 comparison against the stored ETag — no external binary
- * required.
+ * Uses the S3-compatible API for all CRUD operations via native AWS Sig V4
+ * signing (node:crypto + fetch).  Content changes are detected via MD5
+ * comparison against the stored ETag — no external binary required.
  *
  * Parameters
  * ----------
@@ -326,8 +472,9 @@ const R2_BUCKET_ITEM_WRITE_PERMISSION_GROUP_ID =
  * Returns the created `R2Object` instances.
  *
  * This function lives on the `./workersite/r2` sub-path to isolate the
- * `@aws-sdk/client-s3` dependency from consumers that only need
- * `WorkerSite` infrastructure (ADR-014).
+ * R2 upload concern from consumers that only need `WorkerSite`
+ * infrastructure (ADR-014).  No external dependencies are required —
+ * S3 signing is implemented natively via node:crypto + fetch (ADR-015).
  *
  * @param name - Pulumi resource name prefix.
  * @param args - Upload configuration (account, bucket, files).
@@ -374,9 +521,12 @@ export function uploadAssets(
 	);
 
 	const accessKeyId = r2Token.id;
-	const secretAccessKey = r2Token.value.apply((v: string) =>
-		crypto.createHash("sha256").update(v).digest("hex"),
-	);
+	const secretAccessKey = r2Token.value.apply((v: string) => {
+		// crypto is safe at the top level here — this runs in the Pulumi
+		// host process (not inside a serialized dynamic provider closure).
+		const nodeCrypto = require("node:crypto") as typeof import("node:crypto");
+		return nodeCrypto.createHash("sha256").update(v).digest("hex");
+	});
 
 	const assets: R2Object[] = [];
 	for (let index = 0; index < args.files.length; index++) {

--- a/packages/sector7/workersite/r2object.ts
+++ b/packages/sector7/workersite/r2object.ts
@@ -163,8 +163,10 @@ export interface AssetFile {
 
 	/**
 	 * R2 object key (e.g., "index.html", "styles/main.css").
+	 * Must be a static string known at construction time — Pulumi resource
+	 * names cannot incorporate Output values.
 	 */
-	key: Input<string>;
+	key: string;
 
 	/**
 	 * MIME content type (e.g., "text/html; charset=utf-8").

--- a/packages/sector7/workersite/worker-site.ts
+++ b/packages/sector7/workersite/worker-site.ts
@@ -1,7 +1,5 @@
-import * as crypto from "node:crypto";
 import * as cloudflare from "@pulumi/cloudflare";
 import * as pulumi from "@pulumi/pulumi";
-import { R2Object } from "./r2object.ts";
 import {
 	generateWorkerScript,
 	type RedirectRule,
@@ -24,48 +22,6 @@ export interface PathConfig {
 	 * - "github-org": Require GitHub organization membership
 	 */
 	access: "public" | "bypass" | "github-org";
-}
-
-/**
- * A single static file to upload to R2 as a Pulumi-managed resource.
- */
-export interface AssetFile {
-	/**
-	 * Absolute path to the local file on disk.
-	 */
-	filePath: pulumi.Input<string>;
-
-	/**
-	 * R2 object key (e.g., "index.html", "styles/main.css").
-	 */
-	key: pulumi.Input<string>;
-
-	/**
-	 * MIME content type (e.g., "text/html; charset=utf-8").
-	 */
-	contentType: pulumi.Input<string>;
-}
-
-/**
- * Configuration for declarative R2 asset uploads.
- *
- * When provided, WorkerSite creates a scoped R2 API token and uploads each
- * listed file as a separate Pulumi dynamic resource.  Content changes are
- * detected via MD5 comparison against the stored ETag — no external binary
- * required.
- *
- * Notes
- * -----
- * The generated AccountToken is scoped to R2_BUCKET_ITEM_WRITE on the specific
- * bucket only.  Credentials are derived per Cloudflare's spec:
- *   accessKeyId     = token.id
- *   secretAccessKey = SHA-256(token.value)
- */
-export interface AssetConfig {
-	/**
-	 * Files to upload.  Each file becomes a separate Pulumi R2Object resource.
-	 */
-	files: AssetFile[];
 }
 
 /**
@@ -188,7 +144,7 @@ export interface WorkerObservabilityConfig {
  * - Optional path-level access control (Zero Trust; omit for fully public sites)
  * - R2 backend with Cache API
  * - Configurable cache TTL
- * - Optional declarative R2 asset uploads (AssetConfig)
+ * - Optional declarative R2 asset uploads via the `./workersite/r2` sub-path (ADR-014)
  * - Optional host-level redirect rules injected into the generated Worker script
  * - Optional custom Worker script with extra bindings
  */
@@ -307,13 +263,6 @@ export interface WorkerSiteArgs {
 	cacheTtlSeconds?: pulumi.Input<number>;
 
 	/**
-	 * Declarative R2 asset upload configuration.
-	 * When set, WorkerSite creates a scoped API token and uploads each file as
-	 * a separate Pulumi dynamic resource with MD5-based change detection.
-	 */
-	assets?: AssetConfig;
-
-	/**
 	 * Host-level HTTP redirect rules injected into the generated Worker script.
 	 * Evaluated before R2 serving.  Ignored when `workerScript` is set.
 	 *
@@ -340,11 +289,6 @@ export interface WorkerSiteArgs {
 	observability?: WorkerObservabilityConfig;
 }
 
-// Cloudflare permission group ID for R2 bucket item write access.
-// Used to scope the API token created for asset uploads.
-const R2_BUCKET_ITEM_WRITE_PERMISSION_GROUP_ID =
-	"2efd5506f9c8494dacb1fa10a3e7d5b6";
-
 /**
  * WorkerSite component for hosting static sites on Cloudflare Workers.
  *
@@ -353,12 +297,12 @@ const R2_BUCKET_ITEM_WRITE_PERMISSION_GROUP_ID =
  * - R2-backed Worker serving static files with Cache API
  * - Multiple domains via WorkersCustomDomain
  * - Optional Zero Trust access control per path
- * - Optional declarative R2 asset uploads
+ * - Optional declarative R2 asset uploads via the `./workersite/r2` sub-path (ADR-014)
  * - Optional host-level redirect rules
  * - Optional custom Worker script with extra bindings
  *
  * @example
- * Fully public site with asset upload and www redirect:
+ * Fully public site with www redirect:
  * ```typescript
  * const site = new WorkerSite("my-site", {
  *   accountId: "abc123",
@@ -367,12 +311,10 @@ const R2_BUCKET_ITEM_WRITE_PERMISSION_GROUP_ID =
  *   domains: ["example.com", "www.example.com"],
  *   r2Bucket: { bucketName: "my-site-assets", create: true },
  *   redirects: [{ fromHost: "www.example.com", toHost: "example.com" }],
- *   assets: {
- *     files: [
- *       { key: "index.html", filePath: "/dist/index.html", contentType: "text/html" },
- *     ],
- *   },
  * });
+ * // Upload assets separately via the r2 sub-path:
+ * // import { uploadAssets } from "@jmmaloney4/sector7/workersite/r2";
+ * // uploadAssets("my-site", { accountId, bucketName, files }, { parent: site });
  * ```
  *
  * @example
@@ -427,11 +369,6 @@ export class WorkerSite extends pulumi.ComponentResource {
 	 * GitHub auth is needed.
 	 */
 	public readonly githubIdp: cloudflare.ZeroTrustAccessIdentityProvider | undefined;
-
-	/**
-	 * Uploaded R2 objects (populated when assets is provided).
-	 */
-	public readonly uploadedAssets: R2Object[];
 
 	/**
 	 * The domains bound to the Worker.
@@ -707,69 +644,6 @@ export class WorkerSite extends pulumi.ComponentResource {
 			}
 		}
 
-		// 6. Upload static assets (optional)
-		this.uploadedAssets = [];
-
-		if (args.assets && args.assets.files.length > 0) {
-			// Create a scoped R2 API token for uploads.
-			// accessKeyId = token.id
-			// secretAccessKey = SHA-256(token.value)  (Cloudflare R2 S3-compat spec)
-			const r2Token = new cloudflare.AccountToken(
-				`${name}-r2-token`,
-				{
-					accountId: args.accountId,
-					name: pulumi.interpolate`${args.name}-r2-upload`,
-					policies: [
-						{
-							effect: "allow",
-							permissionGroups: [
-								{
-									id: R2_BUCKET_ITEM_WRITE_PERMISSION_GROUP_ID,
-								},
-							],
-							// The `resources` field identifies the R2 bucket the token may
-							// write to.  The Cloudflare API expects a JSON-encoded object
-							// (the Pulumi TS type correctly declares Input<string>), but
-							// the resource key MUST use "default" as the location segment
-							// regardless of the bucket's actual storage location.
-							resources: pulumi
-								.all([args.accountId, bucketName])
-								.apply(([acctId, bktName]: [string, string]) => {
-									const key = `com.cloudflare.edge.r2.bucket.${acctId}_default_${bktName}`;
-									return JSON.stringify({ [key]: "*" });
-								}),
-						},
-					],
-				},
-				resourceOpts,
-			);
-
-			const accessKeyId = r2Token.id;
-			const secretAccessKey = r2Token.value.apply((v: string) =>
-				crypto.createHash("sha256").update(v).digest("hex"),
-			);
-
-			for (const [index, file] of args.assets.files.entries()) {
-				const r2obj = new R2Object(
-					`${name}-asset-${index}`,
-					{
-						accountId: args.accountId,
-						bucketName: bucketName,
-						key: file.key,
-						filePath: file.filePath,
-						contentType: file.contentType,
-						accessKeyId,
-						secretAccessKey,
-					},
-					{
-						...resourceOpts,
-						dependsOn: [this.worker, ...(this.bucket ? [this.bucket] : [])],
-					},
-				);
-				this.uploadedAssets.push(r2obj);
-			}
-		}
-
 		// Outputs
 		this.boundDomains = pulumi.output(args.domains);
 		this.workerName = this.worker.scriptName;
@@ -780,7 +654,6 @@ export class WorkerSite extends pulumi.ComponentResource {
 			workerDomains: this.workerDomains,
 			accessApplications: this.accessApplications,
 			githubIdp: this.githubIdp,
-			uploadedAssets: this.uploadedAssets,
 			boundDomains: this.boundDomains,
 			workerName: this.workerName,
 		});


### PR DESCRIPTION
## Closed — superseded by PR #157

See PR #157 for the latest state including the dependsOn merge fix applied on top of `10ea478`.

The dependsOn merge fix adds the missing `r2ObjectOpts` dependency merge so caller-supplied `dependsOn` from `opts` is preserved alongside `args.dependsOn`.

If GitHub's branch update UI was available, I would have updated PR #156's head branch in place.