### PR TITLE
Remove PROJECT_URL env var from _dogfood-add-to-project.yml

### DIFF
--- a/.github/workflows/_dogfood-add-to-project.yml
+++ b/.github/workflows/_dogfood-add-to-project.yml
@@ -8,8 +8,4 @@ permissions:
   contents: read
 jobs:
   add-to-project:
-    # Secrets cannot be used in `if`; set PROJECT_URL when you want this enabled.
-    if: vars.PROJECT_URL != ''
     uses: jmmaloney4/toolbox/.github/workflows/add-to-project.yml@bc7846003f39ec61654d70f5cfd1413046b3b763 # main
-    with:
-      project_url: ${{ vars.PROJECT_URL }}


### PR DESCRIPTION
Remove the PROJECT_URL env var and use the default project URL from the callee workflow instead.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk workflow change that only affects GitHub Actions configuration. It removes conditional execution and explicit `project_url` input, so behavior now depends on the called reusable workflow’s defaults.
> 
> **Overview**
> Simplifies `.github/workflows/_dogfood-add-to-project.yml` by **removing the `vars.PROJECT_URL` conditional and the `project_url` input**, so the reusable `add-to-project.yml` workflow always runs and uses its own default project configuration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e693105376adb6f266a4a94f9bd9bb202e84278c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->