### PR TITLE
feat(sector7): move R2 uploads to sibling module

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ Barrel files (`index.ts` with re-exports) are fine for internal cohesion but req
    Write `export { WorkerSite, type WorkerSiteArgs } from "./worker-site.ts"` instead of `export * from "./worker-site.ts"`. This forces you to acknowledge every symbol you expose and makes it trivial to grep for "what public surface depends on X".
 
 2. **Group by dependency boundary, not by file system layout.**
-   If a module carries a heavy or optional dependency (e.g. `@aws-sdk/client-s3`), put it behind a separate sub-path export (`package.json` `exports["./workersite/r2"]`) rather than mixing it into the main barrel. The barrel should reflect the dependency graph.
+   If a module carries a heavy or optional dependency (e.g. R2 object upload dynamic-provider code), put it behind a separate sub-path export (`package.json` `exports["./r2"]`) rather than mixing it into the main barrel. The barrel should reflect the dependency graph.
 
 3. **Every re-export is a commitment.**
    If you put something in the barrel, you are signing up for keeping its transitive type closure clean for all consumers. Optional peer deps, platform-specific types, or heavy type-only deps that not every consumer needs do not belong in the main barrel.

--- a/docs/internal/designs/013-workersite-esm-resources-fix.md
+++ b/docs/internal/designs/013-workersite-esm-resources-fix.md
@@ -22,6 +22,7 @@ The `WorkerSite` component (ADR-005, extended by ADR-011) generates a Cloudflare
 2. **AccountToken `resources` key format**: The Cloudflare API resource identifier for R2 buckets always uses `default` as the location segment (`com.cloudflare.edge.r2.bucket.{accountId}_default_{bucketName}`), regardless of the bucket's actual storage location (e.g. `ENAM`). Using the actual location produces the error `R2 Buckets are invalid`.
 
 The hand-rolled `cavinsresearch.io` code avoided both issues by:
+
 - Using esbuild (`--format=esm`) to compile a `.ts` worker file, piping stdout to `workerBuild.stdout` as script content. The compiled output presumably signaled ESM correctly.
 - Hardcoding `_default_` as the location segment in the resources key.
 

--- a/docs/internal/designs/014-decouple-r2-from-workersite.md
+++ b/docs/internal/designs/014-decouple-r2-from-workersite.md
@@ -1,15 +1,206 @@
 ---
 id: ADR-014
-title: "Decouple R2 From Workersite"
+title: "Decouple R2 From WorkerSite"
 status: proposed
 date: 2026-04-24
 ---
 
-# ADR 014: Decouple R2 From Workersite
+# ADR 014: Decouple R2 From WorkerSite
+
 *Date:* 2026-04-24
 *Status:* proposed
 
-**Related PR:** https://github.com/jmmaloney4/toolbox/pull/156
+**Related PRs:**
 
-This ADR is currently being developed in linked pull request above.
-Please refer to that PR for current content and discussion.
+- Initial implementation: https://github.com/jmmaloney4/toolbox/pull/160
+- Superseded draft: https://github.com/jmmaloney4/toolbox/pull/156
+
+## Context
+
+`WorkerSite` provisions the Cloudflare infrastructure needed to serve a static
+site: the Worker script, custom domains, optional Access applications, and the
+R2 bucket binding used by the Worker. Earlier ADR-014 work also added R2 object
+uploads through `WorkerSiteArgs.assets`.
+
+That shape made simple consumers convenient, but it coupled every
+`@jmmaloney4/sector7/workersite` consumer to the R2 upload implementation. The
+upload path is materially different from the infrastructure path:
+
+- it creates a scoped Cloudflare `AccountToken` for R2 object writes;
+- it uses Pulumi dynamic resources for object upload lifecycle management;
+- it carries additional implementation and type dependencies that static-site
+  infrastructure consumers should not inherit unless they opt in; and
+- it has a separate operational failure mode from the Worker, domain, and Access
+  resources.
+
+PR #160 removed `assets` from `WorkerSiteArgs` and introduced an explicit
+`uploadAssets()` API on `@jmmaloney4/sector7/workersite/r2`. That solved the
+main transitive dependency problem, but the public import path still describes
+R2 uploads as a `workersite` subfeature. This is misleading: R2 upload helpers
+should be reusable R2 primitives that can be used with `WorkerSite`, but are not
+owned by it.
+
+## Decision
+
+Keep `WorkerSite` infrastructure-only and move R2 upload APIs to a sibling
+sector7 submodule:
+
+```ts
+import { WorkerSite } from "@jmmaloney4/sector7/workersite";
+import { uploadAssets, uploadStaticAssets } from "@jmmaloney4/sector7/r2";
+```
+
+The `workersite` module remains responsible for serving infrastructure:
+
+- Worker script generation;
+- R2 bucket creation or binding;
+- custom domain bindings;
+- optional Cloudflare Access applications and identity provider wiring; and
+- cache, redirect, and observability configuration.
+
+The `r2` module owns upload concerns:
+
+- scoped R2 write token creation;
+- dynamic resources for object upload/update/delete;
+- low-level asset upload APIs; and
+- static-site upload convenience helpers.
+
+`@jmmaloney4/sector7/workersite` must not re-export R2 upload symbols. Barrel
+or package-export guards should enforce that boundary so future changes do not
+accidentally pull R2 upload types back into the main WorkerSite import surface.
+
+## API Shape
+
+Retain the low-level upload API for callers that already have fully specified
+object inputs:
+
+```ts
+uploadAssets("site-assets", {
+  accountId,
+  bucketName,
+  files: [
+    {
+      key: "index.html",
+      filePath: "/absolute/path/to/index.html",
+      contentType: "text/html; charset=utf-8",
+    },
+  ],
+  dependsOn: [site.worker],
+}, { parent: site });
+```
+
+Add a convenience helper for the common static-site pattern where object keys
+map directly to files under a base directory:
+
+```ts
+uploadStaticAssets("site-assets", {
+  accountId,
+  bucketName,
+  basePath: staticSitePath,
+  files: [
+    { key: "index.html", contentType: "text/html; charset=utf-8" },
+    { key: "styles.css", contentType: "text/css; charset=utf-8" },
+    { key: "favicon.svg", contentType: "image/svg+xml" },
+    { key: "robots.txt", contentType: "text/plain; charset=utf-8" },
+  ],
+  dependsOn: [site.worker],
+}, { parent: site });
+```
+
+Do not add `site.uploadAssets()` to the `WorkerSite` class. An instance method
+would make upload behavior part of the WorkerSite abstraction again, which is
+the dependency boundary this ADR is trying to preserve.
+
+The R2 helpers may be ergonomic, but they should remain explicit: consumers pass
+`accountId`, `bucketName`, file descriptions, dependencies, and Pulumi resource
+options. When a caller uses a `WorkerSite`, it can pass `site.bucket!.name` and
+`{ parent: site }`, but the R2 module should not require `WorkerSite` as its
+primary abstraction.
+
+## Alternatives Considered
+
+### 1. Keep uploads on `WorkerSiteArgs.assets`
+
+This was the original convenient API.
+
+Pros:
+
+- Minimal consumer boilerplate.
+- Single component owns site infrastructure and content upload.
+
+Cons:
+
+- Pulls upload dependencies into all WorkerSite consumers.
+- Makes static infrastructure and object upload lifecycle failures inseparable.
+- Makes the main `workersite` import surface responsible for R2 dynamic resource
+  types.
+
+Rejected because dependency boundaries matter more than saving a few lines at
+the call site.
+
+### 2. Keep the explicit API at `@jmmaloney4/sector7/workersite/r2`
+
+This was the first decoupled shape from PR #160.
+
+Pros:
+
+- Avoids exporting R2 upload symbols from the main `workersite` barrel.
+- Makes callers opt in to upload behavior.
+- Small migration from the removed `assets` block.
+
+Cons:
+
+- The import path still implies R2 upload is a WorkerSite submodule.
+- R2 upload primitives are less discoverable as reusable R2 utilities.
+- Consumers may reasonably ask why a supposedly decoupled R2 module lives under
+  `workersite`.
+
+Rejected as an intermediate shape. It solves the type dependency problem but
+not the conceptual boundary problem.
+
+### 3. Move R2 uploads to `@jmmaloney4/sector7/r2`
+
+Pros:
+
+- Aligns package layout with the intended dependency graph.
+- Keeps `WorkerSite` infrastructure-only.
+- Makes R2 uploads reusable outside WorkerSite.
+- Leaves the explicit opt-in import in place.
+
+Cons:
+
+- Requires one more consumer migration from the intermediate `workersite/r2`
+  path.
+- Requires package export and barrel-guard updates.
+
+Accepted.
+
+## Consequences
+
+- Consumers using static asset uploads must import the R2 module explicitly.
+- `WorkerSiteArgs` should not grow a replacement `assets` field.
+- `@jmmaloney4/sector7/workersite/r2` should be removed before broad adoption,
+  or kept only as a short compatibility shim if a release already exposed it.
+  Prefer removal for now so stale consumers fail loudly and migrate to the
+  correct boundary.
+- The package should expose a sibling subpath export for `./r2`.
+- Type-check guards should ensure R2 upload symbols are not exported from
+  `./workersite`.
+- Existing consumers such as `cavinsresearch/zeus` and `addendalabs/yard` should
+  migrate directly from `WorkerSiteArgs.assets` to `@jmmaloney4/sector7/r2`, not
+  to the intermediate `@jmmaloney4/sector7/workersite/r2` path.
+
+## Implementation Notes
+
+The follow-up implementation should:
+
+1. Move the R2 upload source files from `packages/sector7/workersite/` to a
+   sibling `packages/sector7/r2/` module, or otherwise expose them from that
+   public subpath without re-exporting them through `workersite`.
+2. Add `package.json` exports for `@jmmaloney4/sector7/r2`.
+3. Remove or avoid the `@jmmaloney4/sector7/workersite/r2` export.
+4. Add or update barrel guards so the main `workersite` barrel cannot re-export
+   `uploadAssets`, `uploadStaticAssets`, `R2Object`, or related R2 upload types.
+5. Add `uploadStaticAssets()` as the common static-site helper on the R2 module.
+6. Migrate known consumers (`cavinsresearch/zeus`, `addendalabs/yard`) to the
+   sibling `@jmmaloney4/sector7/r2` import path.

--- a/docs/internal/designs/014-decouple-r2-from-workersite.md
+++ b/docs/internal/designs/014-decouple-r2-from-workersite.md
@@ -1,6 +1,6 @@
 ---
 id: ADR-014
-title: "Decouple R2 From WorkerSite"
+title: Decouple R2 From WorkerSite
 status: proposed
 date: 2026-04-24
 ---

--- a/docs/internal/designs/015-replace-aws-sdk-with-native-s3-signing.md
+++ b/docs/internal/designs/015-replace-aws-sdk-with-native-s3-signing.md
@@ -1,11 +1,12 @@
 ---
 id: ADR-015
-title: "Replace Aws Sdk With Native S3 Signing"
+title: Replace Aws Sdk With Native S3 Signing
 status: proposed
 date: 2026-04-24
 ---
 
 # ADR 015: Replace Aws Sdk With Native S3 Signing
+
 *Date:* 2026-04-24
 *Status:* proposed
 

--- a/docs/internal/plans/2026-04-24-decouple-r2-from-workersite.md
+++ b/docs/internal/plans/2026-04-24-decouple-r2-from-workersite.md
@@ -50,6 +50,7 @@ infrastructure and stays in WorkerSite.
    ```
 
    Key locations:
+
    - Line 4: `import { R2Object } from "./r2object.ts"`
    - `WorkerSiteArgs.assets` property (the `AssetConfig` input)
    - Line 434: `public readonly uploadedAssets: R2Object[]`
@@ -149,6 +150,7 @@ infrastructure and stays in WorkerSite.
    ```
 
    Confirm:
+
    - `worker-site.ts` has zero references to `R2Object`
    - `r2object.ts` uses static imports, no `typeof import()` casts
    - Main barrel does not re-export anything from r2 sub-path
@@ -180,6 +182,7 @@ Theoretical Edge and other consumers in `garden` currently pass `assets` to
    instantiations.
 
 2. For each consumer:
+
    - Remove `assets` from `WorkerSiteArgs`
    - Add `import { uploadAssets } from "@jmmaloney4/sector7/workersite/r2"`
    - After WorkerSite creation, call:

--- a/flake.nix
+++ b/flake.nix
@@ -39,7 +39,7 @@
       jackpkgs.projectRoot = ./.;
       jackpkgs.nodejs = {
         enable = true;
-        pnpmDepsHash = "sha256-tp/rj623gUcbBuDtBhEEsTkNAl7SjSkeeMRd068A2is=";
+        pnpmDepsHash = "sha256-9LFcramMzlGSmxVIgy0xkXKhLRCY70wGDFUps87nKUQ=";
         projectRoot = ./.;
       };
       jackpkgs.checks.typescript.tsc.enable = true;

--- a/packages/sector7/package.json
+++ b/packages/sector7/package.json
@@ -23,15 +23,16 @@
 			"types": "./workersite/index.ts",
 			"default": "./workersite/index.ts"
 		},
-		"./workersite/r2": {
-			"types": "./workersite/r2.ts",
-			"default": "./workersite/r2.ts"
+		"./r2": {
+			"types": "./r2/index.ts",
+			"default": "./r2/index.ts"
 		}
 	},
 	"files": [
 		"index.ts",
 		"iam",
-		"workersite"
+		"workersite",
+		"r2"
 	],
 	"scripts": {
 		"test": "vitest run",

--- a/packages/sector7/r2/index.ts
+++ b/packages/sector7/r2/index.ts
@@ -1,0 +1,11 @@
+export {
+	type AssetConfig,
+	type AssetFile,
+	R2Object,
+	type R2ObjectInputs,
+	type StaticAssetFile,
+	type UploadAssetsArgs,
+	type UploadStaticAssetsArgs,
+	uploadAssets,
+	uploadStaticAssets,
+} from "./r2object.ts";

--- a/packages/sector7/r2/r2object.ts
+++ b/packages/sector7/r2/r2object.ts
@@ -1,3 +1,4 @@
+import * as crypto from "node:crypto";
 import * as cloudflare from "@pulumi/cloudflare";
 import * as pulumi from "@pulumi/pulumi";
 import {
@@ -630,12 +631,17 @@ export function uploadAssets(
 	const assets: R2Object[] = [];
 	for (let index = 0; index < args.files.length; index++) {
 		const file = args.files[index];
-		// Include index to guarantee unique resource names even when keys
-		// differ only in chars that sanitize identically (e.g.
-		// "assets/main.css" vs "assets-main.css").
+		// Use a short SHA-256 hash of the key as the resource identifier.
+		// This is stable across reorders (unlike array index) and unique
+		// in practice for any realistic number of assets.
+		const keyHash = crypto
+			.createHash("sha256")
+			.update(file.key)
+			.digest("hex")
+			.slice(0, 12);
 		const safeKey = file.key.replace(/[^a-zA-Z0-9-_]/g, "-").slice(0, 64);
 		const r2obj = new R2Object(
-			`${name}-asset-${index}-${safeKey}`,
+			`${name}-asset-${keyHash}-${safeKey}`,
 			{
 				accountId: args.accountId,
 				bucketName: args.bucketName,
@@ -656,11 +662,10 @@ export function uploadAssets(
 }
 
 const joinStaticAssetPath = (basePath: string, fileName: string): string => {
+	if (!basePath || basePath === "/") return fileName.replace(/^[\\/]+/, "");
 	const normalizedBasePath = basePath.replace(/[\\/]+$/, "");
 	const normalizedFileName = fileName.replace(/^[\\/]+/, "");
-	return normalizedBasePath
-		? `${normalizedBasePath}/${normalizedFileName}`
-		: normalizedFileName;
+	return `${normalizedBasePath}/${normalizedFileName}`;
 };
 
 /**

--- a/packages/sector7/r2/r2object.ts
+++ b/packages/sector7/r2/r2object.ts
@@ -632,7 +632,7 @@ export function uploadAssets(
 		const file = args.files[index];
 		const safeKey = file.key.replace(/[^a-zA-Z0-9-_]/g, "-");
 		const r2obj = new R2Object(
-			`${name}-asset-${index}-${safeKey}`,
+			`${name}-asset-${safeKey}`,
 			{
 				accountId: args.accountId,
 				bucketName: args.bucketName,

--- a/packages/sector7/r2/r2object.ts
+++ b/packages/sector7/r2/r2object.ts
@@ -176,6 +176,26 @@ export interface AssetFile {
 }
 
 /**
+ * Static-site file descriptor for `uploadStaticAssets`.
+ */
+export interface StaticAssetFile {
+	/**
+	 * R2 object key and, by default, the path below `basePath`.
+	 */
+	key: string;
+
+	/**
+	 * Optional path below `basePath` when it differs from `key`.
+	 */
+	fileName?: string;
+
+	/**
+	 * MIME content type (e.g. "text/html; charset=utf-8").
+	 */
+	contentType: Input<string>;
+}
+
+/**
  * Configuration for declarative R2 asset uploads.
  *
  * When provided, `uploadAssets` creates a scoped R2 API token and uploads each
@@ -233,6 +253,22 @@ export interface UploadAssetsArgs {
 	bucketName: Input<string>;
 	/** Files to upload. */
 	files: AssetFile[];
+	/** Resource dependencies (e.g. the Worker and bucket). */
+	dependsOn?: Input<Input<Resource>[]>;
+}
+
+/**
+ * Arguments for `uploadStaticAssets`.
+ */
+export interface UploadStaticAssetsArgs {
+	/** Cloudflare account ID. */
+	accountId: Input<string>;
+	/** Name of the R2 bucket to upload to. */
+	bucketName: Input<string>;
+	/** Directory containing the static-site files. */
+	basePath: string;
+	/** Files to upload from `basePath`. */
+	files: StaticAssetFile[];
 	/** Resource dependencies (e.g. the Worker and bucket). */
 	dependsOn?: Input<Input<Resource>[]>;
 }
@@ -296,8 +332,9 @@ const tryReadFileSync = (
 // AWS Sig V4 requires for path segments but encodeURIComponent skips.
 // These characters are: ! ' ( ) *
 const rfc3986Encode = (s: string): string =>
-	encodeURIComponent(s).replace(/[!'()*]/g, (c) =>
-		`%${c.charCodeAt(0).toString(16).toUpperCase()}`,
+	encodeURIComponent(s).replace(
+		/[!'()*]/g,
+		(c) => `%${c.charCodeAt(0).toString(16).toUpperCase()}`,
 	);
 
 /** Upload a file to R2 and return the normalized ETag. */
@@ -510,10 +547,10 @@ const R2_BUCKET_ITEM_WRITE_PERMISSION_GROUP_ID =
  * `R2Object` dynamic resource with MD5-based change detection.
  * Returns the created `R2Object` instances.
  *
- * This function lives on the `./workersite/r2` sub-path to isolate the
- * R2 upload concern from consumers that only need `WorkerSite`
- * infrastructure (ADR-014).  No external dependencies are required —
- * S3 signing is implemented natively via node:crypto + fetch (ADR-015).
+ * This function lives on the `./r2` sub-path to isolate the R2 upload concern
+ * from consumers that only need `WorkerSite` infrastructure (ADR-014).  No
+ * external dependencies are required — S3 signing is implemented natively via
+ * node:crypto + fetch (ADR-015).
  *
  * @param name - Pulumi resource name prefix.
  * @param args - Upload configuration (account, bucket, files).
@@ -587,7 +624,8 @@ export function uploadAssets(
 	});
 
 	const assets: R2Object[] = [];
-	for (const [index, file] of args.files.entries()) {
+	for (let index = 0; index < args.files.length; index++) {
+		const file = args.files[index];
 		const safeKey = file.key.replace(/[^a-zA-Z0-9-_]/g, "-");
 		const r2obj = new R2Object(
 			`${name}-asset-${index}-${safeKey}`,
@@ -608,4 +646,37 @@ export function uploadAssets(
 	}
 
 	return assets;
+}
+
+const joinStaticAssetPath = (basePath: string, fileName: string): string => {
+	const normalizedBasePath = basePath.replace(/[\\/]+$/, "");
+	const normalizedFileName = fileName.replace(/^[\\/]+/, "");
+	return `${normalizedBasePath}/${normalizedFileName}`;
+};
+
+/**
+ * Upload static-site assets from a common base directory.
+ *
+ * This is a convenience wrapper around `uploadAssets` for the common case where
+ * R2 object keys map directly to files below a site output directory.
+ */
+export function uploadStaticAssets(
+	name: string,
+	args: UploadStaticAssetsArgs,
+	opts?: ComponentResourceOptions,
+): R2Object[] {
+	return uploadAssets(
+		name,
+		{
+			accountId: args.accountId,
+			bucketName: args.bucketName,
+			files: args.files.map((file) => ({
+				key: file.key,
+				filePath: joinStaticAssetPath(args.basePath, file.fileName ?? file.key),
+				contentType: file.contentType,
+			})),
+			dependsOn: args.dependsOn,
+		},
+		opts,
+	);
 }

--- a/packages/sector7/r2/r2object.ts
+++ b/packages/sector7/r2/r2object.ts
@@ -1,4 +1,5 @@
 import * as crypto from "node:crypto";
+import * as path from "node:path";
 import * as cloudflare from "@pulumi/cloudflare";
 import * as pulumi from "@pulumi/pulumi";
 import {
@@ -663,9 +664,7 @@ export function uploadAssets(
 
 const joinStaticAssetPath = (basePath: string, fileName: string): string => {
 	if (!basePath || basePath === "/") return fileName.replace(/^[\\/]+/, "");
-	const normalizedBasePath = basePath.replace(/[\\/]+$/, "");
-	const normalizedFileName = fileName.replace(/^[\\/]+/, "");
-	return `${normalizedBasePath}/${normalizedFileName}`;
+	return path.join(basePath, fileName);
 };
 
 /**

--- a/packages/sector7/r2/r2object.ts
+++ b/packages/sector7/r2/r2object.ts
@@ -633,7 +633,7 @@ export function uploadAssets(
 		// Include index to guarantee unique resource names even when keys
 		// differ only in chars that sanitize identically (e.g.
 		// "assets/main.css" vs "assets-main.css").
-		const safeKey = file.key.replace(/[^a-zA-Z0-9]/g, "").slice(0, 24);
+		const safeKey = file.key.replace(/[^a-zA-Z0-9-_]/g, "-").slice(0, 64);
 		const r2obj = new R2Object(
 			`${name}-asset-${index}-${safeKey}`,
 			{
@@ -658,7 +658,9 @@ export function uploadAssets(
 const joinStaticAssetPath = (basePath: string, fileName: string): string => {
 	const normalizedBasePath = basePath.replace(/[\\/]+$/, "");
 	const normalizedFileName = fileName.replace(/^[\\/]+/, "");
-	return `${normalizedBasePath}/${normalizedFileName}`;
+	return normalizedBasePath
+		? `${normalizedBasePath}/${normalizedFileName}`
+		: normalizedFileName;
 };
 
 /**

--- a/packages/sector7/r2/r2object.ts
+++ b/packages/sector7/r2/r2object.ts
@@ -630,9 +630,12 @@ export function uploadAssets(
 	const assets: R2Object[] = [];
 	for (let index = 0; index < args.files.length; index++) {
 		const file = args.files[index];
-		const safeKey = file.key.replace(/[^a-zA-Z0-9-_]/g, "-");
+		// Include index to guarantee unique resource names even when keys
+		// differ only in chars that sanitize identically (e.g.
+		// "assets/main.css" vs "assets-main.css").
+		const safeKey = file.key.replace(/[^a-zA-Z0-9]/g, "").slice(0, 24);
 		const r2obj = new R2Object(
-			`${name}-asset-${safeKey}`,
+			`${name}-asset-${index}-${safeKey}`,
 			{
 				accountId: args.accountId,
 				bucketName: args.bucketName,

--- a/packages/sector7/r2/r2object.ts
+++ b/packages/sector7/r2/r2object.ts
@@ -178,22 +178,26 @@ export interface AssetFile {
 /**
  * Static-site file descriptor for `uploadStaticAssets`.
  */
-export interface StaticAssetFile {
-	/**
-	 * R2 object key and, by default, the path below `basePath`.
-	 */
-	key: string;
-
-	/**
-	 * Optional path below `basePath` when it differs from `key`.
-	 */
-	fileName?: string;
-
-	/**
-	 * MIME content type (e.g. "text/html; charset=utf-8").
-	 */
-	contentType: Input<string>;
-}
+export type StaticAssetFile =
+	| {
+			/** R2 object key and, by default, the path below `basePath`. */
+			key: string;
+			/** Optional path below `basePath` when it differs from `key`. */
+			fileName?: string;
+			/** MIME content type (e.g. "text/html; charset=utf-8"). */
+			contentType: Input<string>;
+	  }
+	| {
+			/**
+			 * Existing static-site file name. Used as the R2 object key and, by
+			 * default, the path below `basePath`.
+			 */
+			name: string;
+			/** Optional path below `basePath` when it differs from `name`. */
+			fileName?: string;
+			/** MIME content type (e.g. "text/html; charset=utf-8"). */
+			contentType: Input<string>;
+	  };
 
 /**
  * Configuration for declarative R2 asset uploads.
@@ -670,11 +674,14 @@ export function uploadStaticAssets(
 		{
 			accountId: args.accountId,
 			bucketName: args.bucketName,
-			files: args.files.map((file) => ({
-				key: file.key,
-				filePath: joinStaticAssetPath(args.basePath, file.fileName ?? file.key),
-				contentType: file.contentType,
-			})),
+			files: args.files.map((file) => {
+				const key = "key" in file ? file.key : file.name;
+				return {
+					key,
+					filePath: joinStaticAssetPath(args.basePath, file.fileName ?? key),
+					contentType: file.contentType,
+				};
+			}),
 			dependsOn: args.dependsOn,
 		},
 		opts,

--- a/packages/sector7/tests/r2object.test.ts
+++ b/packages/sector7/tests/r2object.test.ts
@@ -32,7 +32,7 @@ vi.mock("@pulumi/pulumi", () => ({
 	},
 }));
 
-import { R2Object } from "../workersite/r2object.ts";
+import { R2Object } from "../r2/r2object.ts";
 
 const createArgs = (filePath: string) => ({
 	accountId: "account-123",

--- a/packages/sector7/tests/worker-site.test.ts
+++ b/packages/sector7/tests/worker-site.test.ts
@@ -2,26 +2,6 @@ import * as pulumi from "@pulumi/pulumi";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { WorkerSite } from "../workersite/worker-site";
 
-// Replace R2Object (dynamic.Resource) with a plain CustomResource so that
-// Pulumi's closure serializer is never invoked in the Vitest environment.
-// Vitest rewrites import() to __vite_ssr_dynamic_import__ (a captured-this
-// closure) which Pulumi cannot serialize, causing unhandled rejections even
-// though all test assertions pass.  Using a CustomResource bypasses the
-// dynamic-provider serialization path entirely while still going through the
-// Pulumi mock (newResource callback).
-vi.mock("../workersite/r2object.ts", () => ({
-	R2Object: class MockR2Object extends pulumi.CustomResource {
-		public readonly etag!: pulumi.Output<string>;
-		constructor(
-			name: string,
-			args: Record<string, unknown>,
-			opts?: pulumi.CustomResourceOptions,
-		) {
-			super("sector7:r2:R2Object", name, { etag: undefined, ...args }, opts);
-		}
-	},
-}));
-
 type MockResource = {
 	type: string;
 	name: string;
@@ -317,36 +297,6 @@ describe("WorkerSite", () => {
 		).toThrow("zoneId is required because WorkersCustomDomain depends on it");
 	});
 
-	it("passes AccountToken resource scopes as a string for asset uploads", async () => {
-		const site = new WorkerSite("asset-site", {
-			accountId: "account-123",
-			zoneId: "zone-123",
-			name: "asset-site",
-			domains: ["assets.example.com"],
-			r2Bucket: { bucketName: "asset-site-assets" },
-			assets: {
-				files: [
-					{
-						key: "index.html",
-						filePath: "/tmp/index.html",
-						contentType: "text/html; charset=utf-8",
-					},
-				],
-			},
-		});
-
-		await resolveOutput(site.worker.id);
-		await resolveOutput(site.uploadedAssets[0].id);
-
-		const token = byName("-r2-token")[0];
-		const policies = token.inputs.policies as Array<Record<string, unknown>>;
-		const resourcesInput = policies[0].resources as pulumi.Input<string>;
-
-		expect(await resolveOutput(resourcesInput)).toBe(
-			'{"com.cloudflare.edge.r2.bucket.account-123_default_asset-site-assets":"*"}',
-		);
-	});
-
 	it("allows overriding worker observability settings", async () => {
 		const site = new WorkerSite("observability-site", {
 			accountId: "account-123",
@@ -489,9 +439,7 @@ describe("WorkerSite", () => {
 			name: "no-idp-site",
 			domains: ["no-idp.example.com"],
 			r2Bucket: { bucketName: "no-idp-assets" },
-			paths: [
-				{ pattern: "/", access: "bypass" },
-			],
+			paths: [{ pattern: "/", access: "bypass" }],
 		});
 
 		await resolveOutput(site.worker.id);

--- a/packages/sector7/tests/worker-site.test.ts
+++ b/packages/sector7/tests/worker-site.test.ts
@@ -1,5 +1,5 @@
 import * as pulumi from "@pulumi/pulumi";
-import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeAll, beforeEach, describe, expect, it } from "vitest";
 import { WorkerSite } from "../workersite/worker-site";
 
 type MockResource = {

--- a/packages/sector7/workersite/README.md
+++ b/packages/sector7/workersite/README.md
@@ -1,6 +1,6 @@
 # WorkerSite
 
-`WorkerSite` is a Pulumi `ComponentResource` for hosting static sites on Cloudflare Workers with R2 storage, optional Cloudflare Access protection, and custom-domain bindings. R2 asset uploads are available via the separate `./workersite/r2` sub-path (ADR-014).
+`WorkerSite` is a Pulumi `ComponentResource` for hosting static sites on Cloudflare Workers with R2 storage, optional Cloudflare Access protection, and custom-domain bindings. R2 asset uploads are available via the sibling `./r2` sub-path (ADR-014).
 
 ## Features
 
@@ -8,7 +8,7 @@
 - Multiple domains via `WorkersCustomDomain`
 - DNS managed automatically by Cloudflare custom-domain bindings
 - Optional path-level Cloudflare Access policies
-- Optional declarative R2 uploads via the `./workersite/r2` sub-path during `pulumi up`
+- Optional declarative R2 uploads via the sibling `./r2` sub-path during `pulumi up`
 - Optional host redirects in the generated Worker script
 - Optional custom Worker script with extra plain-text bindings
 - Default Cloudflare Worker observability with configurable request/log sampling
@@ -56,7 +56,7 @@ export const boundDomains = site.boundDomains;
 
 ```typescript
 import { WorkerSite } from "@jmmaloney4/sector7/workersite";
-import { uploadAssets } from "@jmmaloney4/sector7/workersite/r2";
+import { uploadStaticAssets } from "@jmmaloney4/sector7/r2";
 
 const site = new WorkerSite("docs-site", {
   accountId: "your-cloudflare-account-id",
@@ -69,20 +69,13 @@ const site = new WorkerSite("docs-site", {
   },
 });
 
-uploadAssets("docs-site", {
+uploadStaticAssets("docs-site", {
   accountId: "your-cloudflare-account-id",
-  bucketName: "docs-site-assets",
+  bucketName: site.bucket!.name,
+  basePath: "/absolute/path/to/dist",
   files: [
-    {
-      key: "index.html",
-      filePath: "/absolute/path/to/dist/index.html",
-      contentType: "text/html; charset=utf-8",
-    },
-    {
-      key: "styles.css",
-      filePath: "/absolute/path/to/dist/styles.css",
-      contentType: "text/css; charset=utf-8",
-    },
+    { key: "index.html", contentType: "text/html; charset=utf-8" },
+    { key: "styles.css", contentType: "text/css; charset=utf-8" },
   ],
   dependsOn: [site.worker],
 }, { parent: site });
@@ -229,7 +222,7 @@ After adding this config, `pulumi preview` should show an `observability` block 
 4. An optional `cloudflare.ZeroTrustAccessIdentityProvider` when `githubOAuthConfig` is provided
 5. Zero or more `cloudflare.ZeroTrustAccessApplication` resources, one per `(domain, path)` combination when `paths` is provided
 
-When using `uploadAssets` from the `./workersite/r2` sub-path, an additional `cloudflare.AccountToken` and one `R2Object` per file are created.
+When using `uploadAssets` from the sibling `./r2` sub-path, an additional `cloudflare.AccountToken` and one `R2Object` per file are created.
 
 ## Access control model
 
@@ -242,10 +235,10 @@ Cloudflare Access enforces authorization before requests reach the Worker. The W
 
 ## Asset uploads
 
-R2 asset uploads are managed via `uploadAssets` from the `./workersite/r2` sub-path, decoupled from `WorkerSite` (ADR-014). S3-compatible signing is implemented natively via `node:crypto` + `fetch` — no external SDK required (ADR-015).
+R2 asset uploads are managed via `uploadAssets` or `uploadStaticAssets` from the sibling `./r2` sub-path, decoupled from `WorkerSite` (ADR-014). S3-compatible signing is implemented natively via `node:crypto` + `fetch` — no external SDK required (ADR-015).
 
 ```typescript
-import { uploadAssets } from "@jmmaloney4/sector7/workersite/r2";
+import { uploadAssets } from "@jmmaloney4/sector7/r2";
 
 uploadAssets("my-site", {
   accountId: "your-account-id",
@@ -289,23 +282,23 @@ redirects: [
 
 ### `WorkerSiteArgs`
 
-| Field                      | Type                        | Required    | Description                                          |
-| -------------------------- | --------------------------- | ----------- | ---------------------------------------------------- |
-| `accountId`                | `string`                    | Yes         | Cloudflare account ID                                |
-| `zoneId`                   | `string`                    | Yes         | Cloudflare zone ID required by `WorkersCustomDomain` |
-| `name`                     | `string`                    | Yes         | Name for the Worker and related resources            |
-| `domains`                  | `string[]`                  | Yes         | Hostnames to bind to the Worker                      |
-| `r2Bucket.bucketName`      | `string`                    | Yes         | R2 bucket name                                       |
-| `r2Bucket.create`          | `boolean`                   | No          | Create the bucket if it does not already exist       |
-| `r2Bucket.prefix`          | `string`                    | No          | Prefix prepended to generated-script object lookups  |
-| `githubIdentityProviderId` | `string`                    | Conditional | Pre-existing GitHub IDP UUID; mutually exclusive with `githubOAuthConfig` |
+| Field                      | Type                        | Required    | Description                                                                  |
+| -------------------------- | --------------------------- | ----------- | ---------------------------------------------------------------------------- |
+| `accountId`                | `string`                    | Yes         | Cloudflare account ID                                                        |
+| `zoneId`                   | `string`                    | Yes         | Cloudflare zone ID required by `WorkersCustomDomain`                         |
+| `name`                     | `string`                    | Yes         | Name for the Worker and related resources                                    |
+| `domains`                  | `string[]`                  | Yes         | Hostnames to bind to the Worker                                              |
+| `r2Bucket.bucketName`      | `string`                    | Yes         | R2 bucket name                                                               |
+| `r2Bucket.create`          | `boolean`                   | No          | Create the bucket if it does not already exist                               |
+| `r2Bucket.prefix`          | `string`                    | No          | Prefix prepended to generated-script object lookups                          |
+| `githubIdentityProviderId` | `string`                    | Conditional | Pre-existing GitHub IDP UUID; mutually exclusive with `githubOAuthConfig`    |
 | `githubOAuthConfig`        | `GithubOAuthConfig`         | Conditional | Auto-create a GitHub IDP; mutually exclusive with `githubIdentityProviderId` |
-| `githubOrganizations`      | `string[]`                  | Conditional | Required when a path uses `github-org`               |
-| `paths`                    | `PathConfig[]`              | No          | Access-control rules; omit for fully public sites    |
-| `cacheTtlSeconds`          | `number`                    | No          | Cache TTL for generated Worker responses             |
-| `redirects`                | `RedirectRule[]`            | No          | Host redirects for the generated Worker              |
-| `workerScript`             | `WorkerScriptConfig`        | No          | Custom Worker source and extra bindings              |
-| `observability`            | `WorkerObservabilityConfig` | No          | Worker observability and log sampling settings       |
+| `githubOrganizations`      | `string[]`                  | Conditional | Required when a path uses `github-org`                                       |
+| `paths`                    | `PathConfig[]`              | No          | Access-control rules; omit for fully public sites                            |
+| `cacheTtlSeconds`          | `number`                    | No          | Cache TTL for generated Worker responses                                     |
+| `redirects`                | `RedirectRule[]`            | No          | Host redirects for the generated Worker                                      |
+| `workerScript`             | `WorkerScriptConfig`        | No          | Custom Worker source and extra bindings                                      |
+| `observability`            | `WorkerObservabilityConfig` | No          | Worker observability and log sampling settings                               |
 
 ### `GithubOAuthConfig`
 
@@ -326,13 +319,14 @@ You must create a GitHub OAuth App at https://github.com/settings/developers wit
 | `pattern` | `string`                   | Yes      | Path pattern such as `/blog/*` |
 | `access`  | `"public" \| "github-org"` | Yes      | Access mode for the path       |
 
-### `AssetConfig` (via `./workersite/r2`)
+### R2 upload config (via `./r2`)
 
-See [Asset uploads](#asset-uploads) for usage. Available from `@jmmaloney4/sector7/workersite/r2`.
+See [Asset uploads](#asset-uploads) for usage. Available from `@jmmaloney4/sector7/r2`.
 
-| Field   | Type          | Required | Description                            |
-| ------- | ------------- | -------- | -------------------------------------- |
-| `files` | `AssetFile[]` | Yes      | Files uploaded to R2 during deployment |
+| Helper               | File type           | Description                                     |
+| -------------------- | ------------------- | ----------------------------------------------- |
+| `uploadAssets`       | `AssetFile[]`       | Upload files with explicit absolute `filePath`s |
+| `uploadStaticAssets` | `StaticAssetFile[]` | Upload files from a common `basePath` directory |
 
 ### `WorkerScriptConfig`
 
@@ -357,19 +351,19 @@ See [Asset uploads](#asset-uploads) for usage. Available from `@jmmaloney4/secto
 
 WorkerSite creates the following Cloudflare resources, and the API token must have permissions for all of them:
 
-| Resource created by WorkerSite                              | Required token permission (Account) |
-| ----------------------------------------------------------- | ----------------------------------- |
-| `cloudflare.R2Bucket` (when `r2Bucket.create` is true)     | R2: Edit                            |
-| `cloudflare.WorkersScript`                                  | Workers Scripts: Edit               |
-| `cloudflare.WorkersCustomDomain`                            | Workers Routes: Edit                |
-| `cloudflare.ZeroTrustAccessIdentityProvider` (when `githubOAuthConfig` is set) | Access: Identity Providers: Edit |
-| `cloudflare.ZeroTrustAccessApplication` (when `paths` is set) | Access: Apps and Policies: Edit  |
+| Resource created by WorkerSite                                                 | Required token permission (Account) |
+| ------------------------------------------------------------------------------ | ----------------------------------- |
+| `cloudflare.R2Bucket` (when `r2Bucket.create` is true)                         | R2: Edit                            |
+| `cloudflare.WorkersScript`                                                     | Workers Scripts: Edit               |
+| `cloudflare.WorkersCustomDomain`                                               | Workers Routes: Edit                |
+| `cloudflare.ZeroTrustAccessIdentityProvider` (when `githubOAuthConfig` is set) | Access: Identity Providers: Edit    |
+| `cloudflare.ZeroTrustAccessApplication` (when `paths` is set)                  | Access: Apps and Policies: Edit     |
 
-When using `uploadAssets` from the `./workersite/r2` sub-path:
+When using `uploadAssets` from the sibling `./r2` sub-path:
 
-| Resource created by uploadAssets         | Required token permission (Account) |
-| ---------------------------------------- | ----------------------------------- |
-| `cloudflare.AccountToken`                | Account Settings: Read              |
+| Resource created by uploadAssets | Required token permission (Account) |
+| -------------------------------- | ----------------------------------- |
+| `cloudflare.AccountToken`        | Account Settings: Read              |
 
 **Zone-level:**
 
@@ -382,6 +376,7 @@ When using `uploadAssets` from the `./workersite/r2` sub-path:
 Create a **Custom Token** in the Cloudflare dashboard (My Profile > API Tokens > Create Token) with:
 
 Account-level permissions (scoped to the target account):
+
 - Workers Scripts: Edit
 - Workers Routes: Edit
 - R2: Edit
@@ -390,9 +385,10 @@ Account-level permissions (scoped to the target account):
 - Account Settings: Read
 
 Zone-level permissions (scoped to the target zone):
+
 - Workers Routes: Edit
 
-If you do not use `paths` (fully public site), you can omit the Access permissions. Account Settings: Read is only needed when using `uploadAssets` from the `./workersite/r2` sub-path.
+If you do not use `paths` (fully public site), you can omit the Access permissions. Account Settings: Read is only needed when using `uploadAssets` from the sibling `./r2` sub-path.
 
 ## Troubleshooting
 

--- a/packages/sector7/workersite/README.md
+++ b/packages/sector7/workersite/README.md
@@ -71,6 +71,8 @@ const site = new WorkerSite("docs-site", {
 
 uploadStaticAssets("docs-site", {
   accountId: "your-cloudflare-account-id",
+  // When r2Bucket.create is true, use site.bucket!.name.
+  // When binding an existing bucket, pass the same bucketName string directly.
   bucketName: site.bucket!.name,
   basePath: "/absolute/path/to/dist",
   files: [

--- a/packages/sector7/workersite/README.md
+++ b/packages/sector7/workersite/README.md
@@ -323,10 +323,10 @@ You must create a GitHub OAuth App at https://github.com/settings/developers wit
 
 See [Asset uploads](#asset-uploads) for usage. Available from `@jmmaloney4/sector7/r2`.
 
-| Helper               | File type           | Description                                     |
-| -------------------- | ------------------- | ----------------------------------------------- |
-| `uploadAssets`       | `AssetFile[]`       | Upload files with explicit absolute `filePath`s |
-| `uploadStaticAssets` | `StaticAssetFile[]` | Upload files from a common `basePath` directory |
+| Helper               | File type           | Description                                                                                          |
+| -------------------- | ------------------- | ---------------------------------------------------------------------------------------------------- |
+| `uploadAssets`       | `AssetFile[]`       | Upload files with explicit absolute `filePath`s                                                      |
+| `uploadStaticAssets` | `StaticAssetFile[]` | Upload files from a common `basePath` directory; accepts either `key` or existing `name` descriptors |
 
 ### `WorkerScriptConfig`
 

--- a/packages/sector7/workersite/barrel-guard.ts
+++ b/packages/sector7/workersite/barrel-guard.ts
@@ -1,16 +1,21 @@
 // Barrel guard: ensure R2Object and related types are NOT re-exported from
-// the main workersite barrel.  They live on the ./r2 sub-path (ADR-014).
-// If someone re-adds them to index.ts, the @ts-expect-error directives
-// will produce "Unused '@ts-expect-error' directive" errors and fail CI.
+// the main workersite barrel. They live on the sibling @jmmaloney4/sector7/r2
+// sub-path (ADR-014). If someone re-adds them to index.ts, the guard
+// directives below become unused and TypeScript fails CI.
 
-// @ts-expect-error — R2Object lives on ./workersite/r2 sub-path only
-import { R2Object } from "./index.ts";
+import * as workersite from "./index.ts";
 
-// @ts-expect-error — AssetFile lives on ./workersite/r2 sub-path only
-import { type AssetFile } from "./index.ts";
+// @ts-expect-error — R2Object lives on the sibling ./r2 sub-path only
+const r2ObjectGuard = workersite.R2Object;
 
-// @ts-expect-error — AssetConfig lives on ./workersite/r2 sub-path only
-import { type AssetConfig } from "./index.ts";
+// @ts-expect-error — AssetFile lives on the sibling ./r2 sub-path only
+type AssetFileGuard = workersite.AssetFile;
 
-// @ts-expect-error — uploadAssets lives on ./workersite/r2 sub-path only
-import { uploadAssets } from "./index.ts";
+// @ts-expect-error — AssetConfig lives on the sibling ./r2 sub-path only
+type AssetConfigGuard = workersite.AssetConfig;
+
+// @ts-expect-error — uploadAssets lives on the sibling ./r2 sub-path only
+const uploadAssetsGuard = workersite.uploadAssets;
+
+// @ts-expect-error — uploadStaticAssets lives on the sibling ./r2 sub-path only
+const uploadStaticAssetsGuard = workersite.uploadStaticAssets;

--- a/packages/sector7/workersite/barrel-guard.ts
+++ b/packages/sector7/workersite/barrel-guard.ts
@@ -6,16 +6,16 @@
 import * as workersite from "./index.ts";
 
 // @ts-expect-error — R2Object lives on the sibling ./r2 sub-path only
-const r2ObjectGuard = workersite.R2Object;
+const _r2ObjectGuard = workersite.R2Object;
 
 // @ts-expect-error — AssetFile lives on the sibling ./r2 sub-path only
-type AssetFileGuard = workersite.AssetFile;
+type _AssetFileGuard = workersite.AssetFile;
 
 // @ts-expect-error — AssetConfig lives on the sibling ./r2 sub-path only
-type AssetConfigGuard = workersite.AssetConfig;
+type _AssetConfigGuard = workersite.AssetConfig;
 
 // @ts-expect-error — uploadAssets lives on the sibling ./r2 sub-path only
-const uploadAssetsGuard = workersite.uploadAssets;
+const _uploadAssetsGuard = workersite.uploadAssets;
 
 // @ts-expect-error — uploadStaticAssets lives on the sibling ./r2 sub-path only
-const uploadStaticAssetsGuard = workersite.uploadStaticAssets;
+const _uploadStaticAssetsGuard = workersite.uploadStaticAssets;

--- a/packages/sector7/workersite/index.ts
+++ b/packages/sector7/workersite/index.ts
@@ -1,10 +1,10 @@
 export {
-	type PathConfig,
-	type WorkerScriptConfig,
 	type GithubOAuthConfig,
+	type PathConfig,
 	type WorkerObservabilityConfig,
-	type WorkerSiteArgs,
+	type WorkerScriptConfig,
 	WorkerSite,
+	type WorkerSiteArgs,
 } from "./worker-site.ts";
 export {
 	generateWorkerScript,

--- a/packages/sector7/workersite/r2.ts
+++ b/packages/sector7/workersite/r2.ts
@@ -1,8 +1,0 @@
-export {
-	type AssetFile,
-	type AssetConfig,
-	type UploadAssetsArgs,
-	uploadAssets,
-	R2Object,
-	type R2ObjectInputs,
-} from "./r2object.ts";

--- a/packages/sector7/workersite/worker-site.ts
+++ b/packages/sector7/workersite/worker-site.ts
@@ -144,7 +144,7 @@ export interface WorkerObservabilityConfig {
  * - Optional path-level access control (Zero Trust; omit for fully public sites)
  * - R2 backend with Cache API
  * - Configurable cache TTL
- * - Optional declarative R2 asset uploads via the `./workersite/r2` sub-path (ADR-014)
+ * - Optional declarative R2 asset uploads via the sibling `./r2` sub-path (ADR-014)
  * - Optional host-level redirect rules injected into the generated Worker script
  * - Optional custom Worker script with extra bindings
  */
@@ -297,7 +297,7 @@ export interface WorkerSiteArgs {
  * - R2-backed Worker serving static files with Cache API
  * - Multiple domains via WorkersCustomDomain
  * - Optional Zero Trust access control per path
- * - Optional declarative R2 asset uploads via the `./workersite/r2` sub-path (ADR-014)
+ * - Optional declarative R2 asset uploads via the sibling `./r2` sub-path (ADR-014)
  * - Optional host-level redirect rules
  * - Optional custom Worker script with extra bindings
  *
@@ -313,7 +313,7 @@ export interface WorkerSiteArgs {
  *   redirects: [{ fromHost: "www.example.com", toHost: "example.com" }],
  * });
  * // Upload assets separately via the r2 sub-path:
- * // import { uploadAssets } from "@jmmaloney4/sector7/workersite/r2";
+ * // import { uploadAssets } from "@jmmaloney4/sector7/r2";
  * // uploadAssets("my-site", { accountId, bucketName, files }, { parent: site });
  * ```
  *
@@ -368,7 +368,9 @@ export class WorkerSite extends pulumi.ComponentResource {
 	 * Undefined when using a pre-existing `githubIdentityProviderId` or when no
 	 * GitHub auth is needed.
 	 */
-	public readonly githubIdp: cloudflare.ZeroTrustAccessIdentityProvider | undefined;
+	public readonly githubIdp:
+		| cloudflare.ZeroTrustAccessIdentityProvider
+		| undefined;
 
 	/**
 	 * The domains bound to the Worker.
@@ -591,11 +593,11 @@ export class WorkerSite extends pulumi.ComponentResource {
 					const policyIncludes =
 						pathConfig.access === "public" || pathConfig.access === "bypass"
 							? [{ everyone: {} }]
-						: pulumi
-								.all([
-									pulumi.all(args.githubOrganizations ?? []),
-									githubIdentityProviderId ?? "",
-								])
+							: pulumi
+									.all([
+										pulumi.all(args.githubOrganizations ?? []),
+										githubIdentityProviderId ?? "",
+									])
 									.apply(
 										([orgs, idpId]: [string[], string]) =>
 											orgs.map((org: string) => ({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,10 +22,6 @@ importers:
         version: 4.1.2(@opentelemetry/api@1.9.0)(@types/node@24.12.2)(vite@7.3.1(@types/node@24.12.2))
 
   packages/sector7:
-    dependencies:
-      '@aws-sdk/client-s3':
-        specifier: ^3.0.0
-        version: 3.1009.0
     devDependencies:
       '@pulumi/cloudflare':
         specifier: 6.14.0
@@ -41,165 +37,6 @@ importers:
         version: 4.1.2(@opentelemetry/api@1.9.0)(@types/node@24.12.2)(vite@7.3.1(@types/node@24.12.2))
 
 packages:
-
-  '@aws-crypto/crc32@5.2.0':
-    resolution: {integrity: sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==}
-    engines: {node: '>=16.0.0'}
-
-  '@aws-crypto/crc32c@5.2.0':
-    resolution: {integrity: sha512-+iWb8qaHLYKrNvGRbiYRHSdKRWhto5XlZUEBwDjYNf+ly5SVYG6zEoYIdxvf5R3zyeP16w4PLBn3rH1xc74Rag==}
-
-  '@aws-crypto/sha1-browser@5.2.0':
-    resolution: {integrity: sha512-OH6lveCFfcDjX4dbAvCFSYUjJZjDr/3XJ3xHtjn3Oj5b9RjojQo8npoLeA/bNwkOkrSQ0wgrHzXk4tDRxGKJeg==}
-
-  '@aws-crypto/sha256-browser@5.2.0':
-    resolution: {integrity: sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==}
-
-  '@aws-crypto/sha256-js@5.2.0':
-    resolution: {integrity: sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==}
-    engines: {node: '>=16.0.0'}
-
-  '@aws-crypto/supports-web-crypto@5.2.0':
-    resolution: {integrity: sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==}
-
-  '@aws-crypto/util@5.2.0':
-    resolution: {integrity: sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==}
-
-  '@aws-sdk/client-s3@3.1009.0':
-    resolution: {integrity: sha512-luy8CxallkoiGWTqU86ca/BbvkWJjs0oala7uIIRN1JtQxMb5i4Yl/PBZVcQFhbK9kQi0PK0GfD8gIpLkI91fw==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/core@3.973.20':
-    resolution: {integrity: sha512-i3GuX+lowD892F3IuJf8o6AbyDupMTdyTxQrCJGcn71ni5hTZ82L4nQhcdumxZ7XPJRJJVHS/CR3uYOIIs0PVA==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/crc64-nvme@3.972.5':
-    resolution: {integrity: sha512-2VbTstbjKdT+yKi8m7b3a9CiVac+pL/IY2PHJwsaGkkHmuuqkJZIErPck1h6P3T9ghQMLSdMPyW6Qp7Di5swFg==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/credential-provider-env@3.972.18':
-    resolution: {integrity: sha512-X0B8AlQY507i5DwjLByeU2Af4ARsl9Vr84koDcXCbAkplmU+1xBFWxEPrWRAoh56waBne/yJqEloSwvRf4x6XA==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/credential-provider-http@3.972.20':
-    resolution: {integrity: sha512-ey9Lelj001+oOfrbKmS6R2CJAiXX7QKY4Vj9VJv6L2eE6/VjD8DocHIoYqztTm70xDLR4E1jYPTKfIui+eRNDA==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/credential-provider-ini@3.972.20':
-    resolution: {integrity: sha512-5flXSnKHMloObNF+9N0cupKegnH1Z37cdVlpETVgx8/rAhCe+VNlkcZH3HDg2SDn9bI765S+rhNPXGDJJPfbtA==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/credential-provider-login@3.972.20':
-    resolution: {integrity: sha512-gEWo54nfqp2jABMu6HNsjVC4hDLpg9HC8IKSJnp0kqWtxIJYHTmiLSsIfI4ScQjxEwpB+jOOH8dOLax1+hy/Hw==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/credential-provider-node@3.972.21':
-    resolution: {integrity: sha512-hah8if3/B/Q+LBYN5FukyQ1Mym6PLPDsBOBsIgNEYD6wLyZg0UmUF/OKIVC3nX9XH8TfTPuITK+7N/jenVACWA==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/credential-provider-process@3.972.18':
-    resolution: {integrity: sha512-Tpl7SRaPoOLT32jbTWchPsn52hYYgJ0kpiFgnwk8pxTANQdUymVSZkzFvv1+oOgZm1CrbQUP9MBeoMZ9IzLZjA==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/credential-provider-sso@3.972.20':
-    resolution: {integrity: sha512-p+R+PYR5Z7Gjqf/6pvbCnzEHcqPCpLzR7Yf127HjJ6EAb4hUcD+qsNRnuww1sB/RmSeCLxyay8FMyqREw4p1RA==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/credential-provider-web-identity@3.972.20':
-    resolution: {integrity: sha512-rWCmh8o7QY4CsUj63qopzMzkDq/yPpkrpb+CnjBEFSOg/02T/we7sSTVg4QsDiVS9uwZ8VyONhq98qt+pIh3KA==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/middleware-bucket-endpoint@3.972.8':
-    resolution: {integrity: sha512-WR525Rr2QJSETa9a050isktyWi/4yIGcmY3BQ1kpHqb0LqUglQHCS8R27dTJxxWNZvQ0RVGtEZjTCbZJpyF3Aw==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/middleware-expect-continue@3.972.8':
-    resolution: {integrity: sha512-5DTBTiotEES1e2jOHAq//zyzCjeMB78lEHd35u15qnrid4Nxm7diqIf9fQQ3Ov0ChH1V3Vvt13thOnrACmfGVQ==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/middleware-flexible-checksums@3.973.6':
-    resolution: {integrity: sha512-0nYEgkJH7Yt9k+nZJyllTghnkKaz17TWFcr5Mi0XMVMzYlF4ytDZADQpF2/iJo36cKL5AYSzRsvlykE4M/ErTA==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/middleware-host-header@3.972.8':
-    resolution: {integrity: sha512-wAr2REfKsqoKQ+OkNqvOShnBoh+nkPurDKW7uAeVSu6kUECnWlSJiPvnoqxGlfousEY/v9LfS9sNc46hjSYDIQ==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/middleware-location-constraint@3.972.8':
-    resolution: {integrity: sha512-KaUoFuoFPziIa98DSQsTPeke1gvGXlc5ZGMhy+b+nLxZ4A7jmJgLzjEF95l8aOQN2T/qlPP3MrAyELm8ExXucw==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/middleware-logger@3.972.8':
-    resolution: {integrity: sha512-CWl5UCM57WUFaFi5kB7IBY1UmOeLvNZAZ2/OZ5l20ldiJ3TiIz1pC65gYj8X0BCPWkeR1E32mpsCk1L1I4n+lA==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/middleware-recursion-detection@3.972.8':
-    resolution: {integrity: sha512-BnnvYs2ZEpdlmZ2PNlV2ZyQ8j8AEkMTjN79y/YA475ER1ByFYrkVR85qmhni8oeTaJcDqbx364wDpitDAA/wCA==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/middleware-sdk-s3@3.972.20':
-    resolution: {integrity: sha512-yhva/xL5H4tWQgsBjwV+RRD0ByCzg0TcByDCLp3GXdn/wlyRNfy8zsswDtCvr1WSKQkSQYlyEzPuWkJG0f5HvQ==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/middleware-ssec@3.972.8':
-    resolution: {integrity: sha512-wqlK0yO/TxEC2UsY9wIlqeeutF6jjLe0f96Pbm40XscTo57nImUk9lBcw0dPgsm0sppFtAkSlDrfpK+pC30Wqw==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/middleware-user-agent@3.972.21':
-    resolution: {integrity: sha512-62XRl1GDYPpkt7cx1AX1SPy9wgNE9Iw/NPuurJu4lmhCWS7sGKO+kS53TQ8eRmIxy3skmvNInnk0ZbWrU5Dpyg==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/nested-clients@3.996.10':
-    resolution: {integrity: sha512-SlDol5Z+C7Ivnc2rKGqiqfSUmUZzY1qHfVs9myt/nxVwswgfpjdKahyTzLTx802Zfq0NFRs7AejwKzzzl5Co2w==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/region-config-resolver@3.972.8':
-    resolution: {integrity: sha512-1eD4uhTDeambO/PNIDVG19A6+v4NdD7xzwLHDutHsUqz0B+i661MwQB2eYO4/crcCvCiQG4SRm1k81k54FEIvw==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/signature-v4-multi-region@3.996.8':
-    resolution: {integrity: sha512-n1qYFD+tbqZuyskVaxUE+t10AUz9g3qzDw3Tp6QZDKmqsjfDmZBd4GIk2EKJJNtcCBtE5YiUjDYA+3djFAFBBg==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/token-providers@3.1009.0':
-    resolution: {integrity: sha512-KCPLuTqN9u0Rr38Arln78fRG9KXpzsPWmof+PZzfAHMMQq2QED6YjQrkrfiH7PDefLWEposY1o4/eGwrmKA4JA==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/types@3.973.6':
-    resolution: {integrity: sha512-Atfcy4E++beKtwJHiDln2Nby8W/mam64opFPTiHEqgsthqeydFS1pY+OUlN1ouNOmf8ArPU/6cDS65anOP3KQw==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/util-arn-parser@3.972.3':
-    resolution: {integrity: sha512-HzSD8PMFrvgi2Kserxuff5VitNq2sgf3w9qxmskKDiDTThWfVteJxuCS9JXiPIPtmCrp+7N9asfIaVhBFORllA==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/util-endpoints@3.996.5':
-    resolution: {integrity: sha512-Uh93L5sXFNbyR5sEPMzUU8tJ++Ku97EY4udmC01nB8Zu+xfBPwpIwJ6F7snqQeq8h2pf+8SGN5/NoytfKgYPIw==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/util-locate-window@3.965.5':
-    resolution: {integrity: sha512-WhlJNNINQB+9qtLtZJcpQdgZw3SCDCpXdUJP7cToGwHbCWCnRckGlc6Bx/OhWwIYFNAn+FIydY8SZ0QmVu3xTQ==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/util-user-agent-browser@3.972.8':
-    resolution: {integrity: sha512-B3KGXJviV2u6Cdw2SDY2aDhoJkVfY/Q/Trwk2CMSkikE1Oi6gRzxhvhIfiRpHfmIsAhV4EA54TVEX8K6CbHbkA==}
-
-  '@aws-sdk/util-user-agent-node@3.973.7':
-    resolution: {integrity: sha512-Hz6EZMUAEzqUd7e+vZ9LE7mn+5gMbxltXy18v+YSFY+9LBJz15wkNZvw5JqfX3z0FS9n3bgUtz3L5rAsfh4YlA==}
-    engines: {node: '>=20.0.0'}
-    peerDependencies:
-      aws-crt: '>=1.0.0'
-    peerDependenciesMeta:
-      aws-crt:
-        optional: true
-
-  '@aws-sdk/xml-builder@3.972.11':
-    resolution: {integrity: sha512-iitV/gZKQMvY9d7ovmyFnFuTHbBAtrmLnvaSb/3X8vOKyevwtpmEtyc8AdhVWZe0pI/1GsHxlEvQeOePFzy7KQ==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws/lambda-invoke-store@0.2.4':
-    resolution: {integrity: sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==}
-    engines: {node: '>=18.0.0'}
 
   '@esbuild/aix-ppc64@0.27.4':
     resolution: {integrity: sha512-cQPwL2mp2nSmHHJlCyoXgHGhbEPMrEEU5xhkcy3Hs/O7nGZqEpZ2sUtLaL9MORLtDfRvVl2/3PAuEkYZH0Ty8Q==}
@@ -663,66 +500,79 @@ packages:
     resolution: {integrity: sha512-t4ONHboXi/3E0rT6OZl1pKbl2Vgxf9vJfWgmUoCEVQVxhW6Cw/c8I6hbbu7DAvgp82RKiH7TpLwxnJeKv2pbsw==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.59.0':
     resolution: {integrity: sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.59.0':
     resolution: {integrity: sha512-jYgUGk5aLd1nUb1CtQ8E+t5JhLc9x5WdBKew9ZgAXg7DBk0ZHErLHdXM24rfX+bKrFe+Xp5YuJo54I5HFjGDAA==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.59.0':
     resolution: {integrity: sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.59.0':
     resolution: {integrity: sha512-gbUSW/97f7+r4gHy3Jlup8zDG190AuodsWnNiXErp9mT90iCy9NKKU0Xwx5k8VlRAIV2uU9CsMnEFg/xXaOfXg==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.59.0':
     resolution: {integrity: sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.59.0':
     resolution: {integrity: sha512-sw1o3tfyk12k3OEpRddF68a1unZ5VCN7zoTNtSn2KndUE+ea3m3ROOKRCZxEpmT9nsGnogpFP9x6mnLTCaoLkA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.59.0':
     resolution: {integrity: sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.59.0':
     resolution: {integrity: sha512-NDYMpsXYJJaj+I7UdwIuHHNxXZ/b/N2hR15NyH3m2qAtb/hHPA4g4SuuvrdxetTdndfj9b1WOmy73kcPRoERUg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.59.0':
     resolution: {integrity: sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.59.0':
     resolution: {integrity: sha512-oF87Ie3uAIvORFBpwnCvUzdeYUqi2wY6jRFWJAy1qus/udHFYIkplYRW+wo+GRUP4sKzYdmE1Y3+rY5Gc4ZO+w==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.59.0':
     resolution: {integrity: sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.59.0':
     resolution: {integrity: sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.59.0':
     resolution: {integrity: sha512-M3bLRAVk6GOwFlPTIxVBSYKUaqfLrn8l0psKinkCFxl4lQvOSz8ZrKDz2gxcBwHFpci0B6rttydI4IpS4IS/jQ==}
@@ -781,222 +631,6 @@ packages:
   '@sindresorhus/is@4.6.0':
     resolution: {integrity: sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==}
     engines: {node: '>=10'}
-
-  '@smithy/abort-controller@4.2.12':
-    resolution: {integrity: sha512-xolrFw6b+2iYGl6EcOL7IJY71vvyZ0DJ3mcKtpykqPe2uscwtzDZJa1uVQXyP7w9Dd+kGwYnPbMsJrGISKiY/Q==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/chunked-blob-reader-native@4.2.3':
-    resolution: {integrity: sha512-jA5k5Udn7Y5717L86h4EIv06wIr3xn8GM1qHRi/Nf31annXcXHJjBKvgztnbn2TxH3xWrPBfgwHsOwZf0UmQWw==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/chunked-blob-reader@5.2.2':
-    resolution: {integrity: sha512-St+kVicSyayWQca+I1rGitaOEH6uKgE8IUWoYnnEX26SWdWQcL6LvMSD19Lg+vYHKdT9B2Zuu7rd3i6Wnyb/iw==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/config-resolver@4.4.11':
-    resolution: {integrity: sha512-YxFiiG4YDAtX7WMN7RuhHZLeTmRRAOyCbr+zB8e3AQzHPnUhS8zXjB1+cniPVQI3xbWsQPM0X2aaIkO/ME0ymw==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/core@3.23.11':
-    resolution: {integrity: sha512-952rGf7hBRnhUIaeLp6q4MptKW8sPFe5VvkoZ5qIzFAtx6c/QZ/54FS3yootsyUSf9gJX/NBqEBNdNR7jMIlpQ==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/credential-provider-imds@4.2.12':
-    resolution: {integrity: sha512-cr2lR792vNZcYMriSIj+Um3x9KWrjcu98kn234xA6reOAFMmbRpQMOv8KPgEmLLtx3eldU6c5wALKFqNOhugmg==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/eventstream-codec@4.2.12':
-    resolution: {integrity: sha512-FE3bZdEl62ojmy8x4FHqxq2+BuOHlcxiH5vaZ6aqHJr3AIZzwF5jfx8dEiU/X0a8RboyNDjmXjlbr8AdEyLgiA==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/eventstream-serde-browser@4.2.12':
-    resolution: {integrity: sha512-XUSuMxlTxV5pp4VpqZf6Sa3vT/Q75FVkLSpSSE3KkWBvAQWeuWt1msTv8fJfgA4/jcJhrbrbMzN1AC/hvPmm5A==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/eventstream-serde-config-resolver@4.3.12':
-    resolution: {integrity: sha512-7epsAZ3QvfHkngz6RXQYseyZYHlmWXSTPOfPmXkiS+zA6TBNo1awUaMFL9vxyXlGdoELmCZyZe1nQE+imbmV+Q==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/eventstream-serde-node@4.2.12':
-    resolution: {integrity: sha512-D1pFuExo31854eAvg89KMn9Oab/wEeJR6Buy32B49A9Ogdtx5fwZPqBHUlDzaCDpycTFk2+fSQgX689Qsk7UGA==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/eventstream-serde-universal@4.2.12':
-    resolution: {integrity: sha512-+yNuTiyBACxOJUTvbsNsSOfH9G9oKbaJE1lNL3YHpGcuucl6rPZMi3nrpehpVOVR2E07YqFFmtwpImtpzlouHQ==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/fetch-http-handler@5.3.15':
-    resolution: {integrity: sha512-T4jFU5N/yiIfrtrsb9uOQn7RdELdM/7HbyLNr6uO/mpkj1ctiVs7CihVr51w4LyQlXWDpXFn4BElf1WmQvZu/A==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/hash-blob-browser@4.2.13':
-    resolution: {integrity: sha512-YrF4zWKh+ghLuquldj6e/RzE3xZYL8wIPfkt0MqCRphVICjyyjH8OwKD7LLlKpVEbk4FLizFfC1+gwK6XQdR3g==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/hash-node@4.2.12':
-    resolution: {integrity: sha512-QhBYbGrbxTkZ43QoTPrK72DoYviDeg6YKDrHTMJbbC+A0sml3kSjzFtXP7BtbyJnXojLfTQldGdUR0RGD8dA3w==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/hash-stream-node@4.2.12':
-    resolution: {integrity: sha512-O3YbmGExeafuM/kP7Y8r6+1y0hIh3/zn6GROx0uNlB54K9oihAL75Qtc+jFfLNliTi6pxOAYZrRKD9A7iA6UFw==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/invalid-dependency@4.2.12':
-    resolution: {integrity: sha512-/4F1zb7Z8LOu1PalTdESFHR0RbPwHd3FcaG1sI3UEIriQTWakysgJr65lc1jj6QY5ye7aFsisajotH6UhWfm/g==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/is-array-buffer@2.2.0':
-    resolution: {integrity: sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==}
-    engines: {node: '>=14.0.0'}
-
-  '@smithy/is-array-buffer@4.2.2':
-    resolution: {integrity: sha512-n6rQ4N8Jj4YTQO3YFrlgZuwKodf4zUFs7EJIWH86pSCWBaAtAGBFfCM7Wx6D2bBJ2xqFNxGBSrUWswT3M0VJow==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/md5-js@4.2.12':
-    resolution: {integrity: sha512-W/oIpHCpWU2+iAkfZYyGWE+qkpuf3vEXHLxQQDx9FPNZTTdnul0dZ2d/gUFrtQ5je1G2kp4cjG0/24YueG2LbQ==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/middleware-content-length@4.2.12':
-    resolution: {integrity: sha512-YE58Yz+cvFInWI/wOTrB+DbvUVz/pLn5mC5MvOV4fdRUc6qGwygyngcucRQjAhiCEbmfLOXX0gntSIcgMvAjmA==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/middleware-endpoint@4.4.25':
-    resolution: {integrity: sha512-dqjLwZs2eBxIUG6Qtw8/YZ4DvzHGIf0DA18wrgtfP6a50UIO7e2nY0FPdcbv5tVJKqWCCU5BmGMOUwT7Puan+A==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/middleware-retry@4.4.42':
-    resolution: {integrity: sha512-vbwyqHRIpIZutNXZpLAozakzamcINaRCpEy1MYmK6xBeW3xN+TyPRA123GjXnuxZIjc9848MRRCugVMTXxC4Eg==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/middleware-serde@4.2.14':
-    resolution: {integrity: sha512-+CcaLoLa5apzSRtloOyG7lQvkUw2ZDml3hRh4QiG9WyEPfW5Ke/3tPOPiPjUneuT59Tpn8+c3RVaUvvkkwqZwg==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/middleware-stack@4.2.12':
-    resolution: {integrity: sha512-kruC5gRHwsCOuyCd4ouQxYjgRAym2uDlCvQ5acuMtRrcdfg7mFBg6blaxcJ09STpt3ziEkis6bhg1uwrWU7txw==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/node-config-provider@4.3.12':
-    resolution: {integrity: sha512-tr2oKX2xMcO+rBOjobSwVAkV05SIfUKz8iI53rzxEmgW3GOOPOv0UioSDk+J8OpRQnpnhsO3Af6IEBabQBVmiw==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/node-http-handler@4.4.16':
-    resolution: {integrity: sha512-ULC8UCS/HivdCB3jhi+kLFYe4B5gxH2gi9vHBfEIiRrT2jfKiZNiETJSlzRtE6B26XbBHjPtc8iZKSNqMol9bw==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/property-provider@4.2.12':
-    resolution: {integrity: sha512-jqve46eYU1v7pZ5BM+fmkbq3DerkSluPr5EhvOcHxygxzD05ByDRppRwRPPpFrsFo5yDtCYLKu+kreHKVrvc7A==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/protocol-http@5.3.12':
-    resolution: {integrity: sha512-fit0GZK9I1xoRlR4jXmbLhoN0OdEpa96ul8M65XdmXnxXkuMxM0Y8HDT0Fh0Xb4I85MBvBClOzgSrV1X2s1Hxw==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/querystring-builder@4.2.12':
-    resolution: {integrity: sha512-6wTZjGABQufekycfDGMEB84BgtdOE/rCVTov+EDXQ8NHKTUNIp/j27IliwP7tjIU9LR+sSzyGBOXjeEtVgzCHg==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/querystring-parser@4.2.12':
-    resolution: {integrity: sha512-P2OdvrgiAKpkPNKlKUtWbNZKB1XjPxM086NeVhK+W+wI46pIKdWBe5QyXvhUm3MEcyS/rkLvY8rZzyUdmyDZBw==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/service-error-classification@4.2.12':
-    resolution: {integrity: sha512-LlP29oSQN0Tw0b6D0Xo6BIikBswuIiGYbRACy5ujw/JgWSzTdYj46U83ssf6Ux0GyNJVivs2uReU8pt7Eu9okQ==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/shared-ini-file-loader@4.4.7':
-    resolution: {integrity: sha512-HrOKWsUb+otTeo1HxVWeEb99t5ER1XrBi/xka2Wv6NVmTbuCUC1dvlrksdvxFtODLBjsC+PHK+fuy2x/7Ynyiw==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/signature-v4@5.3.12':
-    resolution: {integrity: sha512-B/FBwO3MVOL00DaRSXfXfa/TRXRheagt/q5A2NM13u7q+sHS59EOVGQNfG7DkmVtdQm5m3vOosoKAXSqn/OEgw==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/smithy-client@4.12.5':
-    resolution: {integrity: sha512-UqwYawyqSr/aog8mnLnfbPurS0gi4G7IYDcD28cUIBhsvWs1+rQcL2IwkUQ+QZ7dibaoRzhNF99fAQ9AUcO00w==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/types@4.13.1':
-    resolution: {integrity: sha512-787F3yzE2UiJIQ+wYW1CVg2odHjmaWLGksnKQHUrK/lYZSEcy1msuLVvxaR/sI2/aDe9U+TBuLsXnr3vod1g0g==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/url-parser@4.2.12':
-    resolution: {integrity: sha512-wOPKPEpso+doCZGIlr+e1lVI6+9VAKfL4kZWFgzVgGWY2hZxshNKod4l2LXS3PRC9otH/JRSjtEHqQ/7eLciRA==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/util-base64@4.3.2':
-    resolution: {integrity: sha512-XRH6b0H/5A3SgblmMa5ErXQ2XKhfbQB+Fm/oyLZ2O2kCUrwgg55bU0RekmzAhuwOjA9qdN5VU2BprOvGGUkOOQ==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/util-body-length-browser@4.2.2':
-    resolution: {integrity: sha512-JKCrLNOup3OOgmzeaKQwi4ZCTWlYR5H4Gm1r2uTMVBXoemo1UEghk5vtMi1xSu2ymgKVGW631e2fp9/R610ZjQ==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/util-body-length-node@4.2.3':
-    resolution: {integrity: sha512-ZkJGvqBzMHVHE7r/hcuCxlTY8pQr1kMtdsVPs7ex4mMU+EAbcXppfo5NmyxMYi2XU49eqaz56j2gsk4dHHPG/g==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/util-buffer-from@2.2.0':
-    resolution: {integrity: sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==}
-    engines: {node: '>=14.0.0'}
-
-  '@smithy/util-buffer-from@4.2.2':
-    resolution: {integrity: sha512-FDXD7cvUoFWwN6vtQfEta540Y/YBe5JneK3SoZg9bThSoOAC/eGeYEua6RkBgKjGa/sz6Y+DuBZj3+YEY21y4Q==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/util-config-provider@4.2.2':
-    resolution: {integrity: sha512-dWU03V3XUprJwaUIFVv4iOnS1FC9HnMHDfUrlNDSh4315v0cWyaIErP8KiqGVbf5z+JupoVpNM7ZB3jFiTejvQ==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/util-defaults-mode-browser@4.3.41':
-    resolution: {integrity: sha512-M1w1Ux0rSVvBOxIIiqbxvZvhnjQ+VUjJrugtORE90BbadSTH+jsQL279KRL3Hv0w69rE7EuYkV/4Lepz/NBW9g==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/util-defaults-mode-node@4.2.44':
-    resolution: {integrity: sha512-YPze3/lD1KmWuZsl9JlfhcgGLX7AXhSoaCDtiPntUjNW5/YY0lOHjkcgxyE9x/h5vvS1fzDifMGjzqnNlNiqOQ==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/util-endpoints@3.3.3':
-    resolution: {integrity: sha512-VACQVe50j0HZPjpwWcjyT51KUQ4AnsvEaQ2lKHOSL4mNLD0G9BjEniQ+yCt1qqfKfiAHRAts26ud7hBjamrwig==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/util-hex-encoding@4.2.2':
-    resolution: {integrity: sha512-Qcz3W5vuHK4sLQdyT93k/rfrUwdJ8/HZ+nMUOyGdpeGA1Wxt65zYwi3oEl9kOM+RswvYq90fzkNDahPS8K0OIg==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/util-middleware@4.2.12':
-    resolution: {integrity: sha512-Er805uFUOvgc0l8nv0e0su0VFISoxhJ/AwOn3gL2NWNY2LUEldP5WtVcRYSQBcjg0y9NfG8JYrCJaYDpupBHJQ==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/util-retry@4.2.12':
-    resolution: {integrity: sha512-1zopLDUEOwumjcHdJ1mwBHddubYF8GMQvstVCLC54Y46rqoHwlIU+8ZzUeaBcD+WCJHyDGSeZ2ml9YSe9aqcoQ==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/util-stream@4.5.19':
-    resolution: {integrity: sha512-v4sa+3xTweL1CLO2UP0p7tvIMH/Rq1X4KKOxd568mpe6LSLMQCnDHs4uv7m3ukpl3HvcN2JH6jiCS0SNRXKP/w==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/util-uri-escape@4.2.2':
-    resolution: {integrity: sha512-2kAStBlvq+lTXHyAZYfJRb/DfS3rsinLiwb+69SstC9Vb0s9vNWkRwpnj918Pfi85mzi42sOqdV72OLxWAISnw==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/util-utf8@2.3.0':
-    resolution: {integrity: sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==}
-    engines: {node: '>=14.0.0'}
-
-  '@smithy/util-utf8@4.2.2':
-    resolution: {integrity: sha512-75MeYpjdWRe8M5E3AW0O4Cx3UadweS+cwdXjwYGBW5h/gxxnbeZ877sLPX/ZJA9GVTlL/qG0dXP29JWFCD1Ayw==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/util-waiter@4.2.13':
-    resolution: {integrity: sha512-2zdZ9DTHngRtcYxJK1GUDxruNr53kv5W2Lupe0LMU+Imr6ohQg8M2T14MNkj1Y0wS3FFwpgpGQyvuaMF7CiTmQ==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/uuid@1.1.2':
-    resolution: {integrity: sha512-O/IEdcCUKkubz60tFbGA7ceITTAJsty+lBjNoorP4Z6XRqaFb/OjQjZODophEcuq68nKm6/0r+6/lLQ+XVpk8g==}
-    engines: {node: '>=18.0.0'}
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
@@ -1163,9 +797,6 @@ packages:
     resolution: {integrity: sha512-X4CiKlcV2GjnCMwnKAfbVWpHa++65th9TuzAEYtZoATiOE2DQKhSp4CJlyLoTqdhBKlXjpXjCTYPNNFS33Fi6w==}
     engines: {node: ^20.17.0 || >=22.9.0}
 
-  bowser@2.14.1:
-    resolution: {integrity: sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==}
-
   brace-expansion@2.0.2:
     resolution: {integrity: sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==}
 
@@ -1299,13 +930,6 @@ packages:
 
   exponential-backoff@3.1.3:
     resolution: {integrity: sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==}
-
-  fast-xml-builder@1.1.3:
-    resolution: {integrity: sha512-1o60KoFw2+LWKQu3IdcfcFlGTW4dpqEWmjhYec6H82AYZU2TVBXep6tMl8Z1Y+wM+ZrzCwe3BZ9Vyd9N2rIvmg==}
-
-  fast-xml-parser@5.4.1:
-    resolution: {integrity: sha512-BQ30U1mKkvXQXXkAGcuyUA/GA26oEB7NzOtsxCDtyu62sjGw5QraKFhx2Em3WQNjPw9PG6MQ9yuIIgkSDfGu5A==}
-    hasBin: true
 
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
@@ -1695,10 +1319,6 @@ packages:
     resolution: {integrity: sha512-ZHEmNKMq1wyJXNwLxyHnluPfRAFSIliBvbK/UiOceROt4Xh9Pz0fq49NytIaeaCUf5VR86hwQ/34FCcNU5/LKQ==}
     engines: {node: ^20.17.0 || >=22.9.0}
 
-  path-expression-matcher@1.1.3:
-    resolution: {integrity: sha512-qdVgY8KXmVdJZRSS1JdEPOKPdTiEK/pi0RkcT2sw1RhXxohdujUlJFPuS1TSkevZ9vzd3ZlL7ULl1MHGTApKzQ==}
-    engines: {node: '>=14.0.0'}
-
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
@@ -1914,9 +1534,6 @@ packages:
     resolution: {integrity: sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==}
     engines: {node: '>=6'}
 
-  strnum@2.2.0:
-    resolution: {integrity: sha512-Y7Bj8XyJxnPAORMZj/xltsfo55uOiyHcU2tnAVzHUnSJR/KsEX+9RoDeXEnsXtl/CX4fAcrt64gZ13aGaWPeBg==}
-
   supports-preserve-symlinks-flag@1.0.0:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
@@ -1947,9 +1564,6 @@ packages:
   treeverse@3.0.0:
     resolution: {integrity: sha512-gcANaAnd2QDZFmHFEOF4k7uc1J/6a6z3DJMd/QwEyxLoKGiptJRwid582r7QIsFlFMIZ3SnxfS52S4hm2DHkuQ==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
-
-  tslib@2.8.1:
-    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
   tuf-js@4.1.0:
     resolution: {integrity: sha512-50QV99kCKH5P/Vs4E2Gzp7BopNV+KzTXqWeaxrfu5IQJBOULRsTIS9seSsOVT8ZnGXzCyx55nYWAi4qJzpZKEQ==}
@@ -2115,450 +1729,6 @@ packages:
     engines: {node: '>=12'}
 
 snapshots:
-
-  '@aws-crypto/crc32@5.2.0':
-    dependencies:
-      '@aws-crypto/util': 5.2.0
-      '@aws-sdk/types': 3.973.6
-      tslib: 2.8.1
-
-  '@aws-crypto/crc32c@5.2.0':
-    dependencies:
-      '@aws-crypto/util': 5.2.0
-      '@aws-sdk/types': 3.973.6
-      tslib: 2.8.1
-
-  '@aws-crypto/sha1-browser@5.2.0':
-    dependencies:
-      '@aws-crypto/supports-web-crypto': 5.2.0
-      '@aws-crypto/util': 5.2.0
-      '@aws-sdk/types': 3.973.6
-      '@aws-sdk/util-locate-window': 3.965.5
-      '@smithy/util-utf8': 2.3.0
-      tslib: 2.8.1
-
-  '@aws-crypto/sha256-browser@5.2.0':
-    dependencies:
-      '@aws-crypto/sha256-js': 5.2.0
-      '@aws-crypto/supports-web-crypto': 5.2.0
-      '@aws-crypto/util': 5.2.0
-      '@aws-sdk/types': 3.973.6
-      '@aws-sdk/util-locate-window': 3.965.5
-      '@smithy/util-utf8': 2.3.0
-      tslib: 2.8.1
-
-  '@aws-crypto/sha256-js@5.2.0':
-    dependencies:
-      '@aws-crypto/util': 5.2.0
-      '@aws-sdk/types': 3.973.6
-      tslib: 2.8.1
-
-  '@aws-crypto/supports-web-crypto@5.2.0':
-    dependencies:
-      tslib: 2.8.1
-
-  '@aws-crypto/util@5.2.0':
-    dependencies:
-      '@aws-sdk/types': 3.973.6
-      '@smithy/util-utf8': 2.3.0
-      tslib: 2.8.1
-
-  '@aws-sdk/client-s3@3.1009.0':
-    dependencies:
-      '@aws-crypto/sha1-browser': 5.2.0
-      '@aws-crypto/sha256-browser': 5.2.0
-      '@aws-crypto/sha256-js': 5.2.0
-      '@aws-sdk/core': 3.973.20
-      '@aws-sdk/credential-provider-node': 3.972.21
-      '@aws-sdk/middleware-bucket-endpoint': 3.972.8
-      '@aws-sdk/middleware-expect-continue': 3.972.8
-      '@aws-sdk/middleware-flexible-checksums': 3.973.6
-      '@aws-sdk/middleware-host-header': 3.972.8
-      '@aws-sdk/middleware-location-constraint': 3.972.8
-      '@aws-sdk/middleware-logger': 3.972.8
-      '@aws-sdk/middleware-recursion-detection': 3.972.8
-      '@aws-sdk/middleware-sdk-s3': 3.972.20
-      '@aws-sdk/middleware-ssec': 3.972.8
-      '@aws-sdk/middleware-user-agent': 3.972.21
-      '@aws-sdk/region-config-resolver': 3.972.8
-      '@aws-sdk/signature-v4-multi-region': 3.996.8
-      '@aws-sdk/types': 3.973.6
-      '@aws-sdk/util-endpoints': 3.996.5
-      '@aws-sdk/util-user-agent-browser': 3.972.8
-      '@aws-sdk/util-user-agent-node': 3.973.7
-      '@smithy/config-resolver': 4.4.11
-      '@smithy/core': 3.23.11
-      '@smithy/eventstream-serde-browser': 4.2.12
-      '@smithy/eventstream-serde-config-resolver': 4.3.12
-      '@smithy/eventstream-serde-node': 4.2.12
-      '@smithy/fetch-http-handler': 5.3.15
-      '@smithy/hash-blob-browser': 4.2.13
-      '@smithy/hash-node': 4.2.12
-      '@smithy/hash-stream-node': 4.2.12
-      '@smithy/invalid-dependency': 4.2.12
-      '@smithy/md5-js': 4.2.12
-      '@smithy/middleware-content-length': 4.2.12
-      '@smithy/middleware-endpoint': 4.4.25
-      '@smithy/middleware-retry': 4.4.42
-      '@smithy/middleware-serde': 4.2.14
-      '@smithy/middleware-stack': 4.2.12
-      '@smithy/node-config-provider': 4.3.12
-      '@smithy/node-http-handler': 4.4.16
-      '@smithy/protocol-http': 5.3.12
-      '@smithy/smithy-client': 4.12.5
-      '@smithy/types': 4.13.1
-      '@smithy/url-parser': 4.2.12
-      '@smithy/util-base64': 4.3.2
-      '@smithy/util-body-length-browser': 4.2.2
-      '@smithy/util-body-length-node': 4.2.3
-      '@smithy/util-defaults-mode-browser': 4.3.41
-      '@smithy/util-defaults-mode-node': 4.2.44
-      '@smithy/util-endpoints': 3.3.3
-      '@smithy/util-middleware': 4.2.12
-      '@smithy/util-retry': 4.2.12
-      '@smithy/util-stream': 4.5.19
-      '@smithy/util-utf8': 4.2.2
-      '@smithy/util-waiter': 4.2.13
-      tslib: 2.8.1
-    transitivePeerDependencies:
-      - aws-crt
-
-  '@aws-sdk/core@3.973.20':
-    dependencies:
-      '@aws-sdk/types': 3.973.6
-      '@aws-sdk/xml-builder': 3.972.11
-      '@smithy/core': 3.23.11
-      '@smithy/node-config-provider': 4.3.12
-      '@smithy/property-provider': 4.2.12
-      '@smithy/protocol-http': 5.3.12
-      '@smithy/signature-v4': 5.3.12
-      '@smithy/smithy-client': 4.12.5
-      '@smithy/types': 4.13.1
-      '@smithy/util-base64': 4.3.2
-      '@smithy/util-middleware': 4.2.12
-      '@smithy/util-utf8': 4.2.2
-      tslib: 2.8.1
-
-  '@aws-sdk/crc64-nvme@3.972.5':
-    dependencies:
-      '@smithy/types': 4.13.1
-      tslib: 2.8.1
-
-  '@aws-sdk/credential-provider-env@3.972.18':
-    dependencies:
-      '@aws-sdk/core': 3.973.20
-      '@aws-sdk/types': 3.973.6
-      '@smithy/property-provider': 4.2.12
-      '@smithy/types': 4.13.1
-      tslib: 2.8.1
-
-  '@aws-sdk/credential-provider-http@3.972.20':
-    dependencies:
-      '@aws-sdk/core': 3.973.20
-      '@aws-sdk/types': 3.973.6
-      '@smithy/fetch-http-handler': 5.3.15
-      '@smithy/node-http-handler': 4.4.16
-      '@smithy/property-provider': 4.2.12
-      '@smithy/protocol-http': 5.3.12
-      '@smithy/smithy-client': 4.12.5
-      '@smithy/types': 4.13.1
-      '@smithy/util-stream': 4.5.19
-      tslib: 2.8.1
-
-  '@aws-sdk/credential-provider-ini@3.972.20':
-    dependencies:
-      '@aws-sdk/core': 3.973.20
-      '@aws-sdk/credential-provider-env': 3.972.18
-      '@aws-sdk/credential-provider-http': 3.972.20
-      '@aws-sdk/credential-provider-login': 3.972.20
-      '@aws-sdk/credential-provider-process': 3.972.18
-      '@aws-sdk/credential-provider-sso': 3.972.20
-      '@aws-sdk/credential-provider-web-identity': 3.972.20
-      '@aws-sdk/nested-clients': 3.996.10
-      '@aws-sdk/types': 3.973.6
-      '@smithy/credential-provider-imds': 4.2.12
-      '@smithy/property-provider': 4.2.12
-      '@smithy/shared-ini-file-loader': 4.4.7
-      '@smithy/types': 4.13.1
-      tslib: 2.8.1
-    transitivePeerDependencies:
-      - aws-crt
-
-  '@aws-sdk/credential-provider-login@3.972.20':
-    dependencies:
-      '@aws-sdk/core': 3.973.20
-      '@aws-sdk/nested-clients': 3.996.10
-      '@aws-sdk/types': 3.973.6
-      '@smithy/property-provider': 4.2.12
-      '@smithy/protocol-http': 5.3.12
-      '@smithy/shared-ini-file-loader': 4.4.7
-      '@smithy/types': 4.13.1
-      tslib: 2.8.1
-    transitivePeerDependencies:
-      - aws-crt
-
-  '@aws-sdk/credential-provider-node@3.972.21':
-    dependencies:
-      '@aws-sdk/credential-provider-env': 3.972.18
-      '@aws-sdk/credential-provider-http': 3.972.20
-      '@aws-sdk/credential-provider-ini': 3.972.20
-      '@aws-sdk/credential-provider-process': 3.972.18
-      '@aws-sdk/credential-provider-sso': 3.972.20
-      '@aws-sdk/credential-provider-web-identity': 3.972.20
-      '@aws-sdk/types': 3.973.6
-      '@smithy/credential-provider-imds': 4.2.12
-      '@smithy/property-provider': 4.2.12
-      '@smithy/shared-ini-file-loader': 4.4.7
-      '@smithy/types': 4.13.1
-      tslib: 2.8.1
-    transitivePeerDependencies:
-      - aws-crt
-
-  '@aws-sdk/credential-provider-process@3.972.18':
-    dependencies:
-      '@aws-sdk/core': 3.973.20
-      '@aws-sdk/types': 3.973.6
-      '@smithy/property-provider': 4.2.12
-      '@smithy/shared-ini-file-loader': 4.4.7
-      '@smithy/types': 4.13.1
-      tslib: 2.8.1
-
-  '@aws-sdk/credential-provider-sso@3.972.20':
-    dependencies:
-      '@aws-sdk/core': 3.973.20
-      '@aws-sdk/nested-clients': 3.996.10
-      '@aws-sdk/token-providers': 3.1009.0
-      '@aws-sdk/types': 3.973.6
-      '@smithy/property-provider': 4.2.12
-      '@smithy/shared-ini-file-loader': 4.4.7
-      '@smithy/types': 4.13.1
-      tslib: 2.8.1
-    transitivePeerDependencies:
-      - aws-crt
-
-  '@aws-sdk/credential-provider-web-identity@3.972.20':
-    dependencies:
-      '@aws-sdk/core': 3.973.20
-      '@aws-sdk/nested-clients': 3.996.10
-      '@aws-sdk/types': 3.973.6
-      '@smithy/property-provider': 4.2.12
-      '@smithy/shared-ini-file-loader': 4.4.7
-      '@smithy/types': 4.13.1
-      tslib: 2.8.1
-    transitivePeerDependencies:
-      - aws-crt
-
-  '@aws-sdk/middleware-bucket-endpoint@3.972.8':
-    dependencies:
-      '@aws-sdk/types': 3.973.6
-      '@aws-sdk/util-arn-parser': 3.972.3
-      '@smithy/node-config-provider': 4.3.12
-      '@smithy/protocol-http': 5.3.12
-      '@smithy/types': 4.13.1
-      '@smithy/util-config-provider': 4.2.2
-      tslib: 2.8.1
-
-  '@aws-sdk/middleware-expect-continue@3.972.8':
-    dependencies:
-      '@aws-sdk/types': 3.973.6
-      '@smithy/protocol-http': 5.3.12
-      '@smithy/types': 4.13.1
-      tslib: 2.8.1
-
-  '@aws-sdk/middleware-flexible-checksums@3.973.6':
-    dependencies:
-      '@aws-crypto/crc32': 5.2.0
-      '@aws-crypto/crc32c': 5.2.0
-      '@aws-crypto/util': 5.2.0
-      '@aws-sdk/core': 3.973.20
-      '@aws-sdk/crc64-nvme': 3.972.5
-      '@aws-sdk/types': 3.973.6
-      '@smithy/is-array-buffer': 4.2.2
-      '@smithy/node-config-provider': 4.3.12
-      '@smithy/protocol-http': 5.3.12
-      '@smithy/types': 4.13.1
-      '@smithy/util-middleware': 4.2.12
-      '@smithy/util-stream': 4.5.19
-      '@smithy/util-utf8': 4.2.2
-      tslib: 2.8.1
-
-  '@aws-sdk/middleware-host-header@3.972.8':
-    dependencies:
-      '@aws-sdk/types': 3.973.6
-      '@smithy/protocol-http': 5.3.12
-      '@smithy/types': 4.13.1
-      tslib: 2.8.1
-
-  '@aws-sdk/middleware-location-constraint@3.972.8':
-    dependencies:
-      '@aws-sdk/types': 3.973.6
-      '@smithy/types': 4.13.1
-      tslib: 2.8.1
-
-  '@aws-sdk/middleware-logger@3.972.8':
-    dependencies:
-      '@aws-sdk/types': 3.973.6
-      '@smithy/types': 4.13.1
-      tslib: 2.8.1
-
-  '@aws-sdk/middleware-recursion-detection@3.972.8':
-    dependencies:
-      '@aws-sdk/types': 3.973.6
-      '@aws/lambda-invoke-store': 0.2.4
-      '@smithy/protocol-http': 5.3.12
-      '@smithy/types': 4.13.1
-      tslib: 2.8.1
-
-  '@aws-sdk/middleware-sdk-s3@3.972.20':
-    dependencies:
-      '@aws-sdk/core': 3.973.20
-      '@aws-sdk/types': 3.973.6
-      '@aws-sdk/util-arn-parser': 3.972.3
-      '@smithy/core': 3.23.11
-      '@smithy/node-config-provider': 4.3.12
-      '@smithy/protocol-http': 5.3.12
-      '@smithy/signature-v4': 5.3.12
-      '@smithy/smithy-client': 4.12.5
-      '@smithy/types': 4.13.1
-      '@smithy/util-config-provider': 4.2.2
-      '@smithy/util-middleware': 4.2.12
-      '@smithy/util-stream': 4.5.19
-      '@smithy/util-utf8': 4.2.2
-      tslib: 2.8.1
-
-  '@aws-sdk/middleware-ssec@3.972.8':
-    dependencies:
-      '@aws-sdk/types': 3.973.6
-      '@smithy/types': 4.13.1
-      tslib: 2.8.1
-
-  '@aws-sdk/middleware-user-agent@3.972.21':
-    dependencies:
-      '@aws-sdk/core': 3.973.20
-      '@aws-sdk/types': 3.973.6
-      '@aws-sdk/util-endpoints': 3.996.5
-      '@smithy/core': 3.23.11
-      '@smithy/protocol-http': 5.3.12
-      '@smithy/types': 4.13.1
-      '@smithy/util-retry': 4.2.12
-      tslib: 2.8.1
-
-  '@aws-sdk/nested-clients@3.996.10':
-    dependencies:
-      '@aws-crypto/sha256-browser': 5.2.0
-      '@aws-crypto/sha256-js': 5.2.0
-      '@aws-sdk/core': 3.973.20
-      '@aws-sdk/middleware-host-header': 3.972.8
-      '@aws-sdk/middleware-logger': 3.972.8
-      '@aws-sdk/middleware-recursion-detection': 3.972.8
-      '@aws-sdk/middleware-user-agent': 3.972.21
-      '@aws-sdk/region-config-resolver': 3.972.8
-      '@aws-sdk/types': 3.973.6
-      '@aws-sdk/util-endpoints': 3.996.5
-      '@aws-sdk/util-user-agent-browser': 3.972.8
-      '@aws-sdk/util-user-agent-node': 3.973.7
-      '@smithy/config-resolver': 4.4.11
-      '@smithy/core': 3.23.11
-      '@smithy/fetch-http-handler': 5.3.15
-      '@smithy/hash-node': 4.2.12
-      '@smithy/invalid-dependency': 4.2.12
-      '@smithy/middleware-content-length': 4.2.12
-      '@smithy/middleware-endpoint': 4.4.25
-      '@smithy/middleware-retry': 4.4.42
-      '@smithy/middleware-serde': 4.2.14
-      '@smithy/middleware-stack': 4.2.12
-      '@smithy/node-config-provider': 4.3.12
-      '@smithy/node-http-handler': 4.4.16
-      '@smithy/protocol-http': 5.3.12
-      '@smithy/smithy-client': 4.12.5
-      '@smithy/types': 4.13.1
-      '@smithy/url-parser': 4.2.12
-      '@smithy/util-base64': 4.3.2
-      '@smithy/util-body-length-browser': 4.2.2
-      '@smithy/util-body-length-node': 4.2.3
-      '@smithy/util-defaults-mode-browser': 4.3.41
-      '@smithy/util-defaults-mode-node': 4.2.44
-      '@smithy/util-endpoints': 3.3.3
-      '@smithy/util-middleware': 4.2.12
-      '@smithy/util-retry': 4.2.12
-      '@smithy/util-utf8': 4.2.2
-      tslib: 2.8.1
-    transitivePeerDependencies:
-      - aws-crt
-
-  '@aws-sdk/region-config-resolver@3.972.8':
-    dependencies:
-      '@aws-sdk/types': 3.973.6
-      '@smithy/config-resolver': 4.4.11
-      '@smithy/node-config-provider': 4.3.12
-      '@smithy/types': 4.13.1
-      tslib: 2.8.1
-
-  '@aws-sdk/signature-v4-multi-region@3.996.8':
-    dependencies:
-      '@aws-sdk/middleware-sdk-s3': 3.972.20
-      '@aws-sdk/types': 3.973.6
-      '@smithy/protocol-http': 5.3.12
-      '@smithy/signature-v4': 5.3.12
-      '@smithy/types': 4.13.1
-      tslib: 2.8.1
-
-  '@aws-sdk/token-providers@3.1009.0':
-    dependencies:
-      '@aws-sdk/core': 3.973.20
-      '@aws-sdk/nested-clients': 3.996.10
-      '@aws-sdk/types': 3.973.6
-      '@smithy/property-provider': 4.2.12
-      '@smithy/shared-ini-file-loader': 4.4.7
-      '@smithy/types': 4.13.1
-      tslib: 2.8.1
-    transitivePeerDependencies:
-      - aws-crt
-
-  '@aws-sdk/types@3.973.6':
-    dependencies:
-      '@smithy/types': 4.13.1
-      tslib: 2.8.1
-
-  '@aws-sdk/util-arn-parser@3.972.3':
-    dependencies:
-      tslib: 2.8.1
-
-  '@aws-sdk/util-endpoints@3.996.5':
-    dependencies:
-      '@aws-sdk/types': 3.973.6
-      '@smithy/types': 4.13.1
-      '@smithy/url-parser': 4.2.12
-      '@smithy/util-endpoints': 3.3.3
-      tslib: 2.8.1
-
-  '@aws-sdk/util-locate-window@3.965.5':
-    dependencies:
-      tslib: 2.8.1
-
-  '@aws-sdk/util-user-agent-browser@3.972.8':
-    dependencies:
-      '@aws-sdk/types': 3.973.6
-      '@smithy/types': 4.13.1
-      bowser: 2.14.1
-      tslib: 2.8.1
-
-  '@aws-sdk/util-user-agent-node@3.973.7':
-    dependencies:
-      '@aws-sdk/middleware-user-agent': 3.972.21
-      '@aws-sdk/types': 3.973.6
-      '@smithy/node-config-provider': 4.3.12
-      '@smithy/types': 4.13.1
-      '@smithy/util-config-provider': 4.2.2
-      tslib: 2.8.1
-
-  '@aws-sdk/xml-builder@3.972.11':
-    dependencies:
-      '@smithy/types': 4.13.1
-      fast-xml-parser: 5.4.1
-      tslib: 2.8.1
-
-  '@aws/lambda-invoke-store@0.2.4': {}
 
   '@esbuild/aix-ppc64@0.27.4':
     optional: true
@@ -3140,345 +2310,6 @@ snapshots:
 
   '@sindresorhus/is@4.6.0': {}
 
-  '@smithy/abort-controller@4.2.12':
-    dependencies:
-      '@smithy/types': 4.13.1
-      tslib: 2.8.1
-
-  '@smithy/chunked-blob-reader-native@4.2.3':
-    dependencies:
-      '@smithy/util-base64': 4.3.2
-      tslib: 2.8.1
-
-  '@smithy/chunked-blob-reader@5.2.2':
-    dependencies:
-      tslib: 2.8.1
-
-  '@smithy/config-resolver@4.4.11':
-    dependencies:
-      '@smithy/node-config-provider': 4.3.12
-      '@smithy/types': 4.13.1
-      '@smithy/util-config-provider': 4.2.2
-      '@smithy/util-endpoints': 3.3.3
-      '@smithy/util-middleware': 4.2.12
-      tslib: 2.8.1
-
-  '@smithy/core@3.23.11':
-    dependencies:
-      '@smithy/protocol-http': 5.3.12
-      '@smithy/types': 4.13.1
-      '@smithy/url-parser': 4.2.12
-      '@smithy/util-base64': 4.3.2
-      '@smithy/util-body-length-browser': 4.2.2
-      '@smithy/util-middleware': 4.2.12
-      '@smithy/util-stream': 4.5.19
-      '@smithy/util-utf8': 4.2.2
-      '@smithy/uuid': 1.1.2
-      tslib: 2.8.1
-
-  '@smithy/credential-provider-imds@4.2.12':
-    dependencies:
-      '@smithy/node-config-provider': 4.3.12
-      '@smithy/property-provider': 4.2.12
-      '@smithy/types': 4.13.1
-      '@smithy/url-parser': 4.2.12
-      tslib: 2.8.1
-
-  '@smithy/eventstream-codec@4.2.12':
-    dependencies:
-      '@aws-crypto/crc32': 5.2.0
-      '@smithy/types': 4.13.1
-      '@smithy/util-hex-encoding': 4.2.2
-      tslib: 2.8.1
-
-  '@smithy/eventstream-serde-browser@4.2.12':
-    dependencies:
-      '@smithy/eventstream-serde-universal': 4.2.12
-      '@smithy/types': 4.13.1
-      tslib: 2.8.1
-
-  '@smithy/eventstream-serde-config-resolver@4.3.12':
-    dependencies:
-      '@smithy/types': 4.13.1
-      tslib: 2.8.1
-
-  '@smithy/eventstream-serde-node@4.2.12':
-    dependencies:
-      '@smithy/eventstream-serde-universal': 4.2.12
-      '@smithy/types': 4.13.1
-      tslib: 2.8.1
-
-  '@smithy/eventstream-serde-universal@4.2.12':
-    dependencies:
-      '@smithy/eventstream-codec': 4.2.12
-      '@smithy/types': 4.13.1
-      tslib: 2.8.1
-
-  '@smithy/fetch-http-handler@5.3.15':
-    dependencies:
-      '@smithy/protocol-http': 5.3.12
-      '@smithy/querystring-builder': 4.2.12
-      '@smithy/types': 4.13.1
-      '@smithy/util-base64': 4.3.2
-      tslib: 2.8.1
-
-  '@smithy/hash-blob-browser@4.2.13':
-    dependencies:
-      '@smithy/chunked-blob-reader': 5.2.2
-      '@smithy/chunked-blob-reader-native': 4.2.3
-      '@smithy/types': 4.13.1
-      tslib: 2.8.1
-
-  '@smithy/hash-node@4.2.12':
-    dependencies:
-      '@smithy/types': 4.13.1
-      '@smithy/util-buffer-from': 4.2.2
-      '@smithy/util-utf8': 4.2.2
-      tslib: 2.8.1
-
-  '@smithy/hash-stream-node@4.2.12':
-    dependencies:
-      '@smithy/types': 4.13.1
-      '@smithy/util-utf8': 4.2.2
-      tslib: 2.8.1
-
-  '@smithy/invalid-dependency@4.2.12':
-    dependencies:
-      '@smithy/types': 4.13.1
-      tslib: 2.8.1
-
-  '@smithy/is-array-buffer@2.2.0':
-    dependencies:
-      tslib: 2.8.1
-
-  '@smithy/is-array-buffer@4.2.2':
-    dependencies:
-      tslib: 2.8.1
-
-  '@smithy/md5-js@4.2.12':
-    dependencies:
-      '@smithy/types': 4.13.1
-      '@smithy/util-utf8': 4.2.2
-      tslib: 2.8.1
-
-  '@smithy/middleware-content-length@4.2.12':
-    dependencies:
-      '@smithy/protocol-http': 5.3.12
-      '@smithy/types': 4.13.1
-      tslib: 2.8.1
-
-  '@smithy/middleware-endpoint@4.4.25':
-    dependencies:
-      '@smithy/core': 3.23.11
-      '@smithy/middleware-serde': 4.2.14
-      '@smithy/node-config-provider': 4.3.12
-      '@smithy/shared-ini-file-loader': 4.4.7
-      '@smithy/types': 4.13.1
-      '@smithy/url-parser': 4.2.12
-      '@smithy/util-middleware': 4.2.12
-      tslib: 2.8.1
-
-  '@smithy/middleware-retry@4.4.42':
-    dependencies:
-      '@smithy/node-config-provider': 4.3.12
-      '@smithy/protocol-http': 5.3.12
-      '@smithy/service-error-classification': 4.2.12
-      '@smithy/smithy-client': 4.12.5
-      '@smithy/types': 4.13.1
-      '@smithy/util-middleware': 4.2.12
-      '@smithy/util-retry': 4.2.12
-      '@smithy/uuid': 1.1.2
-      tslib: 2.8.1
-
-  '@smithy/middleware-serde@4.2.14':
-    dependencies:
-      '@smithy/core': 3.23.11
-      '@smithy/protocol-http': 5.3.12
-      '@smithy/types': 4.13.1
-      tslib: 2.8.1
-
-  '@smithy/middleware-stack@4.2.12':
-    dependencies:
-      '@smithy/types': 4.13.1
-      tslib: 2.8.1
-
-  '@smithy/node-config-provider@4.3.12':
-    dependencies:
-      '@smithy/property-provider': 4.2.12
-      '@smithy/shared-ini-file-loader': 4.4.7
-      '@smithy/types': 4.13.1
-      tslib: 2.8.1
-
-  '@smithy/node-http-handler@4.4.16':
-    dependencies:
-      '@smithy/abort-controller': 4.2.12
-      '@smithy/protocol-http': 5.3.12
-      '@smithy/querystring-builder': 4.2.12
-      '@smithy/types': 4.13.1
-      tslib: 2.8.1
-
-  '@smithy/property-provider@4.2.12':
-    dependencies:
-      '@smithy/types': 4.13.1
-      tslib: 2.8.1
-
-  '@smithy/protocol-http@5.3.12':
-    dependencies:
-      '@smithy/types': 4.13.1
-      tslib: 2.8.1
-
-  '@smithy/querystring-builder@4.2.12':
-    dependencies:
-      '@smithy/types': 4.13.1
-      '@smithy/util-uri-escape': 4.2.2
-      tslib: 2.8.1
-
-  '@smithy/querystring-parser@4.2.12':
-    dependencies:
-      '@smithy/types': 4.13.1
-      tslib: 2.8.1
-
-  '@smithy/service-error-classification@4.2.12':
-    dependencies:
-      '@smithy/types': 4.13.1
-
-  '@smithy/shared-ini-file-loader@4.4.7':
-    dependencies:
-      '@smithy/types': 4.13.1
-      tslib: 2.8.1
-
-  '@smithy/signature-v4@5.3.12':
-    dependencies:
-      '@smithy/is-array-buffer': 4.2.2
-      '@smithy/protocol-http': 5.3.12
-      '@smithy/types': 4.13.1
-      '@smithy/util-hex-encoding': 4.2.2
-      '@smithy/util-middleware': 4.2.12
-      '@smithy/util-uri-escape': 4.2.2
-      '@smithy/util-utf8': 4.2.2
-      tslib: 2.8.1
-
-  '@smithy/smithy-client@4.12.5':
-    dependencies:
-      '@smithy/core': 3.23.11
-      '@smithy/middleware-endpoint': 4.4.25
-      '@smithy/middleware-stack': 4.2.12
-      '@smithy/protocol-http': 5.3.12
-      '@smithy/types': 4.13.1
-      '@smithy/util-stream': 4.5.19
-      tslib: 2.8.1
-
-  '@smithy/types@4.13.1':
-    dependencies:
-      tslib: 2.8.1
-
-  '@smithy/url-parser@4.2.12':
-    dependencies:
-      '@smithy/querystring-parser': 4.2.12
-      '@smithy/types': 4.13.1
-      tslib: 2.8.1
-
-  '@smithy/util-base64@4.3.2':
-    dependencies:
-      '@smithy/util-buffer-from': 4.2.2
-      '@smithy/util-utf8': 4.2.2
-      tslib: 2.8.1
-
-  '@smithy/util-body-length-browser@4.2.2':
-    dependencies:
-      tslib: 2.8.1
-
-  '@smithy/util-body-length-node@4.2.3':
-    dependencies:
-      tslib: 2.8.1
-
-  '@smithy/util-buffer-from@2.2.0':
-    dependencies:
-      '@smithy/is-array-buffer': 2.2.0
-      tslib: 2.8.1
-
-  '@smithy/util-buffer-from@4.2.2':
-    dependencies:
-      '@smithy/is-array-buffer': 4.2.2
-      tslib: 2.8.1
-
-  '@smithy/util-config-provider@4.2.2':
-    dependencies:
-      tslib: 2.8.1
-
-  '@smithy/util-defaults-mode-browser@4.3.41':
-    dependencies:
-      '@smithy/property-provider': 4.2.12
-      '@smithy/smithy-client': 4.12.5
-      '@smithy/types': 4.13.1
-      tslib: 2.8.1
-
-  '@smithy/util-defaults-mode-node@4.2.44':
-    dependencies:
-      '@smithy/config-resolver': 4.4.11
-      '@smithy/credential-provider-imds': 4.2.12
-      '@smithy/node-config-provider': 4.3.12
-      '@smithy/property-provider': 4.2.12
-      '@smithy/smithy-client': 4.12.5
-      '@smithy/types': 4.13.1
-      tslib: 2.8.1
-
-  '@smithy/util-endpoints@3.3.3':
-    dependencies:
-      '@smithy/node-config-provider': 4.3.12
-      '@smithy/types': 4.13.1
-      tslib: 2.8.1
-
-  '@smithy/util-hex-encoding@4.2.2':
-    dependencies:
-      tslib: 2.8.1
-
-  '@smithy/util-middleware@4.2.12':
-    dependencies:
-      '@smithy/types': 4.13.1
-      tslib: 2.8.1
-
-  '@smithy/util-retry@4.2.12':
-    dependencies:
-      '@smithy/service-error-classification': 4.2.12
-      '@smithy/types': 4.13.1
-      tslib: 2.8.1
-
-  '@smithy/util-stream@4.5.19':
-    dependencies:
-      '@smithy/fetch-http-handler': 5.3.15
-      '@smithy/node-http-handler': 4.4.16
-      '@smithy/types': 4.13.1
-      '@smithy/util-base64': 4.3.2
-      '@smithy/util-buffer-from': 4.2.2
-      '@smithy/util-hex-encoding': 4.2.2
-      '@smithy/util-utf8': 4.2.2
-      tslib: 2.8.1
-
-  '@smithy/util-uri-escape@4.2.2':
-    dependencies:
-      tslib: 2.8.1
-
-  '@smithy/util-utf8@2.3.0':
-    dependencies:
-      '@smithy/util-buffer-from': 2.2.0
-      tslib: 2.8.1
-
-  '@smithy/util-utf8@4.2.2':
-    dependencies:
-      '@smithy/util-buffer-from': 4.2.2
-      tslib: 2.8.1
-
-  '@smithy/util-waiter@4.2.13':
-    dependencies:
-      '@smithy/abort-controller': 4.2.12
-      '@smithy/types': 4.13.1
-      tslib: 2.8.1
-
-  '@smithy/uuid@1.1.2':
-    dependencies:
-      tslib: 2.8.1
-
   '@standard-schema/spec@1.1.0': {}
 
   '@szmarczak/http-timer@4.0.6':
@@ -3655,8 +2486,6 @@ snapshots:
       read-cmd-shim: 6.0.0
       write-file-atomic: 7.0.1
 
-  bowser@2.14.1: {}
-
   brace-expansion@2.0.2:
     dependencies:
       balanced-match: 1.0.2
@@ -3806,15 +2635,6 @@ snapshots:
   expect-type@1.3.0: {}
 
   exponential-backoff@3.1.3: {}
-
-  fast-xml-builder@1.1.3:
-    dependencies:
-      path-expression-matcher: 1.1.3
-
-  fast-xml-parser@5.4.1:
-    dependencies:
-      fast-xml-builder: 1.1.3
-      strnum: 2.2.0
 
   fdir@6.5.0(picomatch@4.0.3):
     optionalDependencies:
@@ -4227,8 +3047,6 @@ snapshots:
       just-diff: 6.0.2
       just-diff-apply: 5.5.0
 
-  path-expression-matcher@1.1.3: {}
-
   path-key@3.1.1: {}
 
   path-parse@1.0.7: {}
@@ -4471,8 +3289,6 @@ snapshots:
 
   strip-final-newline@2.0.0: {}
 
-  strnum@2.2.0: {}
-
   supports-preserve-symlinks-flag@1.0.0: {}
 
   tar@7.5.13:
@@ -4497,8 +3313,6 @@ snapshots:
   tmp@0.2.5: {}
 
   treeverse@3.0.0: {}
-
-  tslib@2.8.1: {}
 
   tuf-js@4.1.0:
     dependencies:


### PR DESCRIPTION
## Summary

- Expands ADR-014 to make the R2/WorkerSite boundary explicit.
- Moves R2 upload exports from `@jmmaloney4/sector7/workersite/r2` to the sibling `@jmmaloney4/sector7/r2` subpath.
- Adds `uploadStaticAssets()` as a static-site convenience wrapper over `uploadAssets()`.
- Updates package exports, docs, barrel guards, tests, and the pnpm lock/hash.

## Architecture alignment

- Keeps `WorkerSite` infrastructure-only: Worker, custom domains, Access, cache/redirect/observability, and R2 bucket binding.
- Moves object upload lifecycle concerns into the sibling `r2` module so upload primitives are reusable and explicitly opted into.
- Preserves the loud boundary: `workersite` does not re-export R2 upload symbols, and the barrel guard fails if they leak back in.

## Validation

- `nix develop --command /tmp/toolbox-sector7-check.sh`
- `nix fmt`
- `nix flake check -L`

## Consumer impact

Consumers currently passing `assets` to `WorkerSite` should migrate directly to:

```ts
import { uploadStaticAssets } from "@jmmaloney4/sector7/r2";
```

Known consumers needing follow-up:

- `cavinsresearch/zeus`: `deploy/www/cavinsresearch.io/`
- `addendalabs/yard`: `deploy/www/addendalabs.com/`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk due to public API/import-path changes (`./workersite/r2` → `./r2`) and updated `uploadAssets` resource naming, which may trigger Pulumi replacements for existing uploaded objects if consumers migrate.
> 
> **Overview**
> **Decouples R2 upload helpers from `WorkerSite`** by removing the `@jmmaloney4/sector7/workersite/r2` export and introducing a sibling `@jmmaloney4/sector7/r2` subpath export.
> 
> Adds a new `r2` module that re-exports `R2Object` and upload helpers, including a new `uploadStaticAssets()` convenience wrapper for static-site directory uploads, and updates `uploadAssets()` to use key-hash-based resource names for stability.
> 
> Updates docs/tests/guards to enforce that `workersite` no longer re-exports R2 upload symbols, and drops the AWS SDK dependency from the lockfile (plus related Nix/pnpm hash updates).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3d2c9e91d3b8335bf5afa7e7bcbeba2527d27101. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->