### PR TITLE
fix(ci): require github-token for add-to-project workflow

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -22,6 +22,14 @@ on:
         required: false
         default: OR
         type: string
+    secrets:
+      github-token:
+        description: >-
+          Personal access token (classic or fine-grained) with `project` scope (classic)
+          or Projects read/write permission (fine-grained) on the target org.
+          GITHUB_TOKEN cannot be used because it is scoped to the triggering repository
+          and cannot access org-level GitHub Projects.
+        required: true
 permissions:
   contents: read
 jobs:
@@ -33,10 +41,12 @@ jobs:
         uses: actions/add-to-project@244f685bbc3b7adfa8466e08b698b5577571133e # v1.0.2
         with:
           project-url: ${{ inputs.project_url }}
+          github-token: ${{ secrets.github-token }}
       - name: Add issue or PR to project (label filter)
         if: inputs.labeled != ''
         uses: actions/add-to-project@244f685bbc3b7adfa8466e08b698b5577571133e # v1.0.2
         with:
           project-url: ${{ inputs.project_url }}
+          github-token: ${{ secrets.github-token }}
           labeled: ${{ inputs.labeled }}
           label-operator: ${{ inputs.label-operator }}


### PR DESCRIPTION
## Problem

The `add-to-project` reusable workflow calls `actions/add-to-project` without passing `github-token`, which is a required input. Every caller workflow fails with:

```
Input required and not supplied: github-token
```

## Root cause

`GITHUB_TOKEN` (auto-provisioned) is scoped to the triggering repository and **cannot access org-level GitHub Projects**. The `actions/add-to-project` action needs a token with org project write access via the GraphQL API. No amount of `permissions:` in the caller workflow will fix this — it is a fundamental scope limitation.

## Changes

- Declare `github-token` as a **required** `workflow_call` secret with a descriptive message explaining the permission requirements
- Pass `github-token` to both `actions/add-to-project` steps (labeled and unlabeled)

## Required token permissions

- **Classic PAT**: `project` scope
- **Fine-grained PAT**: Projects read/write on the target org

## Downstream impact

Caller workflows (e.g. `jmmaloney4/garden`) must be updated to pass the token:

```yaml
jobs:
  add-to-project:
    uses: jmmaloney4/toolbox/.github/workflows/add-to-project.yml@...
    secrets:
      github-token: ${{ secrets.PROJECTS_TOKEN }}
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk workflow wiring change, but it will break downstream callers until they pass the required secret and use a PAT with org Projects access.
> 
> **Overview**
> Fixes the reusable `add-to-project` workflow by **requiring a `github-token` secret** (with guidance on needed PAT permissions) and **passing it through** to `actions/add-to-project` in both the labeled and unlabeled paths so runs no longer fail on a missing required input.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d9d785ad9ec10283085054b11760c5a3cc7395fa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->