### PR TITLE
chore: rename repo references toolbox → sector7

### DIFF
--- a/.github/actions/pulumi-setup/action.yml
+++ b/.github/actions/pulumi-setup/action.yml
@@ -13,7 +13,7 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: jmmaloney4/toolbox/.github/actions/nix-setup@bc7846003f39ec61654d70f5cfd1413046b3b763 # main
+    - uses: jmmaloney4/sector7/.github/actions/nix-setup@bc7846003f39ec61654d70f5cfd1413046b3b763 # main
     - uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
       with:
         workload_identity_provider: ${{ inputs.google_workload_identity_provider }}

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,5 +1,5 @@
 {
   extends: [
-    "github>jmmaloney4/toolbox//renovate/all.json"
+    "github>jmmaloney4/sector7//renovate/all.json"
   ]
 }

--- a/.github/workflows/_dogfood-add-to-project.yml
+++ b/.github/workflows/_dogfood-add-to-project.yml
@@ -8,4 +8,4 @@ permissions:
   contents: read
 jobs:
   add-to-project:
-    uses: jmmaloney4/toolbox/.github/workflows/add-to-project.yml@bc7846003f39ec61654d70f5cfd1413046b3b763 # main
+    uses: jmmaloney4/sector7/.github/workflows/add-to-project.yml@bc7846003f39ec61654d70f5cfd1413046b3b763 # main

--- a/.github/workflows/_dogfood-adr-management.yml
+++ b/.github/workflows/_dogfood-adr-management.yml
@@ -8,7 +8,7 @@ permissions:
 jobs:
   adr-management:
     if: github.actor != 'github-actions[bot]'
-    uses: jmmaloney4/toolbox/.github/workflows/adr-management.yml@bc7846003f39ec61654d70f5cfd1413046b3b763 # main
+    uses: jmmaloney4/sector7/.github/workflows/adr-management.yml@bc7846003f39ec61654d70f5cfd1413046b3b763 # main
     with:
       repository: ${{ github.repository }}
       ref: refs/pull/${{ github.event.pull_request.number }}/head

--- a/.github/workflows/_dogfood-claude-review.yml
+++ b/.github/workflows/_dogfood-claude-review.yml
@@ -25,7 +25,7 @@ jobs:
        !contains(github.event.comment.body, 'no claude review') &&
        !contains(github.event.comment.body, 'disable claude review') &&
        !contains(github.event.comment.body, 'claude review is not needed'))
-    uses: jmmaloney4/toolbox/.github/workflows/claude-review.yml@bc7846003f39ec61654d70f5cfd1413046b3b763 # main
+    uses: jmmaloney4/sector7/.github/workflows/claude-review.yml@bc7846003f39ec61654d70f5cfd1413046b3b763 # main
     with:
       repository: ${{ github.repository }}
       ref: ${{ github.ref }}

--- a/.github/workflows/_dogfood-claude.yml
+++ b/.github/workflows/_dogfood-claude.yml
@@ -32,7 +32,7 @@ jobs:
         (contains(github.event.issue.title, '@claude') || contains(github.event.issue.title, '@Claude') || contains(github.event.issue.title, '@CLAUDE'))) &&
        !((contains(github.event.issue.body, 'claude review') || contains(github.event.issue.body, 'Claude review') || contains(github.event.issue.body, 'CLAUDE REVIEW')) ||
          (contains(github.event.issue.title, 'claude review') || contains(github.event.issue.title, 'Claude review') || contains(github.event.issue.title, 'CLAUDE REVIEW'))))
-    uses: jmmaloney4/toolbox/.github/workflows/claude.yml@bc7846003f39ec61654d70f5cfd1413046b3b763 # main
+    uses: jmmaloney4/sector7/.github/workflows/claude.yml@bc7846003f39ec61654d70f5cfd1413046b3b763 # main
     with:
       repository: ${{ github.repository }}
       ref: ${{ github.ref }}

--- a/.github/workflows/_dogfood-nix.yml
+++ b/.github/workflows/_dogfood-nix.yml
@@ -11,7 +11,7 @@ permissions:
   packages: write
 jobs:
   nix:
-    uses: jmmaloney4/toolbox/.github/workflows/nix.yml@bc7846003f39ec61654d70f5cfd1413046b3b763 # main
+    uses: jmmaloney4/sector7/.github/workflows/nix.yml@bc7846003f39ec61654d70f5cfd1413046b3b763 # main
     with:
       repository: ${{ github.repository }}
       ref: ${{ github.ref }}

--- a/.github/workflows/_dogfood-pnpm.yml
+++ b/.github/workflows/_dogfood-pnpm.yml
@@ -11,7 +11,7 @@ permissions:
   packages: write
 jobs:
   pnpm:
-    uses: jmmaloney4/toolbox/.github/workflows/pnpm.yml@bc7846003f39ec61654d70f5cfd1413046b3b763 # main
+    uses: jmmaloney4/sector7/.github/workflows/pnpm.yml@bc7846003f39ec61654d70f5cfd1413046b3b763 # main
     with:
       repository: ${{ github.repository }}
       ref: ${{ github.ref }}

--- a/.github/workflows/adr-management.yml
+++ b/.github/workflows/adr-management.yml
@@ -95,7 +95,7 @@ jobs:
           fi
       - name: Check ADR number conflicts
         id: check
-        uses: jmmaloney4/toolbox/.github/actions/check-adr-conflicts@bc7846003f39ec61654d70f5cfd1413046b3b763 # main
+        uses: jmmaloney4/sector7/.github/actions/check-adr-conflicts@bc7846003f39ec61654d70f5cfd1413046b3b763 # main
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ inputs.repository }}
@@ -106,7 +106,7 @@ jobs:
           pr_number: ${{ inputs.pr_number }}
       - name: Create and push placeholder to main
         if: steps.detect_new.outputs.has_new_adrs == 'true' && steps.check.outputs.has_conflict == 'false'
-        uses: jmmaloney4/toolbox/.github/actions/create-adr-placeholder@bc7846003f39ec61654d70f5cfd1413046b3b763 # main
+        uses: jmmaloney4/sector7/.github/actions/create-adr-placeholder@bc7846003f39ec61654d70f5cfd1413046b3b763 # main
         with:
           adr_files: /tmp/new_adrs.txt
           pr_url: ${{ inputs.pr_url }}

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -44,13 +44,13 @@ jobs:
         with:
           repository: ${{ inputs.repository }}
           ref: ${{ inputs.ref }}
-      - uses: jmmaloney4/toolbox/.github/actions/nix-setup@bc7846003f39ec61654d70f5cfd1413046b3b763 # main
+      - uses: jmmaloney4/sector7/.github/actions/nix-setup@bc7846003f39ec61654d70f5cfd1413046b3b763 # main
         with:
           runs-on: ${{ inputs.runs-on }}
           cache: ${{ !contains(inputs.runs-on, 'self-hosted') }}
       - name: compute build-needed matrix via nix-eval-jobs
         id: compute
-        uses: jmmaloney4/toolbox/.github/actions/compute-flake-build-matrix@bc7846003f39ec61654d70f5cfd1413046b3b763 # main
+        uses: jmmaloney4/sector7/.github/actions/compute-flake-build-matrix@bc7846003f39ec61654d70f5cfd1413046b3b763 # main
         with:
           probe-timeout-seconds: '180'
       - name: compute images to push
@@ -78,7 +78,7 @@ jobs:
         with:
           repository: ${{ inputs.repository }}
           ref: ${{ inputs.ref }}
-      - uses: jmmaloney4/toolbox/.github/actions/nix-setup@bc7846003f39ec61654d70f5cfd1413046b3b763 # main
+      - uses: jmmaloney4/sector7/.github/actions/nix-setup@bc7846003f39ec61654d70f5cfd1413046b3b763 # main
         with:
           runs-on: ${{ inputs.runs-on }}
           cache: ${{ !contains(inputs.runs-on, 'self-hosted') }}
@@ -99,7 +99,7 @@ jobs:
       fail-fast: false
       matrix:
         package-name: ${{ fromJson(needs.detect.outputs.images_to_push) }}
-    uses: jmmaloney4/toolbox/.github/workflows/push-nix-image.yml@bc7846003f39ec61654d70f5cfd1413046b3b763 # main
+    uses: jmmaloney4/sector7/.github/workflows/push-nix-image.yml@bc7846003f39ec61654d70f5cfd1413046b3b763 # main
     with:
       runs-on: ${{ inputs.runs-on }}
       package-name: ${{ matrix.package-name }}

--- a/.github/workflows/pnpm.yml
+++ b/.github/workflows/pnpm.yml
@@ -37,7 +37,7 @@ jobs:
           ref: ${{ inputs.ref }}
       - name: Analyze packages (GHCR + semver)
         id: analyze
-        uses: jmmaloney4/toolbox/.github/actions/analyze-pnpm-packages@bc7846003f39ec61654d70f5cfd1413046b3b763 # main
+        uses: jmmaloney4/sector7/.github/actions/analyze-pnpm-packages@bc7846003f39ec61654d70f5cfd1413046b3b763 # main
         with:
           dry_run: ${{ inputs.dry_run }}
         env:
@@ -62,7 +62,7 @@ jobs:
         with:
           repository: ${{ inputs.repository }}
           ref: ${{ inputs.ref }}
-      - uses: jmmaloney4/toolbox/.github/actions/nix-setup@bc7846003f39ec61654d70f5cfd1413046b3b763 # main
+      - uses: jmmaloney4/sector7/.github/actions/nix-setup@bc7846003f39ec61654d70f5cfd1413046b3b763 # main
         with:
           runs-on: ${{ inputs.runs-on }}
           cache: ${{ !contains(inputs.runs-on, 'self-hosted') }}
@@ -85,7 +85,7 @@ jobs:
         with:
           repository: ${{ inputs.repository }}
           ref: ${{ inputs.ref }}
-      - uses: jmmaloney4/toolbox/.github/actions/nix-setup@bc7846003f39ec61654d70f5cfd1413046b3b763 # main
+      - uses: jmmaloney4/sector7/.github/actions/nix-setup@bc7846003f39ec61654d70f5cfd1413046b3b763 # main
         with:
           runs-on: ${{ inputs.runs-on }}
           cache: ${{ !contains(inputs.runs-on, 'self-hosted') }}

--- a/.github/workflows/pulumi.yml
+++ b/.github/workflows/pulumi.yml
@@ -59,13 +59,13 @@ jobs:
         with:
           repository: ${{ inputs.repository }}
           ref: ${{ inputs.ref }}
-      - uses: jmmaloney4/toolbox/.github/actions/nix-setup@bc7846003f39ec61654d70f5cfd1413046b3b763 # main
+      - uses: jmmaloney4/sector7/.github/actions/nix-setup@bc7846003f39ec61654d70f5cfd1413046b3b763 # main
         with:
           runs-on: ${{ inputs.runs-on }}
           cache: ${{ !contains(inputs.runs-on, 'self-hosted') }}
       - name: Detect all (project, stack) pairs
         id: set-matrix
-        uses: jmmaloney4/toolbox/.github/actions/detect-pulumi-stacks@bc7846003f39ec61654d70f5cfd1413046b3b763 # main
+        uses: jmmaloney4/sector7/.github/actions/detect-pulumi-stacks@bc7846003f39ec61654d70f5cfd1413046b3b763 # main
         with:
           ignore_projects: ${{ inputs.ignore_projects }}
   pulumi-preview-and-deploy:
@@ -109,7 +109,7 @@ jobs:
               exit 1
               ;;
           esac
-      - uses: jmmaloney4/toolbox/.github/actions/pulumi-setup@bc7846003f39ec61654d70f5cfd1413046b3b763 # main
+      - uses: jmmaloney4/sector7/.github/actions/pulumi-setup@bc7846003f39ec61654d70f5cfd1413046b3b763 # main
         with:
           google_workload_identity_provider: ${{ inputs.google_workload_identity_provider }}
           google_service_account_email: ${{ inputs.google_service_account_email }}
@@ -139,7 +139,7 @@ jobs:
       - name: pulumi preview
         id: preview
         continue-on-error: true
-        uses: jmmaloney4/toolbox/.github/actions/pulumi-preview@bc7846003f39ec61654d70f5cfd1413046b3b763 # main
+        uses: jmmaloney4/sector7/.github/actions/pulumi-preview@bc7846003f39ec61654d70f5cfd1413046b3b763 # main
         with:
           project: ${{ matrix.project }}
           stack: ${{ matrix.stack }}

--- a/.github/workflows/push-nix-image.yml
+++ b/.github/workflows/push-nix-image.yml
@@ -61,12 +61,12 @@ jobs:
           repository: ${{ inputs.repository }}
           ref: ${{ inputs.ref }}
       - name: Install Nix
-        uses: jmmaloney4/toolbox/.github/actions/nix-setup@bc7846003f39ec61654d70f5cfd1413046b3b763 # main
+        uses: jmmaloney4/sector7/.github/actions/nix-setup@bc7846003f39ec61654d70f5cfd1413046b3b763 # main
         with:
           runs-on: ${{ inputs.runs-on }}
           cache: ${{ !contains(inputs.runs-on, 'self-hosted') }}
       - name: Push Nix Image
-        uses: jmmaloney4/toolbox/.github/actions/push-nix-image@bc7846003f39ec61654d70f5cfd1413046b3b763 # main
+        uses: jmmaloney4/sector7/.github/actions/push-nix-image@bc7846003f39ec61654d70f5cfd1413046b3b763 # main
         with:
           package-name: ${{ inputs.package-name }}
           registry: ${{ inputs.registry }}

--- a/.github/workflows/quarto.yml
+++ b/.github/workflows/quarto.yml
@@ -22,7 +22,7 @@ jobs:
       DIST: research/_site
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: jmmaloney4/toolbox/.github/actions/nix-setup@bc7846003f39ec61654d70f5cfd1413046b3b763 # main
+      - uses: jmmaloney4/sector7/.github/actions/nix-setup@bc7846003f39ec61654d70f5cfd1413046b3b763 # main
         with:
           runs-on: ${{ vars.ACTIONS_RUNS_ON }}
           cache: ${{ !contains(vars.ACTIONS_RUNS_ON, 'self-hosted') }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -31,7 +31,7 @@ jobs:
         with:
           repository: ${{ inputs.repository }}
           ref: ${{ inputs.ref }}
-      - uses: jmmaloney4/toolbox/.github/actions/nix-setup@bc7846003f39ec61654d70f5cfd1413046b3b763 # main
+      - uses: jmmaloney4/sector7/.github/actions/nix-setup@bc7846003f39ec61654d70f5cfd1413046b3b763 # main
         with:
           runs-on: ${{ inputs.runs-on }}
           cache: ${{ !contains(inputs.runs-on, 'self-hosted') }}
@@ -51,7 +51,7 @@ jobs:
         with:
           repository: ${{ inputs.repository }}
           ref: ${{ inputs.ref }}
-      - uses: jmmaloney4/toolbox/.github/actions/nix-setup@bc7846003f39ec61654d70f5cfd1413046b3b763 # main
+      - uses: jmmaloney4/sector7/.github/actions/nix-setup@bc7846003f39ec61654d70f5cfd1413046b3b763 # main
         with:
           runs-on: ${{ inputs.runs-on }}
           cache: ${{ !contains(inputs.runs-on, 'self-hosted') }}
@@ -85,7 +85,7 @@ jobs:
         with:
           repository: ${{ inputs.repository }}
           ref: ${{ inputs.ref }}
-      - uses: jmmaloney4/toolbox/.github/actions/nix-setup@bc7846003f39ec61654d70f5cfd1413046b3b763 # main
+      - uses: jmmaloney4/sector7/.github/actions/nix-setup@bc7846003f39ec61654d70f5cfd1413046b3b763 # main
         with:
           runs-on: ${{ inputs.runs-on }}
           cache: ${{ !contains(inputs.runs-on, 'self-hosted') }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -111,7 +111,7 @@ Calling from a workflow (reusable-safe):
 Do NOT use a local relative path (e.g., `./.github/actions/compute-example`) in reusable workflows. When this workflow is called from another repository, local paths may not resolve as intended. Always reference actions via repository path with a pinned ref:
 
 ```yaml
-- uses: jmmaloney4/toolbox/.github/actions/compute-example@main
+- uses: jmmaloney4/sector7/.github/actions/compute-example@main
 ```
 
 Guidelines:

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Use our reusable workflows in your repository:
 # Rust CI
 jobs:
   rust:
-    uses: jmmaloney4/toolbox/.github/workflows/rust.yml@main
+    uses: jmmaloney4/sector7/.github/workflows/rust.yml@main
     with:
       runs-on: ubuntu-latest
       repository: ${{ github.repository }}
@@ -27,7 +27,7 @@ jobs:
 # Nix builds
 jobs:
   nix-build:
-    uses: jmmaloney4/toolbox/.github/workflows/nix.yml@main
+    uses: jmmaloney4/sector7/.github/workflows/nix.yml@main
     with:
       runs-on: ubuntu-latest
       repository: ${{ github.repository }}
@@ -46,7 +46,7 @@ jobs:
             runs-on: '["self-hosted","linux","x64"]'
           - name: darwin
             runs-on: '["self-hosted","macos","arm64"]'
-    uses: jmmaloney4/toolbox/.github/workflows/nix.yml@main
+    uses: jmmaloney4/sector7/.github/workflows/nix.yml@main
     with:
       runs-on: ${{ matrix.runs-on }}
       repository: ${{ github.repository }}
@@ -81,7 +81,7 @@ Configure Renovate with our presets:
 ```json
 {
   "extends": [
-    "github>jmmaloney4/toolbox//renovate/all.json"
+    "github>jmmaloney4/sector7//renovate/all.json"
   ]
 }
 ```

--- a/docs/internal/designs/002-nix-image-publish.md
+++ b/docs/internal/designs/002-nix-image-publish.md
@@ -44,7 +44,7 @@ links:
 
 - Centralizes image publish behavior; thin workflows; minimal secret handling.
 - Tagging remains consistent and branch-aware; no pushes occur if no `*-image` outputs succeed.
-- Requires composite actions to be hosted and pinned (e.g., `jmmaloney4/toolbox@<ref>`), and `packages: write` permission declared.
+- Requires composite actions to be hosted and pinned (e.g., `jmmaloney4/sector7@<ref>`), and `packages: write` permission declared.
 
 ## Alternatives
 

--- a/docs/internal/designs/003-pnpm-ghcr-publish.md
+++ b/docs/internal/designs/003-pnpm-ghcr-publish.md
@@ -43,7 +43,7 @@ Create a reusable GitHub Actions workflow (`.github/workflows/pnpm-publish.yml`)
 - Path: `.github/actions/analyze-pnpm-packages/`
 - Invocation (from reusable workflow):
   - Use repository path with pinned ref, not local path (for cross-repo reuse).
-  - Example: `uses: jmmaloney4/toolbox/.github/actions/analyze-pnpm-packages@<ref>`
+  - Example: `uses: jmmaloney4/sector7/.github/actions/analyze-pnpm-packages@<ref>`
 - Inputs: `dry_run`, `registry` (default `https://npm.pkg.github.com`), `root` (default `.`), optional `scope`.
 - Env: `NODE_AUTH_TOKEN` required for private package metadata; workflow sets `packages: read`.
 - Responsibilities:

--- a/docs/internal/designs/006-iam-role-resource-naming.md
+++ b/docs/internal/designs/006-iam-role-resource-naming.md
@@ -9,7 +9,7 @@ tags: [design, adr, pulumi, gcp, iam]
 supersedes: []
 superseded_by: []
 links:
-  - https://github.com/jmmaloney4/toolbox/pull/74
+  - https://github.com/jmmaloney4/sector7/pull/74
   - https://cloud.google.com/iam/docs/understanding-roles
 ---
 
@@ -181,8 +181,8 @@ function sanitizeRoleForResourceName(role: string): string {
 
 # References
 
-- PR #74: https://github.com/jmmaloney4/toolbox/pull/74
-- Review comment: https://github.com/jmmaloney4/toolbox/pull/74#discussion_r2659215657
+- PR #74: https://github.com/jmmaloney4/sector7/pull/74
+- Review comment: https://github.com/jmmaloney4/sector7/pull/74#discussion_r2659215657
 - GCP IAM Roles documentation: https://cloud.google.com/iam/docs/understanding-roles
 - GCP Custom Roles: https://cloud.google.com/iam/docs/creating-custom-roles
 - ADR-004 (Jest Testing Infrastructure): `docs/internal/designs/004-jest-testing-infrastructure.md`

--- a/docs/internal/designs/009-npm-workspaces-nix-devshell.md
+++ b/docs/internal/designs/009-npm-workspaces-nix-devshell.md
@@ -10,7 +10,7 @@ date: 2026-01-30
 *Date:* 2026-01-30
 *Status:* proposed
 
-**Related PR:** https://github.com/jmmaloney4/toolbox/pull/91
+**Related PR:** https://github.com/jmmaloney4/sector7/pull/91
 
 This ADR is currently being developed in linked pull request above.
 Please refer to that PR for current content and discussion.

--- a/docs/internal/designs/012-ci-skip-meta-attribute.md
+++ b/docs/internal/designs/012-ci-skip-meta-attribute.md
@@ -10,7 +10,7 @@ date: 2026-04-15
 *Date:* 2026-04-15
 *Status:* proposed
 
-**Related PR:** https://github.com/jmmaloney4/toolbox/pull/147
+**Related PR:** https://github.com/jmmaloney4/sector7/pull/147
 
 This ADR is currently being developed in linked pull request above.
 Please refer to that PR for current content and discussion.

--- a/docs/internal/designs/014-decouple-r2-from-workersite.md
+++ b/docs/internal/designs/014-decouple-r2-from-workersite.md
@@ -12,8 +12,8 @@ date: 2026-04-24
 
 **Related PRs:**
 
-- Initial implementation: https://github.com/jmmaloney4/toolbox/pull/160
-- Superseded draft: https://github.com/jmmaloney4/toolbox/pull/156
+- Initial implementation: https://github.com/jmmaloney4/sector7/pull/160
+- Superseded draft: https://github.com/jmmaloney4/sector7/pull/156
 
 ## Context
 

--- a/docs/internal/designs/015-replace-aws-sdk-with-native-s3-signing.md
+++ b/docs/internal/designs/015-replace-aws-sdk-with-native-s3-signing.md
@@ -10,7 +10,7 @@ date: 2026-04-24
 *Date:* 2026-04-24
 *Status:* proposed
 
-**Related PR:** https://github.com/jmmaloney4/toolbox/pull/156
+**Related PR:** https://github.com/jmmaloney4/sector7/pull/156
 
 This ADR is currently being developed in linked pull request above.
 Please refer to that PR for current content and discussion.

--- a/docs/public/pulumi.md
+++ b/docs/public/pulumi.md
@@ -7,13 +7,13 @@ Reusable Pulumi components for infrastructure management.
 You can install this package directly from GitHub using pnpm:
 
 ```bash
-pnpm add "git+https://github.com/jmmaloney4/toolbox.git#path:/packages/toolbox"
+pnpm add "git+https://github.com/jmmaloney4/sector7.git#path:/packages/sector7"
 ```
 
 Or pin to a specific version/commit:
 
 ```bash
-pnpm add "git+https://github.com/jmmaloney4/toolbox.git#path:/packages/toolbox#v0.1.0"
+pnpm add "git+https://github.com/jmmaloney4/sector7.git#path:/packages/sector7#v0.1.0"
 ```
 
 ## Components
@@ -78,7 +78,7 @@ on:
 
 jobs:
   pulumi:
-    uses: jmmaloney4/toolbox/.github/workflows/pulumi.yml@main
+    uses: jmmaloney4/sector7/.github/workflows/pulumi.yml@main
     with:
       runs-on: ubuntu-latest
       repository: ${{ github.repository }}

--- a/docs/public/renovate.md
+++ b/docs/public/renovate.md
@@ -24,9 +24,9 @@ To use these presets in your Renovate configuration, extend them using the GitHu
 ```json
 {
   "extends": [
-    "github>jmmaloney4/toolbox//renovate/default.json",
-    "github>jmmaloney4/toolbox//renovate:nix",
-    "github>jmmaloney4/toolbox//renovate:security"
+    "github>jmmaloney4/sector7//renovate/default.json",
+    "github>jmmaloney4/sector7//renovate:nix",
+    "github>jmmaloney4/sector7//renovate:security"
   ]
 }
 ```
@@ -36,17 +36,17 @@ Alternatively, you can use the aggregate preset to include everything from this 
 ```json
 {
   "extends": [
-    "github>jmmaloney4/toolbox//renovate/all.json"
+    "github>jmmaloney4/sector7//renovate/all.json"
   ]
 }
 ```
 
 ### Preset Resolution Examples
 
-- `github>jmmaloney4/toolbox//renovate/default.json` → loads `renovate/default.json`
-- `github>jmmaloney4/toolbox//renovate/all.json` → loads `renovate/all.json`
-- `github>jmmaloney4/toolbox//renovate/nix.json` → loads `renovate/nix.json`
-- `github>jmmaloney4/toolbox//renovate/security.json` → loads `renovate/security.json`
+- `github>jmmaloney4/sector7//renovate/default.json` → loads `renovate/default.json`
+- `github>jmmaloney4/sector7//renovate/all.json` → loads `renovate/all.json`
+- `github>jmmaloney4/sector7//renovate/nix.json` → loads `renovate/nix.json`
+- `github>jmmaloney4/sector7//renovate/security.json` → loads `renovate/security.json`
 
 ### Pinning to Releases
 
@@ -55,7 +55,7 @@ For production use, consider pinning to a specific release:
 ```json
 {
   "extends": [
-    "github>jmmaloney4/toolbox//renovate/default.json#v1.0.0"
+    "github>jmmaloney4/sector7//renovate/default.json#v1.0.0"
   ]
 }
 ```
@@ -65,7 +65,7 @@ Or pin the aggregate preset:
 ```json
 {
   "extends": [
-    "github>jmmaloney4/toolbox//renovate/all.json#v1.0.0"
+    "github>jmmaloney4/sector7//renovate/all.json#v1.0.0"
   ]
 }
 ```
@@ -79,10 +79,10 @@ The presets are designed to be composable. Common combinations:
 ```json
 {
   "extends": [
-    "github>jmmaloney4/toolbox//renovate/default.json",
-    "github>jmmaloney4/toolbox//renovate/security.json",
-    "github>jmmaloney4/toolbox//renovate/package-groups.json",
-    "github>jmmaloney4/toolbox//renovate/lock-maintenance.json"
+    "github>jmmaloney4/sector7//renovate/default.json",
+    "github>jmmaloney4/sector7//renovate/security.json",
+    "github>jmmaloney4/sector7//renovate/package-groups.json",
+    "github>jmmaloney4/sector7//renovate/lock-maintenance.json"
   ]
 }
 ```
@@ -92,7 +92,7 @@ Alternatively, use the single aggregate preset:
 ```json
 {
   "extends": [
-    "github>jmmaloney4/toolbox//renovate/all.json"
+    "github>jmmaloney4/sector7//renovate/all.json"
   ]
 }
 ```
@@ -102,9 +102,9 @@ Alternatively, use the single aggregate preset:
 ```json
 {
   "extends": [
-    "github>jmmaloney4/toolbox//renovate/default.json",
-    "github>jmmaloney4/toolbox//renovate/nix.json",
-    "github>jmmaloney4/toolbox//renovate/pulumi.json"
+    "github>jmmaloney4/sector7//renovate/default.json",
+    "github>jmmaloney4/sector7//renovate/nix.json",
+    "github>jmmaloney4/sector7//renovate/pulumi.json"
   ]
 }
 ```
@@ -114,7 +114,7 @@ Alternatively, use the single aggregate preset:
 ```json
 {
   "extends": [
-    "github>jmmaloney4/toolbox//renovate/all.json"
+    "github>jmmaloney4/sector7//renovate/all.json"
   ]
 }
 ```

--- a/docs/public/workflows.md
+++ b/docs/public/workflows.md
@@ -31,7 +31,7 @@ permissions:
 
 jobs:
   rust:
-    uses: jmmaloney4/toolbox/.github/workflows/rust.yml@main
+    uses: jmmaloney4/sector7/.github/workflows/rust.yml@main
     with:
       repository: ${{ github.repository }}
       ref: ${{ github.ref }}
@@ -63,7 +63,7 @@ permissions:
 
 jobs:
   nix:
-    uses: jmmaloney4/toolbox/.github/workflows/nix.yml@main
+    uses: jmmaloney4/sector7/.github/workflows/nix.yml@main
     with:
       repository: ${{ github.repository }}
       ref: ${{ github.ref }}
@@ -81,7 +81,7 @@ jobs:
             runs-on: '["self-hosted","linux","x64"]'
           - name: darwin
             runs-on: '["self-hosted","macos","arm64"]'
-    uses: jmmaloney4/toolbox/.github/workflows/nix.yml@main
+    uses: jmmaloney4/sector7/.github/workflows/nix.yml@main
     with:
       runs-on: ${{ matrix.runs-on }}
       repository: ${{ github.repository }}
@@ -117,7 +117,7 @@ permissions:
 
 jobs:
   pnpm:
-    uses: jmmaloney4/toolbox/.github/workflows/pnpm.yml@main
+    uses: jmmaloney4/sector7/.github/workflows/pnpm.yml@main
     with:
       repository: ${{ github.repository }}
       ref: ${{ github.ref }}
@@ -166,7 +166,7 @@ permissions:
 
 jobs:
   pulumi:
-    uses: jmmaloney4/toolbox/.github/workflows/pulumi.yml@main
+    uses: jmmaloney4/sector7/.github/workflows/pulumi.yml@main
     with:
       repository: ${{ github.repository }}
       ref: ${{ github.ref }}
@@ -239,7 +239,7 @@ jobs:
         (contains(github.event.issue.title, '@claude') || contains(github.event.issue.title, '@Claude') || contains(github.event.issue.title, '@CLAUDE'))) &&
        !((contains(github.event.issue.body, 'claude review') || contains(github.event.issue.body, 'Claude review') || contains(github.event.issue.body, 'CLAUDE REVIEW')) ||
          (contains(github.event.issue.title, 'claude review') || contains(github.event.issue.title, 'Claude review') || contains(github.event.issue.title, 'CLAUDE REVIEW'))))
-    uses: jmmaloney4/toolbox/.github/workflows/claude.yml@main
+    uses: jmmaloney4/sector7/.github/workflows/claude.yml@main
     with:
       repository: ${{ github.repository }}
       ref: ${{ github.ref }}
@@ -293,7 +293,7 @@ jobs:
        !contains(github.event.comment.body, 'disable claude review') &&
        !contains(github.event.comment.body, 'claude review is not needed'))
 
-    uses: jmmaloney4/toolbox/.github/workflows/claude-review.yml@main
+    uses: jmmaloney4/sector7/.github/workflows/claude-review.yml@main
     with:
       repository: ${{ github.repository }}
       ref: ${{ github.ref }}
@@ -332,7 +332,7 @@ permissions:
 jobs:
   adr-management:
     if: github.actor != 'github-actions[bot]'
-    uses: jmmaloney4/toolbox/.github/workflows/adr-management.yml@main
+    uses: jmmaloney4/sector7/.github/workflows/adr-management.yml@main
     with:
       runs-on: ubuntu-latest
       repository: ${{ github.repository }}

--- a/docs/quarto.md
+++ b/docs/quarto.md
@@ -97,7 +97,7 @@ on:
 
 jobs:
   deploy:
-    uses: jmmaloney4/toolbox/.github/workflows/quarto.yml@main
+    uses: jmmaloney4/sector7/.github/workflows/quarto.yml@main
     with:
       runs-on: ubuntu-latest
       repository: ${{ github.repository }}
@@ -124,7 +124,7 @@ Multi-site example:
 ```yaml
 jobs:
   deploy:
-    uses: jmmaloney4/toolbox/.github/workflows/quarto.yml@main
+    uses: jmmaloney4/sector7/.github/workflows/quarto.yml@main
     with:
       runs-on: ubuntu-latest
       repository: ${{ github.repository }}

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
-	"name": "@jmmaloney4/toolbox",
+	"name": "@jmmaloney4/sector7",
 	"private": true,
 	"version": "0.3.3",
-	"description": "Toolbox monorepo",
+	"description": "Sector7 monorepo",
 	"license": "MPL-2.0",
 	"workspaces": [
 		"packages/*"

--- a/packages/sector7/README.md
+++ b/packages/sector7/README.md
@@ -7,13 +7,13 @@ Reusable Pulumi components for infrastructure management.
 You can install this package directly from GitHub using pnpm:
 
 ```bash
-pnpm add "git+https://github.com/jmmaloney4/toolbox.git#path:/packages/toolbox"
+pnpm add "git+https://github.com/jmmaloney4/sector7.git#path:/packages/sector7"
 ```
 
 Or pin to a specific version/commit:
 
 ```bash
-pnpm add "git+https://github.com/jmmaloney4/toolbox.git#path:/packages/toolbox#v0.1.0"
+pnpm add "git+https://github.com/jmmaloney4/sector7.git#path:/packages/sector7#v0.1.0"
 ```
 
 ## Components
@@ -78,7 +78,7 @@ on:
 
 jobs:
   pulumi:
-    uses: jmmaloney4/toolbox/.github/workflows/pulumi.yml@main
+    uses: jmmaloney4/sector7/.github/workflows/pulumi.yml@main
     with:
       runs-on: ubuntu-latest
       repository: ${{ github.repository }}

--- a/renovate/README.md
+++ b/renovate/README.md
@@ -24,9 +24,9 @@ To use these presets in your Renovate configuration, extend them using the GitHu
 ```json
 {
   "extends": [
-    "github>jmmaloney4/toolbox//renovate/default.json",
-    "github>jmmaloney4/toolbox//renovate:nix",
-    "github>jmmaloney4/toolbox//renovate:security"
+    "github>jmmaloney4/sector7//renovate/default.json",
+    "github>jmmaloney4/sector7//renovate:nix",
+    "github>jmmaloney4/sector7//renovate:security"
   ]
 }
 ```
@@ -36,17 +36,17 @@ Alternatively, you can use the aggregate preset to include everything from this 
 ```json
 {
   "extends": [
-    "github>jmmaloney4/toolbox//renovate/all.json"
+    "github>jmmaloney4/sector7//renovate/all.json"
   ]
 }
 ```
 
 ### Preset Resolution Examples
 
-- `github>jmmaloney4/toolbox//renovate/default.json` → loads `renovate/default.json`
-- `github>jmmaloney4/toolbox//renovate/all.json` → loads `renovate/all.json`
-- `github>jmmaloney4/toolbox//renovate/nix.json` → loads `renovate/nix.json`
-- `github>jmmaloney4/toolbox//renovate/security.json` → loads `renovate/security.json`
+- `github>jmmaloney4/sector7//renovate/default.json` → loads `renovate/default.json`
+- `github>jmmaloney4/sector7//renovate/all.json` → loads `renovate/all.json`
+- `github>jmmaloney4/sector7//renovate/nix.json` → loads `renovate/nix.json`
+- `github>jmmaloney4/sector7//renovate/security.json` → loads `renovate/security.json`
 
 ### Pinning to Releases
 
@@ -55,7 +55,7 @@ For production use, consider pinning to a specific release:
 ```json
 {
   "extends": [
-    "github>jmmaloney4/toolbox//renovate/default.json#v1.0.0"
+    "github>jmmaloney4/sector7//renovate/default.json#v1.0.0"
   ]
 }
 ```
@@ -65,7 +65,7 @@ Or pin the aggregate preset:
 ```json
 {
   "extends": [
-    "github>jmmaloney4/toolbox//renovate/all.json#v1.0.0"
+    "github>jmmaloney4/sector7//renovate/all.json#v1.0.0"
   ]
 }
 ```
@@ -79,10 +79,10 @@ The presets are designed to be composable. Common combinations:
 ```json
 {
   "extends": [
-    "github>jmmaloney4/toolbox//renovate/default.json",
-    "github>jmmaloney4/toolbox//renovate/security.json",
-    "github>jmmaloney4/toolbox//renovate/package-groups.json",
-    "github>jmmaloney4/toolbox//renovate/lock-maintenance.json"
+    "github>jmmaloney4/sector7//renovate/default.json",
+    "github>jmmaloney4/sector7//renovate/security.json",
+    "github>jmmaloney4/sector7//renovate/package-groups.json",
+    "github>jmmaloney4/sector7//renovate/lock-maintenance.json"
   ]
 }
 ```
@@ -92,7 +92,7 @@ Alternatively, use the single aggregate preset:
 ```json
 {
   "extends": [
-    "github>jmmaloney4/toolbox//renovate/all.json"
+    "github>jmmaloney4/sector7//renovate/all.json"
   ]
 }
 ```
@@ -102,9 +102,9 @@ Alternatively, use the single aggregate preset:
 ```json
 {
   "extends": [
-    "github>jmmaloney4/toolbox//renovate/default.json",
-    "github>jmmaloney4/toolbox//renovate/nix.json",
-    "github>jmmaloney4/toolbox//renovate/pulumi.json"
+    "github>jmmaloney4/sector7//renovate/default.json",
+    "github>jmmaloney4/sector7//renovate/nix.json",
+    "github>jmmaloney4/sector7//renovate/pulumi.json"
   ]
 }
 ```
@@ -114,7 +114,7 @@ Alternatively, use the single aggregate preset:
 ```json
 {
   "extends": [
-    "github>jmmaloney4/toolbox//renovate/all.json"
+    "github>jmmaloney4/sector7//renovate/all.json"
   ]
 }
 ```

--- a/renovate/all.json
+++ b/renovate/all.json
@@ -2,12 +2,12 @@
 	"$schema": "https://docs.renovatebot.com/renovate-schema.json",
 	"description": "Aggregate preset that composes all presets in this repository",
 	"extends": [
-		"github>jmmaloney4/toolbox//renovate/default.json",
-		"github>jmmaloney4/toolbox//renovate/major-updates.json",
-		"github>jmmaloney4/toolbox//renovate/minor-patch-automerge.json",
-		"github>jmmaloney4/toolbox//renovate/security.json",
-		"github>jmmaloney4/toolbox//renovate/pulumi.json",
-		"github>jmmaloney4/toolbox//renovate/nix.json",
-		"github>jmmaloney4/toolbox//renovate/lock-maintenance.json"
+		"github>jmmaloney4/sector7//renovate/default.json",
+		"github>jmmaloney4/sector7//renovate/major-updates.json",
+		"github>jmmaloney4/sector7//renovate/minor-patch-automerge.json",
+		"github>jmmaloney4/sector7//renovate/security.json",
+		"github>jmmaloney4/sector7//renovate/pulumi.json",
+		"github>jmmaloney4/sector7//renovate/nix.json",
+		"github>jmmaloney4/sector7//renovate/lock-maintenance.json"
 	]
 }

--- a/renovate/default.json
+++ b/renovate/default.json
@@ -38,8 +38,8 @@
 	},
 	"packageRules": [
 		{
-			"description": "Skip stability days for internal toolbox actions (own repo)",
-			"matchPackageNames": ["jmmaloney4/toolbox"],
+			"description": "Skip stability days for internal sector7 actions (own repo)",
+			"matchPackageNames": ["jmmaloney4/sector7"],
 			"minimumReleaseAge": null
 		}
 	]


### PR DESCRIPTION
Phase 2 of the toolbox → sector7 rename plan.

## What
Replace all \`jmmaloney4/toolbox\` references with \`jmmaloney4/sector7\` across:

- **27 workflow \`uses:\` refs** (15 workflow files + 1 composite action)
- **8 renovate preset URLs** (all.json + default.json + .github/renovate.json5)
- **1 npm package name** (root package.json: \`@jmmaloney4/toolbox\` → \`@jmmaloney4/sector7\`)
- **4 pnpm install URLs** (packages/toolbox → packages/sector7)
- **~40 doc lines** (README, AGENTS.md, public docs, internal designs)

33 files changed, 107 replacements total.

## Why
GitHub Actions \`uses:\` refs **do not follow redirects**. Now that the repo is renamed, every workflow that references the old name will 404 until this lands on main.

## How to merge
**Merge immediately** — CI is currently broken on main for any push that triggers these workflows. This should be the first commit merged after the rename.

## Tracking
- Plan: \`docs/internal/plans/2026-05-04-rename-toolbox-to-sector7.md\`
- Issue: ergodicsystems/hq#130

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is a mechanical rename of GitHub Actions `uses:` references, Renovate preset URLs, and package/docs identifiers with no functional logic changes. Main risk is CI breakage if any external `sector7` refs/tags/paths don’t exist or aren’t accessible.
> 
> **Overview**
> **Repo rename follow-through:** switches all reusable workflow/composite action `uses:` targets (including dogfood workflows) from `jmmaloney4/toolbox` to `jmmaloney4/sector7`, keeping the same pinned commit SHA.
> 
> **Renovate + npm metadata:** updates Renovate preset `extends` URLs to `sector7` and adjusts Renovate rules that match the internal repo name; renames the root npm package from `@jmmaloney4/toolbox` to `@jmmaloney4/sector7`.
> 
> **Docs:** replaces example URLs and PR links across README/public docs/internal ADRs to reference `sector7` instead of `toolbox`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit da4be1cc261f1e3e7f1fa08113f618eefa3c4114. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->