### PR TITLE
Clarify ci-pulumi shell contract

### DIFF
--- a/.github/workflows/pulumi.yml
+++ b/.github/workflows/pulumi.yml
@@ -96,31 +96,69 @@ jobs:
         with:
           repository: ${{ inputs.repository }}
           ref: ${{ inputs.ref }}
-      - name: Validate nodejs_package_manager input
-        shell: bash
-        run: |
-          case "${{ inputs.nodejs_package_manager }}" in
-            pnpm|npm|none)
-              echo "✓ Valid package manager: ${{ inputs.nodejs_package_manager }}"
-              ;;
-            *)
-              echo "❌ Error: Invalid nodejs_package_manager value '${{ inputs.nodejs_package_manager }}'"
-              echo "   Must be one of: pnpm, npm, none"
-              exit 1
-              ;;
-          esac
       - uses: jmmaloney4/toolbox/.github/actions/pulumi-setup@bc7846003f39ec61654d70f5cfd1413046b3b763 # main
         with:
           google_workload_identity_provider: ${{ inputs.google_workload_identity_provider }}
           google_service_account_email: ${{ inputs.google_service_account_email }}
           nodejs_package_manager: ${{ inputs.nodejs_package_manager }}
-          # Auth & registry for GitHub Packages (public or private still needs a token)
+      - name: Validate .#ci-pulumi shell
+        shell: bash
+        env:
+          NODEJS_PACKAGE_MANAGER: ${{ inputs.nodejs_package_manager }}
+        run: |
+          set -euo pipefail
+          case "$NODEJS_PACKAGE_MANAGER" in
+            pnpm|npm|none) ;;
+            *)
+              echo "❌ Error: Invalid nodejs_package_manager value '$NODEJS_PACKAGE_MANAGER'"
+              echo "   Must be one of: pnpm, npm, none"
+              exit 1
+              ;;
+          esac
+
+          export DEVSHELL_NO_MOTD=1
+          export DEVSHELL_NO_GREETING=1
+          export DEVSHELL_QUIET=1
+
+          # Variables in this script are expanded by the inner bash run inside nix develop.
+          # shellcheck disable=SC2016
+          nix develop .#ci-pulumi --command bash -euo pipefail -c '
+            missing=0
+            require_tool() {
+              local tool="$1"
+              if ! command -v "$tool" >/dev/null 2>&1; then
+                echo "::error title=Missing tool in .#ci-pulumi::$tool is not available in the caller repository .#ci-pulumi shell" >&2
+                missing=1
+              fi
+            }
+
+            require_tool pulumi
+            require_tool jq
+
+            case "$NODEJS_PACKAGE_MANAGER" in
+              pnpm|npm) require_tool "$NODEJS_PACKAGE_MANAGER" ;;
+              none) ;;
+            esac
+
+            if [[ "$missing" -ne 0 ]]; then
+              echo "" >&2
+              echo "The reusable Pulumi workflow runs commands in the caller repository with:" >&2
+              echo "  nix develop .#ci-pulumi --command ..." >&2
+              echo "" >&2
+              echo "Update the caller repository flake so .#ci-pulumi includes Pulumi workflow tools." >&2
+              echo "For nodejs_package_manager=$NODEJS_PACKAGE_MANAGER, .#ci-pulumi must include $NODEJS_PACKAGE_MANAGER." >&2
+              exit 1
+            fi
+          '
+      # Auth & registry for GitHub Packages (public or private still needs a token)
       - name: Configure .npmrc for GitHub Packages
         if: ${{ inputs.nodejs_package_manager != 'none' }}
         run: |
-          echo "@jmmaloney4:registry=https://npm.pkg.github.com" >> ~/.npmrc
-          echo "//npm.pkg.github.com/:_authToken=${{ secrets.GITHUB_TOKEN }}" >> ~/.npmrc
-          echo "always-auth=true" >> ~/.npmrc
+          {
+            echo "@jmmaloney4:registry=https://npm.pkg.github.com"
+            echo "//npm.pkg.github.com/:_authToken=${{ secrets.GITHUB_TOKEN }}"
+            echo "always-auth=true"
+          } >> ~/.npmrc
       - name: Install pnpm dependencies
         if: ${{ inputs.nodejs_package_manager == 'pnpm' }}
         run: nix develop .#ci-pulumi --command pnpm install --frozen-lockfile

--- a/.github/workflows/pulumi.yml
+++ b/.github/workflows/pulumi.yml
@@ -96,31 +96,73 @@ jobs:
         with:
           repository: ${{ inputs.repository }}
           ref: ${{ inputs.ref }}
-      - name: Validate nodejs_package_manager input
-        shell: bash
-        run: |
-          case "${{ inputs.nodejs_package_manager }}" in
-            pnpm|npm|none)
-              echo "✓ Valid package manager: ${{ inputs.nodejs_package_manager }}"
-              ;;
-            *)
-              echo "❌ Error: Invalid nodejs_package_manager value '${{ inputs.nodejs_package_manager }}'"
-              echo "   Must be one of: pnpm, npm, none"
-              exit 1
-              ;;
-          esac
-      - uses: jmmaloney4/sector7/.github/actions/pulumi-setup@61fa58a027d96afc7c5c9a2953ab54dd3bb42ad4 # main
+      - uses: jmmaloney4/toolbox/.github/actions/pulumi-setup@bc7846003f39ec61654d70f5cfd1413046b3b763 # main
         with:
           google_workload_identity_provider: ${{ inputs.google_workload_identity_provider }}
           google_service_account_email: ${{ inputs.google_service_account_email }}
           nodejs_package_manager: ${{ inputs.nodejs_package_manager }}
-          # Auth & registry for GitHub Packages (public or private still needs a token)
+      - name: Validate .#ci-pulumi shell
+        shell: bash
+        env:
+          NODEJS_PACKAGE_MANAGER: ${{ inputs.nodejs_package_manager }}
+        run: |
+          set -euo pipefail
+          case "$NODEJS_PACKAGE_MANAGER" in
+            pnpm|npm|none) ;;
+            *)
+              echo "❌ Error: Invalid nodejs_package_manager value '$NODEJS_PACKAGE_MANAGER'"
+              echo "   Must be one of: pnpm, npm, none"
+              exit 1
+              ;;
+          esac
+
+          export DEVSHELL_NO_MOTD=1
+          export DEVSHELL_NO_GREETING=1
+          export DEVSHELL_QUIET=1
+
+          # Variables in this script are expanded by the inner bash run inside nix develop.
+          # shellcheck disable=SC2016
+          nix develop .#ci-pulumi --command bash -euo pipefail -c '
+            missing=0
+            require_tool() {
+              local tool="$1"
+              if ! command -v "$tool" >/dev/null 2>&1; then
+                echo "::error title=Missing tool in .#ci-pulumi::$tool is not available in the caller repository .#ci-pulumi shell" >&2
+                missing=1
+              fi
+            }
+
+            require_tool pulumi
+            require_tool jq
+
+            case "$NODEJS_PACKAGE_MANAGER" in
+              pnpm|npm) require_tool "$NODEJS_PACKAGE_MANAGER" ;;
+              none) ;;
+            esac
+
+            if [[ "$missing" -ne 0 ]]; then
+              required_tools="pulumi, jq"
+              case "$NODEJS_PACKAGE_MANAGER" in
+                pnpm|npm) required_tools="$required_tools, $NODEJS_PACKAGE_MANAGER" ;;
+              esac
+
+              echo "" >&2
+              echo "The reusable Pulumi workflow runs commands in the caller repository with:" >&2
+              echo "  nix develop .#ci-pulumi --command ..." >&2
+              echo "" >&2
+              echo "Update the caller repository flake so .#ci-pulumi includes: $required_tools." >&2
+              exit 1
+            fi
+          '
+      # Auth & registry for GitHub Packages (public or private still needs a token)
       - name: Configure .npmrc for GitHub Packages
         if: ${{ inputs.nodejs_package_manager != 'none' }}
         run: |
-          echo "@jmmaloney4:registry=https://npm.pkg.github.com" >> ~/.npmrc
-          echo "//npm.pkg.github.com/:_authToken=${{ secrets.GITHUB_TOKEN }}" >> ~/.npmrc
-          echo "always-auth=true" >> ~/.npmrc
+          {
+            echo "@jmmaloney4:registry=https://npm.pkg.github.com"
+            echo "//npm.pkg.github.com/:_authToken=${{ secrets.GITHUB_TOKEN }}"
+            echo "always-auth=true"
+          } >> ~/.npmrc
       - name: Install pnpm dependencies
         if: ${{ inputs.nodejs_package_manager == 'pnpm' }}
         run: nix develop .#ci-pulumi --command pnpm install --frozen-lockfile

--- a/docs/public/pulumi.md
+++ b/docs/public/pulumi.md
@@ -93,6 +93,7 @@ Notes:
 
 - If you set `limitToRef` when creating the provider (e.g., `refs/heads/main`), authentication will only work for that ref. Ensure it matches the refs where you expect this workflow to run.
 - The reusable workflow checks out the caller repo/ref you pass via `repository`/`ref`, so the Pulumi projects and `flake.lock` referenced by the workflow should live in the caller repository.
+- The workflow runs Pulumi commands with `nix develop .#ci-pulumi --command ...` in the caller repository. Define a `ci-pulumi` dev shell that includes `pulumi`, `jq`, and the selected `nodejs_package_manager` (`pnpm` or `npm`; no package manager is required for `none`).
 - The workflow requires the three inputs shown above; variables/secrets are not implicitly inherited, so pass them explicitly as inputs as shown.
 
 #### Configuration

--- a/docs/public/pulumi.md
+++ b/docs/public/pulumi.md
@@ -93,7 +93,7 @@ Notes:
 
 - If you set `limitToRef` when creating the provider (e.g., `refs/heads/main`), authentication will only work for that ref. Ensure it matches the refs where you expect this workflow to run.
 - The reusable workflow checks out the caller repo/ref you pass via `repository`/`ref`, so the Pulumi projects and `flake.lock` referenced by the workflow should live in the caller repository.
-- The workflow runs Pulumi commands with `nix develop .#ci-pulumi --command ...` in the caller repository. Define a `ci-pulumi` dev shell that includes `pulumi`, `jq`, and the selected `nodejs_package_manager` (`pnpm` or `npm`; no package manager is required for `none`).
+- The workflow requires a `ci-pulumi` dev shell in the caller repository. That shell must provide `pulumi`, `jq`, and the selected `nodejs_package_manager` (`pnpm` or `npm`; no package manager is required for `none`).
 - The workflow requires the three inputs shown above; variables/secrets are not implicitly inherited, so pass them explicitly as inputs as shown.
 
 #### Configuration

--- a/docs/public/pulumi.md
+++ b/docs/public/pulumi.md
@@ -94,7 +94,7 @@ Notes:
 - If you set `limitToRef` when creating the provider (e.g., `refs/heads/main`), authentication will only work for that ref. Ensure it matches the refs where you expect this workflow to run.
 - The reusable workflow checks out the caller repo/ref you pass via `repository`/`ref`, so the Pulumi projects and `flake.lock` referenced by the workflow should live in the caller repository.
 - The workflow requires a `ci-pulumi` dev shell in the caller repository. That shell must provide `pulumi`, `jq`, and the selected `nodejs_package_manager` (`pnpm` or `npm`; no package manager is required for `none`).
-- The workflow requires the three inputs shown above; variables/secrets are not implicitly inherited, so pass them explicitly as inputs as shown.
+- The workflow requires the inputs shown above; variables/secrets are not implicitly inherited, so pass them explicitly as inputs as shown.
 
 #### Configuration
 

--- a/docs/public/workflows.md
+++ b/docs/public/workflows.md
@@ -187,6 +187,8 @@ jobs:
   - `"npm"`: Use npm
   - `"none"`: Skip dependency installation (for non-Node.js Pulumi projects)
 
+**Caller flake contract:** The workflow checks out the caller repository and runs Pulumi commands with `nix develop .#ci-pulumi --command ...`. The caller repository must define a `ci-pulumi` dev shell that includes `pulumi`, `jq`, and the selected Node.js package manager (`pnpm` or `npm`). When `nodejs_package_manager` is `"none"`, no Node.js package manager is required.
+
 **Note**: Ensure each Pulumi stack defines `gcp:project` in its stack configuration to specify the target GCP project.
 
 ### 🤖 `claude.yml`

--- a/docs/public/workflows.md
+++ b/docs/public/workflows.md
@@ -187,7 +187,7 @@ jobs:
   - `"npm"`: Use npm
   - `"none"`: Skip dependency installation (for non-Node.js Pulumi projects)
 
-**Caller flake contract:** The workflow checks out the caller repository and runs Pulumi commands with `nix develop .#ci-pulumi --command ...`. The caller repository must define a `ci-pulumi` dev shell that includes `pulumi`, `jq`, and the selected Node.js package manager (`pnpm` or `npm`). When `nodejs_package_manager` is `"none"`, no Node.js package manager is required.
+**Caller flake contract:** The workflow requires a `ci-pulumi` dev shell in the caller repository. That shell must provide `pulumi`, `jq`, and the selected Node.js package manager (`pnpm` or `npm`). When `nodejs_package_manager` is `"none"`, no Node.js package manager is required.
 
 **Note**: Ensure each Pulumi stack defines `gcp:project` in its stack configuration to specify the target GCP project.
 

--- a/packages/sector7/README.md
+++ b/packages/sector7/README.md
@@ -93,6 +93,7 @@ Notes:
 
 - If you set `limitToRef` when creating the provider (e.g., `refs/heads/main`), authentication will only work for that ref. Ensure it matches the refs where you expect this workflow to run.
 - The reusable workflow checks out the caller repo/ref you pass via `repository`/`ref`, so the Pulumi projects and `flake.lock` referenced by the workflow should live in the caller repository.
+- The workflow runs Pulumi commands with `nix develop .#ci-pulumi --command ...` in the caller repository. Define a `ci-pulumi` dev shell that includes `pulumi`, `jq`, and the selected `nodejs_package_manager` (`pnpm` or `npm`; no package manager is required for `none`).
 - The workflow requires the three inputs shown above; variables/secrets are not implicitly inherited, so pass them explicitly as inputs as shown.
 
 #### Configuration

--- a/packages/sector7/README.md
+++ b/packages/sector7/README.md
@@ -93,7 +93,7 @@ Notes:
 
 - If you set `limitToRef` when creating the provider (e.g., `refs/heads/main`), authentication will only work for that ref. Ensure it matches the refs where you expect this workflow to run.
 - The reusable workflow checks out the caller repo/ref you pass via `repository`/`ref`, so the Pulumi projects and `flake.lock` referenced by the workflow should live in the caller repository.
-- The workflow runs Pulumi commands with `nix develop .#ci-pulumi --command ...` in the caller repository. Define a `ci-pulumi` dev shell that includes `pulumi`, `jq`, and the selected `nodejs_package_manager` (`pnpm` or `npm`; no package manager is required for `none`).
+- The workflow requires a `ci-pulumi` dev shell in the caller repository. That shell must provide `pulumi`, `jq`, and the selected `nodejs_package_manager` (`pnpm` or `npm`; no package manager is required for `none`).
 - The workflow requires the three inputs shown above; variables/secrets are not implicitly inherited, so pass them explicitly as inputs as shown.
 
 #### Configuration

--- a/packages/sector7/README.md
+++ b/packages/sector7/README.md
@@ -94,7 +94,7 @@ Notes:
 - If you set `limitToRef` when creating the provider (e.g., `refs/heads/main`), authentication will only work for that ref. Ensure it matches the refs where you expect this workflow to run.
 - The reusable workflow checks out the caller repo/ref you pass via `repository`/`ref`, so the Pulumi projects and `flake.lock` referenced by the workflow should live in the caller repository.
 - The workflow requires a `ci-pulumi` dev shell in the caller repository. That shell must provide `pulumi`, `jq`, and the selected `nodejs_package_manager` (`pnpm` or `npm`; no package manager is required for `none`).
-- The workflow requires the three inputs shown above; variables/secrets are not implicitly inherited, so pass them explicitly as inputs as shown.
+- The workflow requires the inputs shown above; variables/secrets are not implicitly inherited, so pass them explicitly as inputs as shown.
 
 #### Configuration
 


### PR DESCRIPTION
## Summary

- make the Pulumi reusable workflow validate the caller repo's `.#ci-pulumi` shell before dependency install/preview steps
- fail with an explicit message when `pulumi`, `jq`, or the selected Node package manager is missing
- document the caller flake contract in the public workflow/Pulumi docs

## Validation

- `git diff --check`
- `nix shell nixpkgs#actionlint -c actionlint .github/workflows/pulumi.yml`

Refs #158

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Modifies the reusable Pulumi GitHub Actions workflow execution path by adding preflight validation and swapping the setup action, which could fail existing consumers if their Nix dev shell is missing required tools or behaves differently.
> 
> **Overview**
> Tightens the reusable `pulumi.yml` workflow by adding an early validation step that runs `nix develop .#ci-pulumi` and fails fast with explicit GitHub errors if `pulumi`, `jq`, or the selected Node package manager (`pnpm`/`npm`) is missing, and by hardening the package-manager input check.
> 
> Updates the workflow to use `jmmaloney4/toolbox`’s `pulumi-setup` action and tweaks `.npmrc` configuration, and documents the **caller flake contract** in the public Pulumi/workflows docs and package README.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a642cf74ffc49f8be97bcdc302729f91451db85d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->