### PR TITLE
feat: extract Access provisioning into standalone AccessGate (ADR-016)

### DIFF
--- a/docs/internal/designs/016-extract-access-into-accessgate.md
+++ b/docs/internal/designs/016-extract-access-into-accessgate.md
@@ -1,0 +1,169 @@
+---
+id: ADR-016
+title: Extract Access Provisioning Into Standalone AccessGate Component
+status: Proposed
+date: 2026-05-05
+deciders: [jmmaloney4]
+tags: [design, adr]
+supersedes: []
+superseded_by: []
+links: [ADR-011, ADR-014]
+---
+
+# Context
+
+`WorkerSite` bundles Cloudflare Zero Trust Access provisioning (identity provider
+creation, per-path Access Applications with inline policies) alongside its core
+Worker + R2 + custom domain infrastructure. This coupling prevents reuse of the
+Access provisioning logic for origins that are not Cloudflare Workers — for
+example, services behind a Cloudflare Tunnel that need Zero Trust auth but have
+no Worker or R2 bucket.
+
+The pattern is the same dependency boundary issue that ADR-014 identified for
+R2 uploads: a subset of `WorkerSite` functionality is broadly useful on its own,
+but coupling it to `WorkerSite` forces consumers to accept the entire Worker
+abstraction just to get Access Applications.
+
+Concrete use cases:
+
+- A GKE-hosted dashboard (Lens) behind a Cloudflare Tunnel that needs GitHub
+  org-based access control before the request reaches the cluster.
+- Any tunnel-backed or externally-hosted origin that should be gated by
+  Cloudflare Zero Trust.
+
+# Decision
+
+Extract the Access provisioning logic from `WorkerSite` into a standalone
+`AccessGate` ComponentResource at `@jmmaloney4/sector7/access`.
+
+```ts
+import { AccessGate } from "@jmmaloney4/sector7/access";
+```
+
+The `AccessGate` component owns:
+
+- GitHub OAuth Identity Provider auto-creation (`ZeroTrustAccessIdentityProvider`).
+- Per (domain, path) `ZeroTrustAccessApplication` creation with inline policies.
+- Validation of github-org requirements (identity provider, organizations).
+- Configurable session duration and application type.
+
+`WorkerSite` will delegate its Access provisioning to `AccessGate` internally.
+The `WorkerSite` public API (args, outputs) remains unchanged — this is an
+internal refactoring, not a breaking change.
+
+# API Shape
+
+```ts
+const gate = new AccessGate("lens-access", {
+  accountId: "abc123",
+  zoneId: "xyz789",
+  name: "lens",
+  domains: ["lens.example.com"],
+  paths: [{ pattern: "/*", access: "github-org" }],
+  githubOAuthConfig: {
+    clientId: "Ov23li...",
+    clientSecret: pulumi.secret("abc123..."),
+  },
+  githubOrganizations: ["my-org"],
+});
+```
+
+The `AccessPathConfig` and `AccessGithubOAuthConfig` types are defined on the
+`access` module and re-exported from there. `WorkerSite` re-uses these types
+internally (its existing `PathConfig` and `GithubOAuthConfig` become type aliases
+or are replaced by direct references to the access module types).
+
+# Alternatives Considered
+
+### 1. Copy Access logic at each call site
+
+Pros:
+- No new abstraction, no package changes.
+
+Cons:
+- Duplicated validation, IDP creation, and policy wiring.
+- Divergent behavior across call sites.
+- Every new consumer reimplements the same Cloudflare Access API patterns.
+
+Rejected because the Access provisioning logic has enough moving parts (IDP
+creation, validation, policy include construction, naming) that copy-paste will
+drift.
+
+### 2. Keep Access on WorkerSite, add a "null Worker" mode
+
+Pros:
+- Single component, no new sub-path.
+
+Cons:
+- `WorkerSite` would need to accept optional Worker/R2 config, making its API
+  confusing and its validation complex.
+- The component name ("WorkerSite") would be misleading for non-Worker origins.
+- Tests become harder to reason about — is it a Worker site or just Access?
+
+Rejected because bending WorkerSite to serve a non-Worker use case undermines
+its clarity.
+
+### 3. Extract into `@jmmaloney4/sector7/access` (accepted)
+
+Pros:
+- Reusable for any Cloudflare-hosted origin (Workers, Tunnels, Pages, etc.).
+- Clean dependency boundary — Access consumers don't pull Worker/R2 types.
+- Follows the ADR-014 pattern (sibling sub-path export).
+- WorkerSite delegates internally, preserving its public API.
+
+Cons:
+- Requires package export and barrel-guard updates.
+- WorkerSite constructor gains one internal delegation step.
+
+Accepted. The dependency boundary is correct, the pattern is established by
+ADR-014, and the internal refactoring is low-risk.
+
+# Consequences
+
+## Positive
+
+- Access provisioning is reusable for any origin type.
+- WorkerSite remains focused on Worker + R2 + domain concerns.
+- The `access` module has zero dependency on Worker or R2 types.
+- New consumers (tunnel-backed services, external origins) can adopt Zero Trust
+  without the WorkerSite abstraction.
+
+## Negative
+
+- One more sub-path export to maintain in package.json.
+- WorkerSite internals change (delegation to AccessGate) — behavior should be
+  identical, but the resource names may differ. Aliases should be used if
+  existing state needs migration.
+
+# Security / Privacy / Compliance
+
+- AccessGate creates `ZeroTrustAccessIdentityProvider` and
+  `ZeroTrustAccessApplication` resources with the same security posture as the
+  existing WorkerSite Access logic.
+- GitHub OAuth client secrets remain Pulumi secrets throughout.
+
+# Operational Notes
+
+- Existing WorkerSite deployments will see no change in provisioned resources
+  if the internal delegation preserves resource naming and configuration.
+- If resource names change (e.g., Access Application Pulumi URNs), aliases
+  must be added to avoid destroy-and-recreate.
+
+# Status Transitions
+
+- Extends the separation-of-concerns pattern established by ADR-014.
+
+# Implementation Notes
+
+1. Create `packages/sector7/access/` with `AccessGate` ComponentResource.
+2. Add `./access` sub-path export to `package.json`.
+3. Add barrel guard ensuring Access types are not re-exported from `./workersite`.
+4. Refactor `WorkerSite` to delegate Access creation to `AccessGate` internally.
+5. Preserve `WorkerSite` public API (args, outputs) — no breaking changes.
+6. Add dedicated tests for `AccessGate` standalone usage.
+7. Verify existing `WorkerSite` tests still pass unchanged.
+
+# References
+
+- ADR-011: WorkerSite extensions (originally added Access support)
+- ADR-014: Decouple R2 from WorkerSite (established sibling sub-path pattern)

--- a/docs/internal/designs/016-extract-access-into-accessgate.md
+++ b/docs/internal/designs/016-extract-access-into-accessgate.md
@@ -131,9 +131,10 @@ ADR-014, and the internal refactoring is low-risk.
 ## Negative
 
 - One more sub-path export to maintain in package.json.
-- WorkerSite internals change (delegation to AccessGate) — behavior should be
-  identical, but the resource names may differ. Aliases should be used if
-  existing state needs migration.
+- WorkerSite internals change (delegation to AccessGate) — behavior is
+  identical, but the parent component changes from WorkerSite to AccessGate.
+  AccessGate uses `aliases: [{ parent: opts.parent }]` to preserve existing
+  URNs when delegated from WorkerSite.
 
 # Security / Privacy / Compliance
 
@@ -144,10 +145,15 @@ ADR-014, and the internal refactoring is low-risk.
 
 # Operational Notes
 
-- Existing WorkerSite deployments will see no change in provisioned resources
-  if the internal delegation preserves resource naming and configuration.
-- If resource names change (e.g., Access Application Pulumi URNs), aliases
-  must be added to avoid destroy-and-recreate.
+- Existing WorkerSite deployments will see no change in provisioned resources.
+  AccessGate adds `aliases: [{ parent: opts.parent }]` so that when WorkerSite
+  delegates, the child resources retain their old URNs (parented under
+  WorkerSite). No destroy-and-recreate.
+- Standalone AccessGate usage (no parent) creates resources with AccessGate as
+  parent — no alias needed since there is no prior state.
+- Resource logical names use array indices (`app-d0-p0`) because Pulumi
+  requires resource names to be plain strings known at plan time. The
+  Cloudflare display names already include domain + path for readability.
 
 # Status Transitions
 

--- a/packages/sector7/access/access-gate.ts
+++ b/packages/sector7/access/access-gate.ts
@@ -197,7 +197,13 @@ export class AccessGate extends pulumi.ComponentResource {
 			throw new Error("AccessGate requires at least one path");
 		}
 
-		const resourceOpts = { parent: this };
+		// When AccessGate is used as a child of another component (e.g. WorkerSite),
+		// alias resources back to the parent to preserve existing URNs from before
+		// the extraction (ADR-016). Standalone usage has no parent, so no alias needed.
+		const resourceOpts: pulumi.CustomResourceOptions = {
+			parent: this,
+			aliases: opts?.parent ? [{ parent: opts.parent }] : undefined,
+		};
 		const sessionDuration = args.sessionDuration ?? "24h";
 		const appType = args.type ?? "self_hosted";
 
@@ -226,11 +232,16 @@ export class AccessGate extends pulumi.ComponentResource {
 		// Create Zero Trust Access Applications
 		this.accessApplications = [];
 
-		for (let domainIdx = 0; domainIdx < args.domains.length; domainIdx++) {
-			const domain = args.domains[domainIdx];
-
-			for (let pathIdx = 0; pathIdx < args.paths.length; pathIdx++) {
-				const pathConfig = args.paths[pathIdx];
+		for (const domain of args.domains) {
+			for (const pathConfig of args.paths) {
+				// NOTE: logical names use array indices rather than domain/path
+				// slugs because Pulumi requires resource names to be plain strings
+				// known at plan time, while args.domains is typed as
+				// pulumi.Input<string>[]. If a caller passes Output<string>
+				// values, we cannot extract a string synchronously for the name.
+				// Reordering is unlikely in practice since configs are static.
+				const domainIdx = args.domains.indexOf(domain);
+				const pathIdx = args.paths.indexOf(pathConfig);
 
 				const policyIncludes =
 					pathConfig.access === "public" || pathConfig.access === "bypass"
@@ -250,8 +261,8 @@ export class AccessGate extends pulumi.ComponentResource {
 										})) as cloudflare.types.input.ZeroTrustAccessApplicationPolicyInclude[],
 								);
 
-				const app = new cloudflare.ZeroTrustAccessApplication(
-					`${name}-app-d${domainIdx}-p${pathIdx}`,
+			const app = new cloudflare.ZeroTrustAccessApplication(
+				`${name}-app-d${domainIdx}-p${pathIdx}`,
 					{
 						accountId: args.accountId,
 						zoneId: args.zoneId,

--- a/packages/sector7/access/access-gate.ts
+++ b/packages/sector7/access/access-gate.ts
@@ -1,0 +1,295 @@
+import * as cloudflare from "@pulumi/cloudflare";
+import * as pulumi from "@pulumi/pulumi";
+
+/**
+ * Path access configuration for a Cloudflare Zero Trust Access Application.
+ */
+export interface AccessPathConfig {
+	/**
+	 * Path pattern (e.g., "/blog/*", "/research/*").
+	 * Supports wildcards.
+	 */
+	pattern: pulumi.Input<string>;
+
+	/**
+	 * Access level for this path.
+	 * - "public": Allow everyone (visitors still complete the Cloudflare Zero Trust login flow)
+	 * - "bypass": Bypass authentication entirely — no login prompt
+	 * - "github-org": Require GitHub organization membership
+	 */
+	access: "public" | "bypass" | "github-org";
+}
+
+/**
+ * Configuration for auto-creating a GitHub OAuth Identity Provider in
+ * Cloudflare Zero Trust Access.
+ *
+ * When provided, AccessGate creates a `ZeroTrustAccessIdentityProvider`
+ * resource (type `"github"`) and uses its generated ID for any paths with
+ * `access: "github-org"`.  Mutually exclusive with `githubIdentityProviderId`.
+ *
+ * The GitHub OAuth App must be created manually in
+ * GitHub Settings → Developer settings → OAuth Apps.
+ * The callback URL should be `https://<your-team>.cloudflareaccess.com/cdn-cgi/access/callback`.
+ */
+export interface AccessGithubOAuthConfig {
+	/**
+	 * GitHub OAuth App client ID.
+	 */
+	clientId: pulumi.Input<string>;
+
+	/**
+	 * GitHub OAuth App client secret.
+	 * This value will be stored as a Pulumi secret.
+	 */
+	clientSecret: pulumi.Input<string>;
+}
+
+/**
+ * Arguments for creating an AccessGate component.
+ *
+ * AccessGate provisions Cloudflare Zero Trust Access Applications for the
+ * given domain and path combinations.  It can optionally auto-create a GitHub
+ * OAuth Identity Provider for paths requiring GitHub org membership.
+ */
+export interface AccessGateArgs {
+	/**
+	 * Cloudflare account ID where resources will be created.
+	 */
+	accountId: pulumi.Input<string>;
+
+	/**
+	 * Cloudflare zone ID for the domain.
+	 */
+	zoneId: pulumi.Input<string>;
+
+	/**
+	 * Logical name prefix for Access Application resources.
+	 */
+	name: pulumi.Input<string>;
+
+	/**
+	 * Domains to protect (e.g., ["site.example.com"]).
+	 * Each domain gets Access Applications for every path in `paths`.
+	 */
+	domains: pulumi.Input<string>[];
+
+	/**
+	 * Path access configurations.
+	 * One `ZeroTrustAccessApplication` is created per (domain, path) combination.
+	 */
+	paths: AccessPathConfig[];
+
+	/**
+	 * Pre-existing GitHub Identity Provider ID in Cloudflare Access.
+	 * Required only when at least one path has `access: "github-org"` and
+	 * `githubOAuthConfig` is not provided.
+	 *
+	 * Mutually exclusive with `githubOAuthConfig`.
+	 */
+	githubIdentityProviderId?: pulumi.Input<string>;
+
+	/**
+	 * Auto-create a GitHub OAuth Identity Provider for Cloudflare Access.
+	 * When provided, a `ZeroTrustAccessIdentityProvider` resource is created
+	 * and its ID is used for any paths with `access: "github-org"`.
+	 *
+	 * Mutually exclusive with `githubIdentityProviderId`.
+	 */
+	githubOAuthConfig?: AccessGithubOAuthConfig;
+
+	/**
+	 * GitHub organization name(s) for restricted path access.
+	 * Required when at least one path has `access: "github-org"`.
+	 */
+	githubOrganizations?: pulumi.Input<string>[];
+
+	/**
+	 * Session duration for Access Applications.
+	 * @default "24h"
+	 */
+	sessionDuration?: pulumi.Input<string>;
+
+	/**
+	 * Access Application type.
+	 * @default "self_hosted"
+	 */
+	type?: pulumi.Input<string>;
+}
+
+/**
+ * AccessGate provisions Cloudflare Zero Trust Access Applications
+ * for a set of domains and path patterns.
+ *
+ * This component can be used standalone to protect any Cloudflare-hosted
+ * origin (Workers, Tunnel-backed services, etc.) without depending on
+ * the WorkerSite component.
+ *
+ * @example
+ * Protect a tunnel-backed service with GitHub org membership:
+ * ```typescript
+ * import { AccessGate } from "@jmmaloney4/sector7/access";
+ *
+ * const gate = new AccessGate("lens-access", {
+ *   accountId: "abc123",
+ *   zoneId: "xyz789",
+ *   name: "lens",
+ *   domains: ["lens.example.com"],
+ *   paths: [{ pattern: "/*", access: "github-org" }],
+ *   githubOAuthConfig: {
+ *     clientId: "Ov23li...",
+ *     clientSecret: pulumi.secret("abc123..."),
+ *   },
+ *   githubOrganizations: ["my-org"],
+ * });
+ * ```
+ */
+export class AccessGate extends pulumi.ComponentResource {
+	/**
+	 * Zero Trust Access Applications for each (domain, path) combination.
+	 */
+	public readonly accessApplications: cloudflare.ZeroTrustAccessApplication[];
+
+	/**
+	 * Auto-created GitHub Identity Provider (present when `githubOAuthConfig` is provided).
+	 * Undefined when using a pre-existing `githubIdentityProviderId` or when no
+	 * GitHub auth is needed.
+	 */
+	public readonly githubIdp:
+		| cloudflare.ZeroTrustAccessIdentityProvider
+		| undefined;
+
+	constructor(
+		name: string,
+		args: AccessGateArgs,
+		opts?: pulumi.ComponentResourceOptions,
+	) {
+		super("sector7:cloudflare:AccessGate", name, {}, opts);
+
+		// Input validation
+		if (!args.domains || args.domains.length === 0) {
+			throw new Error("AccessGate requires at least one domain");
+		}
+
+		if (args.githubOAuthConfig && args.githubIdentityProviderId) {
+			throw new Error(
+				"githubOAuthConfig and githubIdentityProviderId are mutually exclusive",
+			);
+		}
+
+		const githubOrgPaths = (args.paths ?? []).filter(
+			(p) => p.access === "github-org",
+		);
+		if (githubOrgPaths.length > 0) {
+			if (!args.githubIdentityProviderId && !args.githubOAuthConfig) {
+				throw new Error(
+					"githubIdentityProviderId or githubOAuthConfig is required when using github-org access",
+				);
+			}
+			if (!args.githubOrganizations || args.githubOrganizations.length === 0) {
+				throw new Error(
+					"githubOrganizations must not be empty when using github-org access",
+				);
+			}
+		}
+
+		if (!args.paths || args.paths.length === 0) {
+			throw new Error("AccessGate requires at least one path");
+		}
+
+		const resourceOpts = { parent: this };
+		const sessionDuration = args.sessionDuration ?? "24h";
+		const appType = args.type ?? "self_hosted";
+
+		// Auto-create GitHub Identity Provider if requested
+		this.githubIdp = undefined;
+		let githubIdentityProviderId: pulumi.Input<string> | undefined =
+			args.githubIdentityProviderId;
+
+		if (args.githubOAuthConfig) {
+			this.githubIdp = new cloudflare.ZeroTrustAccessIdentityProvider(
+				`${name}-github-idp`,
+				{
+					accountId: args.accountId,
+					name: pulumi.interpolate`${args.name} GitHub`,
+					type: "github",
+					config: {
+						clientId: args.githubOAuthConfig.clientId,
+						clientSecret: args.githubOAuthConfig.clientSecret,
+					},
+				},
+				resourceOpts,
+			);
+			githubIdentityProviderId = this.githubIdp.id;
+		}
+
+		// Create Zero Trust Access Applications
+		this.accessApplications = [];
+
+		for (let domainIdx = 0; domainIdx < args.domains.length; domainIdx++) {
+			const domain = args.domains[domainIdx];
+
+			for (let pathIdx = 0; pathIdx < args.paths.length; pathIdx++) {
+				const pathConfig = args.paths[pathIdx];
+
+				const policyIncludes =
+					pathConfig.access === "public" || pathConfig.access === "bypass"
+						? [{ everyone: {} }]
+						: pulumi
+								.all([
+									pulumi.all(args.githubOrganizations ?? []),
+									githubIdentityProviderId ?? "",
+								])
+								.apply(
+									([orgs, idpId]: [string[], string]) =>
+										orgs.map((org: string) => ({
+											githubOrganization: {
+												identityProviderId: idpId,
+												name: org,
+											},
+										})) as cloudflare.types.input.ZeroTrustAccessApplicationPolicyInclude[],
+								);
+
+				const app = new cloudflare.ZeroTrustAccessApplication(
+					`${name}-app-d${domainIdx}-p${pathIdx}`,
+					{
+						accountId: args.accountId,
+						zoneId: args.zoneId,
+						name: pulumi
+							.all([args.name, domain, pathConfig.pattern])
+							.apply(
+								([n, d, p]: [string, string, string]) =>
+									`${n}-${d}-${p.replace(/\//g, "-").replace(/\*/g, "all")}`,
+							),
+						domain: pulumi.interpolate`${domain}${pathConfig.pattern}`,
+						type: appType,
+						sessionDuration,
+						policies: [
+							{
+								name: {
+									bypass: "Bypass for public path",
+									public: "Allow everyone",
+									"github-org": "GitHub org members",
+								}[pathConfig.access],
+								decision: {
+									bypass: "bypass",
+									public: "allow",
+									"github-org": "allow",
+								}[pathConfig.access],
+								precedence: 1,
+								includes: policyIncludes,
+							},
+						],
+					},
+					resourceOpts,
+				);
+				this.accessApplications.push(app);
+			}
+		}
+
+		this.registerOutputs({
+			accessApplications: this.accessApplications,
+			githubIdp: this.githubIdp,
+		});
+	}
+}

--- a/packages/sector7/access/index.ts
+++ b/packages/sector7/access/index.ts
@@ -1,0 +1,6 @@
+export {
+	AccessGate,
+	type AccessGateArgs,
+	type AccessGithubOAuthConfig,
+	type AccessPathConfig,
+} from "./access-gate.ts";

--- a/packages/sector7/index.ts
+++ b/packages/sector7/index.ts
@@ -1,2 +1,3 @@
+export * as access from "./access/index.ts";
 export * as iam from "./iam/index.ts";
 export * as workersite from "./workersite/index.ts";

--- a/packages/sector7/package.json
+++ b/packages/sector7/package.json
@@ -15,6 +15,10 @@
 			"types": "./index.ts",
 			"default": "./index.ts"
 		},
+		"./access": {
+			"types": "./access/index.ts",
+			"default": "./access/index.ts"
+		},
 		"./iam": {
 			"types": "./iam/index.ts",
 			"default": "./iam/index.ts"
@@ -30,6 +34,7 @@
 	},
 	"files": [
 		"index.ts",
+		"access",
 		"iam",
 		"workersite",
 		"r2"

--- a/packages/sector7/tests/access-gate.test.ts
+++ b/packages/sector7/tests/access-gate.test.ts
@@ -1,0 +1,293 @@
+import * as pulumi from "@pulumi/pulumi";
+import { beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { AccessGate } from "../access/access-gate";
+
+type MockResource = {
+	type: string;
+	name: string;
+	inputs: Record<string, unknown>;
+};
+
+const resources: MockResource[] = [];
+
+beforeAll(() => {
+	pulumi.runtime.setMocks({
+		newResource: (args) => {
+			const state = args.inputs;
+
+			resources.push({
+				type: args.type,
+				name: args.name,
+				inputs: state as Record<string, unknown>,
+			});
+
+			return {
+				id: `${args.name}-id`,
+				state,
+			};
+		},
+		call: (args) => args.inputs,
+	});
+});
+
+beforeEach(() => {
+	resources.length = 0;
+});
+
+function resolveOutput<T>(value: pulumi.Input<T>): Promise<T> {
+	return new Promise((resolve) => {
+		pulumi.output(value).apply((resolved) => {
+			resolve(resolved as T);
+			return resolved;
+		});
+	});
+}
+
+function byName(fragment: string): MockResource[] {
+	return resources.filter((resource) => resource.name.includes(fragment));
+}
+
+describe("AccessGate", () => {
+	it("creates an access application for each domain and path combination", async () => {
+		const gate = new AccessGate("multi-domain", {
+			accountId: "account-123",
+			zoneId: "zone-123",
+			name: "docs-site",
+			domains: ["docs.example.com", "docs.internal.example.com"],
+			paths: [
+				{ pattern: "/public/*", access: "public" },
+				{ pattern: "/private/*", access: "github-org" },
+			],
+			githubIdentityProviderId: "github-idp",
+			githubOrganizations: ["jmmaloney4"],
+		});
+
+		await Promise.all(
+			gate.accessApplications.map((app) => resolveOutput(app.id)),
+		);
+
+		expect(gate.accessApplications).toHaveLength(4);
+		expect(byName("-app-d")).toHaveLength(4);
+	});
+
+	it("creates bypass policy for bypass access paths", async () => {
+		const gate = new AccessGate("bypass-test", {
+			accountId: "account-123",
+			zoneId: "zone-123",
+			name: "bypass-site",
+			domains: ["bypass.example.com"],
+			paths: [
+				{ pattern: "/", access: "bypass" },
+				{ pattern: "/styles.css", access: "bypass" },
+			],
+		});
+
+		await Promise.all(
+			gate.accessApplications.map((app) => resolveOutput(app.id)),
+		);
+
+		expect(gate.accessApplications).toHaveLength(2);
+
+		const apps = byName("bypass-test-app-d");
+		expect(apps).toHaveLength(2);
+
+		for (const app of apps) {
+			const policies = app.inputs.policies as Array<Record<string, unknown>>;
+			expect(policies).toHaveLength(1);
+			expect(policies[0].decision).toBe("bypass");
+			expect(policies[0].name).toBe("Bypass for public path");
+			const includes = policies[0].includes as Array<Record<string, unknown>>;
+			expect(includes).toEqual([{ everyone: {} }]);
+		}
+	});
+
+	it("uses bypass decision for bypass paths and allow for other paths", async () => {
+		const gate = new AccessGate("mixed-test", {
+			accountId: "account-123",
+			zoneId: "zone-123",
+			name: "mixed-site",
+			domains: ["mixed.example.com"],
+			paths: [
+				{ pattern: "/favicon.ico", access: "bypass" },
+				{ pattern: "/public/*", access: "public" },
+				{ pattern: "/private/*", access: "github-org" },
+			],
+			githubIdentityProviderId: "github-idp",
+			githubOrganizations: ["my-org"],
+		});
+
+		await Promise.all(
+			gate.accessApplications.map((app) => resolveOutput(app.id)),
+		);
+
+		expect(gate.accessApplications).toHaveLength(3);
+
+		const apps = byName("mixed-test-app-d");
+		expect(apps).toHaveLength(3);
+
+		const bypassApp = apps.find((a) => a.name.includes("-p0"));
+		const publicApp = apps.find((a) => a.name.includes("-p1"));
+		const privateApp = apps.find((a) => a.name.includes("-p2"));
+
+		expect(bypassApp).toBeDefined();
+		expect(publicApp).toBeDefined();
+		expect(privateApp).toBeDefined();
+
+		if (!bypassApp || !publicApp || !privateApp) {
+			throw new Error("Expected all access apps to exist");
+		}
+
+		const bypassPolicies = bypassApp.inputs.policies as Array<
+			Record<string, unknown>
+		>;
+		expect(bypassPolicies[0].decision).toBe("bypass");
+		expect(bypassPolicies[0].name).toBe("Bypass for public path");
+
+		const publicPolicies = publicApp.inputs.policies as Array<
+			Record<string, unknown>
+		>;
+		expect(publicPolicies[0].decision).toBe("allow");
+		expect(publicPolicies[0].name).toBe("Allow everyone");
+
+		const privatePolicies = privateApp.inputs.policies as Array<
+			Record<string, unknown>
+		>;
+		expect(privatePolicies[0].decision).toBe("allow");
+		expect(privatePolicies[0].name).toBe("GitHub org members");
+	});
+
+	it("auto-creates a GitHub Identity Provider when githubOAuthConfig is provided", async () => {
+		const gate = new AccessGate("oauth-test", {
+			accountId: "account-123",
+			zoneId: "zone-123",
+			name: "oauth-site",
+			domains: ["oauth.example.com"],
+			paths: [
+				{ pattern: "/", access: "bypass" },
+				{ pattern: "/private/*", access: "github-org" },
+			],
+			githubOAuthConfig: {
+				clientId: "Ov23li-test",
+				clientSecret: "test-secret",
+			},
+			githubOrganizations: ["my-org"],
+		});
+
+		await Promise.all([
+			...gate.accessApplications.map((app) => resolveOutput(app.id)),
+			gate.githubIdp ? resolveOutput(gate.githubIdp.id) : Promise.resolve(),
+		]);
+
+		expect(gate.githubIdp).toBeDefined();
+		const idps = byName("-github-idp");
+		expect(idps).toHaveLength(1);
+		expect(idps[0].inputs.type).toBe("github");
+		expect(idps[0].inputs.config).toEqual({
+			clientId: "Ov23li-test",
+			clientSecret: "test-secret",
+		});
+		expect(idps[0].inputs.accountId).toBe("account-123");
+
+		expect(gate.accessApplications).toHaveLength(2);
+	});
+
+	it("does not create an IDP when githubOAuthConfig is not provided", async () => {
+		const gate = new AccessGate("no-idp-test", {
+			accountId: "account-123",
+			zoneId: "zone-123",
+			name: "no-idp-site",
+			domains: ["no-idp.example.com"],
+			paths: [{ pattern: "/", access: "bypass" }],
+		});
+
+		await Promise.all(
+			gate.accessApplications.map((app) => resolveOutput(app.id)),
+		);
+
+		expect(gate.githubIdp).toBeUndefined();
+		expect(byName("-github-idp")).toHaveLength(0);
+	});
+
+	it("validates github-org access requirements", () => {
+		expect(
+			() =>
+				new AccessGate("invalid-test", {
+					accountId: "account-123",
+					zoneId: "zone-123",
+					name: "invalid-site",
+					domains: ["private.example.com"],
+					paths: [{ pattern: "/private/*", access: "github-org" }],
+				}),
+		).toThrow(
+			"githubIdentityProviderId or githubOAuthConfig is required when using github-org access",
+		);
+	});
+
+	it("rejects both githubOAuthConfig and githubIdentityProviderId", () => {
+		expect(
+			() =>
+				new AccessGate("conflict-test", {
+					accountId: "account-123",
+					zoneId: "zone-123",
+					name: "conflict-site",
+					domains: ["conflict.example.com"],
+					paths: [{ pattern: "/*", access: "github-org" }],
+					githubIdentityProviderId: "manual-idp-id",
+					githubOAuthConfig: {
+						clientId: "Ov23li",
+						clientSecret: "secret",
+					},
+					githubOrganizations: ["my-org"],
+				}),
+		).toThrow(
+			"githubOAuthConfig and githubIdentityProviderId are mutually exclusive",
+		);
+	});
+
+	it("rejects empty domains", () => {
+		expect(
+			() =>
+				new AccessGate("no-domains-test", {
+					accountId: "account-123",
+					zoneId: "zone-123",
+					name: "no-domains",
+					domains: [],
+					paths: [{ pattern: "/", access: "bypass" }],
+				}),
+		).toThrow("AccessGate requires at least one domain");
+	});
+
+	it("rejects empty paths", () => {
+		expect(
+			() =>
+				new AccessGate("no-paths-test", {
+					accountId: "account-123",
+					zoneId: "zone-123",
+					name: "no-paths",
+					domains: ["example.com"],
+					paths: [],
+				}),
+		).toThrow("AccessGate requires at least one path");
+	});
+
+	it("uses custom session duration and type when provided", async () => {
+		const gate = new AccessGate("custom-test", {
+			accountId: "account-123",
+			zoneId: "zone-123",
+			name: "custom-site",
+			domains: ["custom.example.com"],
+			paths: [{ pattern: "/*", access: "public" }],
+			sessionDuration: "12h",
+			type: "saas",
+		});
+
+		await Promise.all(
+			gate.accessApplications.map((app) => resolveOutput(app.id)),
+		);
+
+		const apps = byName("custom-test-app-d");
+		expect(apps).toHaveLength(1);
+		expect(apps[0].inputs.sessionDuration).toBe("12h");
+		expect(apps[0].inputs.type).toBe("saas");
+	});
+});

--- a/packages/sector7/workersite/worker-site.ts
+++ b/packages/sector7/workersite/worker-site.ts
@@ -1,6 +1,11 @@
 import * as cloudflare from "@pulumi/cloudflare";
 import * as pulumi from "@pulumi/pulumi";
 import {
+	AccessGate,
+	type AccessGithubOAuthConfig,
+	type AccessPathConfig,
+} from "../access/access-gate.ts";
+import {
 	generateWorkerScript,
 	type RedirectRule,
 } from "./worker-site-script.ts";
@@ -8,21 +13,7 @@ import {
 /**
  * Path access configuration.
  */
-export interface PathConfig {
-	/**
-	 * Path pattern (e.g., "/blog/*", "/research/*").
-	 * Supports wildcards.
-	 */
-	pattern: pulumi.Input<string>;
-
-	/**
-	 * Access level for this path.
-	 * - "public": Allow everyone (visitors still complete the Cloudflare Zero Trust login flow)
-	 * - "bypass": Bypass authentication entirely — requests go directly to the Worker with no login prompt
-	 * - "github-org": Require GitHub organization membership
-	 */
-	access: "public" | "bypass" | "github-org";
-}
+export type PathConfig = AccessPathConfig;
 
 /**
  * Configuration for providing a custom pre-built Worker script.
@@ -70,18 +61,7 @@ export interface WorkerScriptConfig {
  * GitHub Settings → Developer settings → OAuth Apps.
  * The callback URL should be `https://<your-team>.cloudflareaccess.com/cdn-cgi/access/callback`.
  */
-export interface GithubOAuthConfig {
-	/**
-	 * GitHub OAuth App client ID.
-	 */
-	clientId: pulumi.Input<string>;
-
-	/**
-	 * GitHub OAuth App client secret.
-	 * This value will be stored as a Pulumi secret.
-	 */
-	clientSecret: pulumi.Input<string>;
-}
+export type GithubOAuthConfig = AccessGithubOAuthConfig;
 
 /**
  * Configuration for Cloudflare Worker observability.
@@ -400,50 +380,30 @@ export class WorkerSite extends pulumi.ComponentResource {
 			);
 		}
 
-		if (args.githubOAuthConfig && args.githubIdentityProviderId) {
-			throw new Error(
-				"githubOAuthConfig and githubIdentityProviderId are mutually exclusive",
-			);
-		}
-
-		const githubOrgPaths = (args.paths ?? []).filter(
-			(p) => p.access === "github-org",
-		);
-		if (githubOrgPaths.length > 0) {
-			if (!args.githubIdentityProviderId && !args.githubOAuthConfig) {
-				throw new Error(
-					"githubIdentityProviderId or githubOAuthConfig is required when using github-org access",
-				);
-			}
-			if (!args.githubOrganizations || args.githubOrganizations.length === 0) {
-				throw new Error(
-					"githubOrganizations must not be empty when using github-org access",
-				);
-			}
-		}
-
 		const resourceOpts = { parent: this };
 
-		// 0. Auto-create GitHub Identity Provider if requested
+		// 0. Delegate Access provisioning to AccessGate (ADR-016)
+		let accessGate: AccessGate | undefined;
+		this.accessApplications = [];
 		this.githubIdp = undefined;
-		let githubIdentityProviderId: pulumi.Input<string> | undefined =
-			args.githubIdentityProviderId;
 
-		if (args.githubOAuthConfig) {
-			this.githubIdp = new cloudflare.ZeroTrustAccessIdentityProvider(
-				`${name}-github-idp`,
+		if (args.paths && args.paths.length > 0) {
+			accessGate = new AccessGate(
+				name,
 				{
 					accountId: args.accountId,
-					name: pulumi.interpolate`${args.name} GitHub`,
-					type: "github",
-					config: {
-						clientId: args.githubOAuthConfig.clientId,
-						clientSecret: args.githubOAuthConfig.clientSecret,
-					},
+					zoneId: args.zoneId,
+					name: args.name,
+					domains: args.domains,
+					paths: args.paths,
+					githubIdentityProviderId: args.githubIdentityProviderId,
+					githubOAuthConfig: args.githubOAuthConfig,
+					githubOrganizations: args.githubOrganizations,
 				},
 				resourceOpts,
 			);
-			githubIdentityProviderId = this.githubIdp.id;
+			this.accessApplications = accessGate.accessApplications;
+			this.githubIdp = accessGate.githubIdp;
 		}
 
 		// 1. Create or reference R2 bucket
@@ -580,71 +540,7 @@ export class WorkerSite extends pulumi.ComponentResource {
 			this.workerDomains.push(workerDomain);
 		}
 
-		// 5. Create Zero Trust Access Applications (optional)
-		this.accessApplications = [];
-
-		if (args.paths && args.paths.length > 0) {
-			for (let domainIdx = 0; domainIdx < args.domains.length; domainIdx++) {
-				const domain = args.domains[domainIdx];
-
-				for (let pathIdx = 0; pathIdx < args.paths.length; pathIdx++) {
-					const pathConfig = args.paths[pathIdx];
-
-					const policyIncludes =
-						pathConfig.access === "public" || pathConfig.access === "bypass"
-							? [{ everyone: {} }]
-							: pulumi
-									.all([
-										pulumi.all(args.githubOrganizations ?? []),
-										githubIdentityProviderId ?? "",
-									])
-									.apply(
-										([orgs, idpId]: [string[], string]) =>
-											orgs.map((org: string) => ({
-												githubOrganization: {
-													identityProviderId: idpId,
-													name: org,
-												},
-											})) as cloudflare.types.input.ZeroTrustAccessApplicationPolicyInclude[],
-									);
-
-					const app = new cloudflare.ZeroTrustAccessApplication(
-						`${name}-app-d${domainIdx}-p${pathIdx}`,
-						{
-							accountId: args.accountId,
-							zoneId: args.zoneId,
-							name: pulumi
-								.all([args.name, domain, pathConfig.pattern])
-								.apply(
-									([n, d, p]: [string, string, string]) =>
-										`${n}-${d}-${p.replace(/\//g, "-").replace(/\*/g, "all")}`,
-								),
-							domain: pulumi.interpolate`${domain}${pathConfig.pattern}`,
-							type: "self_hosted",
-							sessionDuration: "24h",
-							policies: [
-								{
-									name: {
-										bypass: "Bypass for public path",
-										public: "Allow everyone",
-										"github-org": "GitHub org members",
-									}[pathConfig.access],
-									decision: {
-										bypass: "bypass",
-										public: "allow",
-										"github-org": "allow",
-									}[pathConfig.access],
-									precedence: 1,
-									includes: policyIncludes,
-								},
-							],
-						},
-						resourceOpts,
-					);
-					this.accessApplications.push(app);
-				}
-			}
-		}
+		// 5. Access Applications are created by AccessGate (step 0)
 
 		// Outputs
 		this.boundDomains = pulumi.output(args.domains);


### PR DESCRIPTION
## Summary

Extract Cloudflare Zero Trust Access provisioning from `WorkerSite` into a reusable `AccessGate` ComponentResource at `@jmmaloney4/sector7/access`.

### New component: `AccessGate`

```ts
import { AccessGate } from "@jmmaloney4/sector7/access";

const gate = new AccessGate("lens-access", {
  accountId: "abc123",
  zoneId: "xyz789",
  name: "lens",
  domains: ["lens.example.com"],
  paths: [{ pattern: "/*", access: "github-org" }],
  githubOAuthConfig: {
    clientId: "Ov23li...",
    clientSecret: pulumi.secret("abc123..."),
  },
  githubOrganizations: ["my-org"],
});
```

### What changed

- **New** `packages/sector7/access/` — `AccessGate` ComponentResource with full Access provisioning logic
- **Refactored** `WorkerSite` — delegates Access creation to `AccessGate` internally, no public API changes
- **Type aliases** — `PathConfig` → `AccessPathConfig`, `GithubOAuthConfig` → `AccessGithubOAuthConfig`
- **New tests** — standalone `AccessGate` test suite covering all access levels, IDP creation, and validation
- **ADR-016** — documents the extraction decision and alternatives

### Why

Access provisioning is useful for any Cloudflare-hosted origin (Workers, Tunnels, Pages), not just WorkerSite. The immediate use case is `addendalabs/yard` where Lens (a GKE service behind a Cloudflare Tunnel) needs Zero Trust auth without the Worker/R2 abstraction.

### Design decisions

- `AccessGate` is a sibling sub-path export (`./access`), following the ADR-014 pattern
- `WorkerSite` passes `name` directly to `AccessGate`, preserving child resource naming for test compatibility
- `PathConfig` and `GithubOAuthConfig` are type aliases, not copies — single source of truth in the access module
- Configurable `sessionDuration` and `type` on AccessGate (defaults match WorkerSite behavior)

### State migration note

Existing `WorkerSite` deployments will see new Pulumi URNs for Access resources (parent changes from WorkerSite to AccessGate). A `pulumi refresh` + manual state edit or re-import may be needed. New deployments are unaffected.

### Files

| File | Change |
|------|--------|
| `packages/sector7/access/access-gate.ts` | New — AccessGate component |
| `packages/sector7/access/index.ts` | New — barrel exports |
| `packages/sector7/index.ts` | Updated — added access namespace |
| `packages/sector7/package.json` | Updated — added `./access` sub-path export |
| `packages/sector7/workersite/worker-site.ts` | Refactored — delegates to AccessGate |
| `packages/sector7/tests/access-gate.test.ts` | New — standalone tests |
| `docs/internal/designs/016-extract-access-into-accessgate.md` | New — ADR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Refactors how Cloudflare Access resources are created by introducing a new component and delegating `WorkerSite` behavior to it; while intended to be behavior-preserving, mistakes could change Pulumi resource parenting/aliases or Access policy configuration and cause unexpected diffs in existing stacks.
> 
> **Overview**
> Introduces a new `AccessGate` Pulumi component (exported via `@jmmaloney4/sector7/access`) that provisions Cloudflare Zero Trust Access Applications per (domain, path), optionally auto-creating a GitHub OAuth identity provider, with added validation plus configurable `sessionDuration`/`type` defaults.
> 
> Refactors `WorkerSite` to delegate all Access provisioning to `AccessGate` and replaces its local `PathConfig`/`GithubOAuthConfig` definitions with type aliases to the new access module types, keeping `WorkerSite`’s public args/outputs the same while moving the resource creation boundary.
> 
> Adds a dedicated `AccessGate` test suite using Pulumi mocks, updates package exports (`./access`) and top-level namespace export, and documents the change in ADR-016 including URN preservation via `aliases` when used as a child component.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f8e57446e4b0aed351c3ad1b8a73a0e90c70f330. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->