### PR TITLE
Cap nix-fast-build parallelism at -j 2

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -24,13 +24,16 @@ on:
       REGISTRY_PASSWORD:
         description: 'Registry password/token (usually GITHUB_TOKEN)'
         required: false
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
+
 permissions:
   contents: read
   id-token: write
   packages: write
+
 jobs:
   detect:
     name: '☃️ detect flake outputs'
@@ -63,6 +66,7 @@ jobs:
           image_names=$(echo '${{ steps.compute.outputs.matrix_include }}' | jq -c '[ .[] | select(.is_image == true) | .name ]')
           echo "Found images: $image_names"
           echo "image_matrix=$image_names" >> "$GITHUB_OUTPUT"
+
   build:
     name: "👷‍♂️ ${{ matrix.category }}.${{ matrix.system }}.${{ matrix.name }}"
     needs: [detect]
@@ -89,7 +93,8 @@ jobs:
           attr='${{ matrix.flake_attr }}'
           echo "Building via nix-fast-build: $attr"
           # Build only missing (uncached) derivations, with CI-friendly logs and no out-link
-          nix-fast-build --skip-cached --no-nom --no-link --flake "$attr"
+          nix-fast-build --skip-cached --no-nom --no-link -j 2 --flake "$attr"
+
   push-images:
     name: "🐳 push ${{ matrix.package-name }}"
     needs: [detect, build]


### PR DESCRIPTION
## Why

Self-hosted ARC runner pods are being OOM-killed during `nix-fast-build` steps because parallel Nix derivations exceed the container memory limit (garden#487). The runner log shows the process vanishing mid-build with no error trace.

## What

Add `-j 2` to the `nix-fast-build` invocation to cap concurrent derivation builds at 2, reducing peak memory consumption. This is a belt-and-suspenders measure alongside the memory limit increase and PriorityClass changes in garden (ADR 045).

## Testing

- Existing CI callers are unaffected (no input changes).
- Peak memory for nix builds should roughly halve compared to unrestricted parallelism.

## Related

- ergodicsystems/hq#98 (work thread)
- jmmaloney4/garden#487 (runner lost communication -- root cause)
- Garden ADR 045 (CI runner PriorityClass + memory increase)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes GitHub Actions workflow behavior for Nix builds and image publishing; misconfiguration could impact CI throughput or when/what images are pushed, but scope is limited to CI.
> 
> **Overview**
> **Updates the reusable `nix` GitHub Actions workflow to be more CI-friendly and deterministic.** It adds workflow-level `concurrency` (cancel in-progress runs per ref/PR) and explicit `permissions` for checkout, OIDC, and package publishing.
> 
> The workflow now computes a list of image outputs to push and introduces a `push-images` matrix job that runs only when images are present. Nix builds are adjusted to cap `nix-fast-build` parallelism with `-j 2` to reduce runner memory pressure.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2bac76562ef452f2dcf082fd2734574fbf6072e4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->