### PR TITLE
feat: add NixImage component for nix2container build-push

### DIFF
--- a/docs/internal/designs/017-nix-image-component.md
+++ b/docs/internal/designs/017-nix-image-component.md
@@ -1,0 +1,161 @@
+---
+id: ADR-017
+title: NixImage Pulumi Component for nix2container Build-Push
+status: Accepted
+date: 2026-05-05
+deciders: [jmmaloney4]
+tags: [design, adr]
+supersedes: []
+superseded_by: []
+links: [ADR-016]
+---
+
+# Context
+
+Multiple repositories (yard, zeus, and potentially others) build container images
+using nix2container and push them to Google Artifact Registry. Currently each
+repo carries its own build-push script with slight variations in logging, auth,
+and digest extraction. This leads to duplicated effort and divergent behavior.
+
+The nix2container workflow follows a consistent pattern:
+
+1. `nix build` the image derivation
+2. Authenticate to Artifact Registry via `gcloud auth print-access-token`
+3. `skopeo copy` the image to the registry
+4. Extract the digest for downstream Pulumi resource wiring
+
+A shared Pulumi ComponentResource can encapsulate this pattern so consumers
+declare the image they want and get back a stable `imageRef` output with digest,
+just like any other Pulumi resource.
+
+# Decision
+
+Create a `NixImage` ComponentResource at `@jmmaloney4/sector7/nix-image` with
+type token `sector7:nix:NixImage`.
+
+```ts
+import { NixImage } from "@jmmaloney4/sector7/nix-image";
+
+const img = new NixImage("lens-api", {
+  nixAttr: "packages.x86_64-linux.lens-api-image",
+  imageName: "lens-api",
+  imageTag: "dev",
+  artifactRegistryUrl: "us-east1-docker.pkg.dev/my-project/my-repo",
+  repoRoot: "/home/user/my-repo",
+});
+
+// img.imageRef → "registry/lens-api@sha256:..."
+// img.digest → "sha256:..."
+```
+
+The component MUST:
+
+- Delegate actual build+push to an external bash script
+  (`packages/sector7/scripts/nix-image-build-push.sh`), not inlined bash in
+  the Pulumi program. External scripts are easier to test locally and keep
+  the TypeScript thin.
+- Use a `DIGEST_OUTPUT:` marker convention in the script's stdout so the
+  component can reliably parse the digest from `command.local.Command` stdout.
+- Support two modes via the `mode` arg:
+  - `"build"` (default): runs the full build+push pipeline.
+  - `"resolve"`: skips build, uses `skopeo inspect` to resolve the digest of an
+    already-pushed tag. Useful when the image was built elsewhere (e.g. CI) and
+    Pulumi just needs the digest for wiring.
+- Default triggers to `[imageTag]` so Pulumi re-runs the command when the tag
+  changes.
+
+# Consequences
+
+## Positive
+
+- Single source of truth for nix2container build-push logic across repos.
+- Consumers get a Pulumi-native experience: declare, plan, apply.
+- `resolve` mode supports CI-built images without requiring Pulumi to run the
+  nix build itself.
+- `DIGEST_OUTPUT:` marker convention is simple and grep-friendly.
+- Script is independently testable outside Pulumi.
+
+## Negative
+
+- Adds `@pulumi/command` as a peer dependency.
+- The bash script depends on `nix`, `skopeo-nix2container`, and `gcloud` being
+  available on the Pulumi runner.
+- `command.local.Command` stores stdout in state — large build logs could bloat
+  state if not managed carefully.
+
+# Alternatives
+
+### 1. In-repo scripts (status quo)
+
+Pros:
+- No shared dependency.
+- Each repo can customize freely.
+
+Cons:
+- Duplicated auth, logging, and digest extraction logic.
+- Divergent behavior across repos.
+- Changes require updating multiple repos.
+
+Rejected: the pattern is stable enough to share.
+
+### 2. Inline bash in Pulumi program
+
+Pros:
+- No separate script file to manage.
+
+Cons:
+- Hard to test locally without Pulumi.
+- Escaping and readability issues in template strings.
+- Cannot be run standalone for debugging.
+
+Rejected: external script is more maintainable.
+
+### 3. NixImage in yard or zeus (not sector7)
+
+Pros:
+- Closer to the consumer.
+
+Cons:
+- Other repos would depend on yard or zeus just for image building.
+- sector7 exists precisely for shared infrastructure components.
+
+Rejected: sector7 is the correct home for reusable Pulumi components.
+
+# Security / Privacy / Compliance
+
+- The script authenticates to Artifact Registry using `gcloud auth print-access-token`.
+  The token is written to a temporary auth file that is cleaned up on exit (trap).
+- No credentials are stored in Pulumi state beyond the command environment.
+- The `DIGEST_OUTPUT` marker is informational and contains no secrets.
+
+# Operational Notes
+
+- The script creates a log file under `COMMAND_LOG_STEM` (default
+  `.pulumi/command-logs/`) for each build, capturing full output.
+- The `RESULT_LINK` symlink is cleaned up on script exit.
+- `resolve` mode is lightweight and does not require nix or gcloud — only
+  skopeo (via nix2container) with read access to the registry.
+- Default trigger is `[imageTag]`, so changing the tag forces a new build.
+  Consumers can pass custom triggers (e.g. a commit SHA) for finer control.
+
+# Status Transitions
+
+- Follows the component extraction pattern established by ADR-016 (AccessGate).
+
+# Implementation Notes
+
+1. Create `packages/sector7/scripts/nix-image-build-push.sh` (external bash script).
+2. Create `packages/sector7/scripts/index.ts` (script path resolver).
+3. Create `packages/sector7/nix-image/nix-image.ts` (ComponentResource).
+4. Create `packages/sector7/nix-image/index.ts` (barrel export).
+5. Add `./nix-image` and `./scripts` sub-path exports to `package.json`.
+6. Add `@pulumi/command` to peerDependencies and devDependencies.
+7. Add `nixImage` barrel export to `packages/sector7/index.ts`.
+8. Add tests in `packages/sector7/tests/nix-image.test.ts`.
+9. Add ADR-017.
+
+# References
+
+- ADR-016: Extract Access into AccessGate (established ComponentResource pattern)
+- nix2container: https://github.com/nlewo/nix2container
+- hq Front issue: ergodicsystems/hq#135

--- a/package.json
+++ b/package.json
@@ -17,5 +17,12 @@
 		"rimraf": "6.1.3",
 		"@types/node": "24.12.2",
 		"vitest": "4.1.2"
+	},
+	"pnpm": {
+		"onlyBuiltDependencies": [
+			"@pulumi/command",
+			"esbuild",
+			"protobufjs"
+		]
 	}
 }

--- a/packages/sector7/index.ts
+++ b/packages/sector7/index.ts
@@ -1,3 +1,4 @@
 export * as access from "./access/index.ts";
 export * as iam from "./iam/index.ts";
 export * as workersite from "./workersite/index.ts";
+export * as nixImage from "./nix-image/index.ts";

--- a/packages/sector7/nix-image/index.ts
+++ b/packages/sector7/nix-image/index.ts
@@ -1,0 +1,1 @@
+export { NixImage, type NixImageArgs } from "./nix-image.ts";

--- a/packages/sector7/nix-image/nix-image.ts
+++ b/packages/sector7/nix-image/nix-image.ts
@@ -12,8 +12,8 @@ export interface NixImageArgs {
 	/** Registry URL (e.g. "us-east1-docker.pkg.dev/addenda-dev/addenda") */
 	artifactRegistryUrl: pulumi.Input<string>;
 	/** Absolute path to the repo root containing the flake */
-	repoRoot: string;
-	/** Additional trigger values (default: [imageTag]) */
+	repoRoot: pulumi.Input<string>;
+	/** Additional trigger values (added alongside imageTag) */
 	triggers?: pulumi.Input<string>[];
 	/**
 	 * "build" = build+push the image (default)
@@ -33,7 +33,17 @@ export class NixImage extends pulumi.ComponentResource {
 		args: NixImageArgs,
 		opts?: pulumi.ComponentResourceOptions,
 	) {
-		super("sector7:nix:NixImage", name, {}, opts);
+		// Build resource aliases: add URN alias when parented so the child
+		// resource is adopted correctly under the parent.
+		const aliases: pulumi.Alias[] = [];
+		if (opts?.parent) {
+			aliases.push({ parent: opts.parent });
+		}
+
+		super("sector7:nix:NixImage", name, args, {
+			...opts,
+			aliases: [...aliases, ...(opts?.aliases ?? [])],
+		});
 
 		const scriptPath = getScriptPath("nix-image-build-push.sh");
 		const commandLogStem = `.pulumi/command-logs/${name}`;
@@ -45,16 +55,16 @@ export class NixImage extends pulumi.ComponentResource {
 			const fullTag = pulumi.interpolate`${args.artifactRegistryUrl}/${args.imageName}:${args.imageTag}`;
 
 			const resolveCmd = new command.local.Command(`${name}-resolve`, {
-				create: pulumi.interpolate`nix run github:nlewo/nix2container#skopeo-nix2container -- inspect --override-os linux docker://${fullTag} 2>/dev/null | grep -o '"digest":"[^"]*"' | cut -d'"' -f4`,
-				triggers: args.triggers ?? [args.imageTag],
+				create: pulumi.interpolate`nix run github:nlewo/nix2container#skopeo-nix2container -- inspect --format '{{.Digest}}' --override-os linux docker://${fullTag}`,
+				triggers: [args.imageTag, ...(args.triggers ?? [])],
 			}, { parent: this });
 
-			this.digest = resolveCmd.stdout;
+			this.digest = resolveCmd.stdout.apply((stdout: string) => stdout.trim());
 			this.imageRef = pulumi.interpolate`${args.artifactRegistryUrl}/${args.imageName}@${this.digest}`;
 		} else {
 			// Build + push
 			const buildCmd = new command.local.Command(`${name}-build-push`, {
-				create: pulumi.interpolate`bash ${scriptPath}`,
+				create: pulumi.interpolate`bash "${scriptPath}"`,
 				environment: {
 					NIX_ATTR: args.nixAttr,
 					IMAGE_NAME: args.imageName,
@@ -64,7 +74,7 @@ export class NixImage extends pulumi.ComponentResource {
 					RESULT_LINK: `result-${name}`,
 					COMMAND_LOG_STEM: commandLogStem,
 				},
-				triggers: args.triggers ?? [args.imageTag],
+				triggers: [args.imageTag, ...(args.triggers ?? [])],
 			}, { parent: this });
 
 			// Parse DIGEST_OUTPUT: from stdout

--- a/packages/sector7/nix-image/nix-image.ts
+++ b/packages/sector7/nix-image/nix-image.ts
@@ -1,0 +1,87 @@
+import * as pulumi from "@pulumi/pulumi";
+import * as command from "@pulumi/command";
+import { getScriptPath } from "../scripts/index.ts";
+
+export interface NixImageArgs {
+	/** Flake attribute path (e.g. "packages.x86_64-linux.lens-api-image") */
+	nixAttr: pulumi.Input<string>;
+	/** Image name in the registry (e.g. "lens-api") */
+	imageName: pulumi.Input<string>;
+	/** Tag to push (e.g. "dev", "v1.2.3") */
+	imageTag: pulumi.Input<string>;
+	/** Registry URL (e.g. "us-east1-docker.pkg.dev/addenda-dev/addenda") */
+	artifactRegistryUrl: pulumi.Input<string>;
+	/** Absolute path to the repo root containing the flake */
+	repoRoot: string;
+	/** Additional trigger values (default: [imageTag]) */
+	triggers?: pulumi.Input<string>[];
+	/**
+	 * "build" = build+push the image (default)
+	 * "resolve" = skip build, just resolve the digest of the already-pushed tag
+	 */
+	mode?: "build" | "resolve";
+}
+
+export class NixImage extends pulumi.ComponentResource {
+	/** Full image reference with digest (e.g. "registry/image@sha256:...") */
+	public readonly imageRef: pulumi.Output<string>;
+	/** The digest (e.g. "sha256:...") */
+	public readonly digest: pulumi.Output<string>;
+
+	constructor(
+		name: string,
+		args: NixImageArgs,
+		opts?: pulumi.ComponentResourceOptions,
+	) {
+		super("sector7:nix:NixImage", name, {}, opts);
+
+		const scriptPath = getScriptPath("nix-image-build-push.sh");
+		const commandLogStem = `.pulumi/command-logs/${name}`;
+
+		const mode = args.mode ?? "build";
+
+		if (mode === "resolve") {
+			// Resolve-only: inspect the already-pushed image to get its digest
+			const fullTag = pulumi.interpolate`${args.artifactRegistryUrl}/${args.imageName}:${args.imageTag}`;
+
+			const resolveCmd = new command.local.Command(`${name}-resolve`, {
+				create: pulumi.interpolate`nix run github:nlewo/nix2container#skopeo-nix2container -- inspect --override-os linux docker://${fullTag} 2>/dev/null | grep -o '"digest":"[^"]*"' | cut -d'"' -f4`,
+				triggers: args.triggers ?? [args.imageTag],
+			}, { parent: this });
+
+			this.digest = resolveCmd.stdout;
+			this.imageRef = pulumi.interpolate`${args.artifactRegistryUrl}/${args.imageName}@${this.digest}`;
+		} else {
+			// Build + push
+			const buildCmd = new command.local.Command(`${name}-build-push`, {
+				create: pulumi.interpolate`bash ${scriptPath}`,
+				environment: {
+					NIX_ATTR: args.nixAttr,
+					IMAGE_NAME: args.imageName,
+					IMAGE_TAG: args.imageTag,
+					ARTIFACT_REGISTRY_URL: args.artifactRegistryUrl,
+					REPO_ROOT: args.repoRoot,
+					RESULT_LINK: `result-${name}`,
+					COMMAND_LOG_STEM: commandLogStem,
+				},
+				triggers: args.triggers ?? [args.imageTag],
+			}, { parent: this });
+
+			// Parse DIGEST_OUTPUT: from stdout
+			this.digest = buildCmd.stdout.apply((stdout: string) => {
+				const match = stdout.match(/DIGEST_OUTPUT:(sha256:[a-f0-9]+)/);
+				if (!match) {
+					throw new Error(`Could not parse DIGEST_OUTPUT from build output for ${name}`);
+				}
+				return match[1];
+			});
+
+			this.imageRef = pulumi.interpolate`${args.artifactRegistryUrl}/${args.imageName}@${this.digest}`;
+		}
+
+		this.registerOutputs({
+			imageRef: this.imageRef,
+			digest: this.digest,
+		});
+	}
+}

--- a/packages/sector7/package.json
+++ b/packages/sector7/package.json
@@ -30,6 +30,14 @@
 		"./r2": {
 			"types": "./r2/index.ts",
 			"default": "./r2/index.ts"
+		},
+		"./nix-image": {
+			"types": "./nix-image/index.ts",
+			"default": "./nix-image/index.ts"
+		},
+		"./scripts": {
+			"types": "./scripts/index.ts",
+			"default": "./scripts/index.ts"
 		}
 	},
 	"files": [
@@ -37,7 +45,9 @@
 		"access",
 		"iam",
 		"workersite",
-		"r2"
+		"r2",
+		"nix-image",
+		"scripts"
 	],
 	"scripts": {
 		"test": "vitest run",
@@ -46,12 +56,14 @@
 	"peerDependencies": {
 		"@pulumi/pulumi": "^3.0.0",
 		"@pulumi/cloudflare": "^6.0.0",
-		"@pulumi/gcp": "^9.0.0"
+		"@pulumi/gcp": "^9.0.0",
+		"@pulumi/command": "^1.0.0"
 	},
 	"devDependencies": {
 		"@pulumi/pulumi": "3.230.0",
 		"@pulumi/cloudflare": "6.14.0",
 		"@pulumi/gcp": "9.19.0",
+		"@pulumi/command": "1.2.1",
 		"vitest": "4.1.2"
 	}
 }

--- a/packages/sector7/scripts/index.ts
+++ b/packages/sector7/scripts/index.ts
@@ -1,0 +1,9 @@
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+/** Resolve the absolute path to a script shipped with this package */
+export function getScriptPath(scriptName: string): string {
+	return path.join(__dirname, scriptName);
+}

--- a/packages/sector7/scripts/nix-image-build-push.sh
+++ b/packages/sector7/scripts/nix-image-build-push.sh
@@ -30,7 +30,7 @@ echo "REPO_ROOT: ${REPO_ROOT}"
 DIGEST_FILE=$(mktemp)
 
 # Set up cleanup trap for temp files
-AUTH_FILE=***
+AUTH_FILE=$(mktemp)
 trap 'rm -f "${AUTH_FILE}" "${RESULT_LINK}" "${DIGEST_FILE}"' EXIT
 
 # Build the image

--- a/packages/sector7/scripts/nix-image-build-push.sh
+++ b/packages/sector7/scripts/nix-image-build-push.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Generic nix2container image build+push script
+# Env vars: NIX_ATTR, IMAGE_NAME, IMAGE_TAG, ARTIFACT_REGISTRY_URL, 
+#           REPO_ROOT, RESULT_LINK (default: result-image), COMMAND_LOG_STEM
+
+set -euo pipefail
+
+# Validate required env vars
+for var in NIX_ATTR IMAGE_NAME IMAGE_TAG ARTIFACT_REGISTRY_URL REPO_ROOT; do
+  if [ -z "${!var:-}" ]; then
+    echo "ERROR: Required env var $var is not set" >&2
+    exit 1
+  fi
+done
+
+RESULT_LINK="${RESULT_LINK:-result-image}"
+COMMAND_LOG_STEM="${COMMAND_LOG_STEM:-.pulumi/command-logs}"
+
+# Set up logging
+LOG_DIR="${COMMAND_LOG_STEM}"
+mkdir -p "${LOG_DIR}"
+LOG_FILE="${LOG_DIR}/$(date +%Y%m%d-%H%M%S)-${IMAGE_NAME}.log"
+exec > >(tee -a "${LOG_FILE}") 2>&1
+
+echo "=== Building ${IMAGE_NAME}:${IMAGE_TAG} ==="
+echo "NIX_ATTR: ${NIX_ATTR}"
+echo "REPO_ROOT: ${REPO_ROOT}"
+
+# Build the image
+echo "--- nix build ---"
+nix build "${REPO_ROOT}#${NIX_ATTR}" -o "${RESULT_LINK}" -L
+
+IMAGE_PATH="nix:./${RESULT_LINK}"
+FULL_TAG="${ARTIFACT_REGISTRY_URL}/${IMAGE_NAME}:${IMAGE_TAG}"
+
+# Authenticate
+echo "--- authenticating ---"
+AUTH_FILE=$(mktemp)
+trap 'rm -f "${AUTH_FILE}" "${RESULT_LINK}"' EXIT
+gcloud auth print-access-token \
+  | nix run github:nlewo/nix2container#skopeo-nix2container -- \
+      login -u oauth2accesstoken --password-stdin \
+      --authfile "${AUTH_FILE}" \
+      "${ARTIFACT_REGISTRY_URL}"
+
+# Push the image
+echo "--- skopeo copy ---"
+DIGEST_FILE=$(mktemp)
+nix run github:nlewo/nix2container#skopeo-nix2container -- \
+  copy --digestfile "${DIGEST_FILE}" \
+  --authfile "${AUTH_FILE}" \
+  "${IMAGE_PATH}" \
+  "docker://${FULL_TAG}"
+
+DIGEST=$(cat "${DIGEST_FILE}")
+rm -f "${DIGEST_FILE}"
+
+echo "=== Pushed ${FULL_TAG} ==="
+echo "=== Digest: ${DIGEST} ==="
+echo "DIGEST_OUTPUT:${DIGEST}"

--- a/packages/sector7/scripts/nix-image-build-push.sh
+++ b/packages/sector7/scripts/nix-image-build-push.sh
@@ -26,6 +26,13 @@ echo "=== Building ${IMAGE_NAME}:${IMAGE_TAG} ==="
 echo "NIX_ATTR: ${NIX_ATTR}"
 echo "REPO_ROOT: ${REPO_ROOT}"
 
+# Create temp files early so they can be cleaned up by the trap
+DIGEST_FILE=$(mktemp)
+
+# Set up cleanup trap for temp files
+AUTH_FILE=***
+trap 'rm -f "${AUTH_FILE}" "${RESULT_LINK}" "${DIGEST_FILE}"' EXIT
+
 # Build the image
 echo "--- nix build ---"
 nix build "${REPO_ROOT}#${NIX_ATTR}" -o "${RESULT_LINK}" -L
@@ -35,8 +42,6 @@ FULL_TAG="${ARTIFACT_REGISTRY_URL}/${IMAGE_NAME}:${IMAGE_TAG}"
 
 # Authenticate
 echo "--- authenticating ---"
-AUTH_FILE=$(mktemp)
-trap 'rm -f "${AUTH_FILE}" "${RESULT_LINK}"' EXIT
 gcloud auth print-access-token \
   | nix run github:nlewo/nix2container#skopeo-nix2container -- \
       login -u oauth2accesstoken --password-stdin \
@@ -45,7 +50,6 @@ gcloud auth print-access-token \
 
 # Push the image
 echo "--- skopeo copy ---"
-DIGEST_FILE=$(mktemp)
 nix run github:nlewo/nix2container#skopeo-nix2container -- \
   copy --digestfile "${DIGEST_FILE}" \
   --authfile "${AUTH_FILE}" \
@@ -53,7 +57,6 @@ nix run github:nlewo/nix2container#skopeo-nix2container -- \
   "docker://${FULL_TAG}"
 
 DIGEST=$(cat "${DIGEST_FILE}")
-rm -f "${DIGEST_FILE}"
 
 echo "=== Pushed ${FULL_TAG} ==="
 echo "=== Digest: ${DIGEST} ==="

--- a/packages/sector7/tests/nix-image.test.ts
+++ b/packages/sector7/tests/nix-image.test.ts
@@ -25,9 +25,9 @@ beforeAll(() => {
 					(state as Record<string, unknown>).stdout =
 						"=== Pushed registry/example:dev ===\n=== Digest: sha256:abc123def456 ===\nDIGEST_OUTPUT:sha256:abc123def456\n";
 				} else if (create?.includes("inspect")) {
-					// Resolve mode: simulate skopeo inspect output
+					// Resolve mode: simulate skopeo inspect --format output
 					(state as Record<string, unknown>).stdout =
-						"sha256:abc123def456";
+						"sha256:abc123def456\n";
 				}
 			}
 
@@ -111,6 +111,7 @@ describe("NixImage", () => {
 
 		const createCmd = cmd.inputs.create as string;
 		expect(createCmd).toContain("inspect");
+		expect(createCmd).toContain("--format");
 		expect(createCmd).toContain("my-image");
 		expect(createCmd).toContain("v1.0.0");
 	});
@@ -143,7 +144,7 @@ describe("NixImage", () => {
 		);
 	});
 
-	it("uses default triggers [imageTag] when no triggers specified", async () => {
+	it("uses additive triggers with imageTag first when no triggers specified", async () => {
 		const img = new NixImage("test-triggers-default", {
 			nixAttr: "packages.x86_64-linux.my-image",
 			imageName: "my-image",
@@ -161,7 +162,7 @@ describe("NixImage", () => {
 		expect(triggers).toEqual(["dev"]);
 	});
 
-	it("uses custom triggers when specified", async () => {
+	it("uses additive triggers: imageTag plus custom triggers", async () => {
 		const img = new NixImage("test-triggers-custom", {
 			nixAttr: "packages.x86_64-linux.my-image",
 			imageName: "my-image",
@@ -177,10 +178,10 @@ describe("NixImage", () => {
 		expect(cmds).toHaveLength(1);
 
 		const triggers = cmds[0].inputs.triggers as string[];
-		expect(triggers).toEqual(["custom-trigger-1", "custom-trigger-2"]);
+		expect(triggers).toEqual(["dev", "custom-trigger-1", "custom-trigger-2"]);
 	});
 
-	it("uses resolve mode default triggers [imageTag]", async () => {
+	it("uses resolve mode additive triggers with imageTag first", async () => {
 		const img = new NixImage("test-resolve-triggers", {
 			nixAttr: "packages.x86_64-linux.my-image",
 			imageName: "my-image",
@@ -213,6 +214,21 @@ describe("NixImage", () => {
 		expect(imageRef).toBe(
 			"us-east1-docker.pkg.dev/my-project/my-repo/my-image@sha256:abc123def456",
 		);
+	});
+
+	it("trims trailing newline from resolve stdout", async () => {
+		const img = new NixImage("test-resolve-trim", {
+			nixAttr: "packages.x86_64-linux.my-image",
+			imageName: "my-image",
+			imageTag: "v1.0.0",
+			artifactRegistryUrl: "us-east1-docker.pkg.dev/my-project/my-repo",
+			repoRoot: "/home/user/my-repo",
+			mode: "resolve",
+		});
+
+		const digest = await resolveOutput(img.digest);
+		expect(digest).toBe("sha256:abc123def456");
+		expect(digest).not.toContain("\n");
 	});
 
 	it("registers outputs imageRef and digest", async () => {

--- a/packages/sector7/tests/nix-image.test.ts
+++ b/packages/sector7/tests/nix-image.test.ts
@@ -1,0 +1,251 @@
+import * as pulumi from "@pulumi/pulumi";
+import * as command from "@pulumi/command";
+import { beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { NixImage } from "../nix-image/nix-image";
+
+type MockResource = {
+	type: string;
+	name: string;
+	inputs: Record<string, unknown>;
+};
+
+const resources: MockResource[] = [];
+
+beforeAll(() => {
+	pulumi.runtime.setMocks({
+		newResource: (args) => {
+			const state = args.inputs;
+
+			// For command.local.Command, simulate stdout with DIGEST_OUTPUT marker
+			if (args.type === "command:local:Command") {
+				const create = state.create as string | undefined;
+
+				if (create?.includes("nix-image-build-push.sh")) {
+					// Build mode: simulate script output
+					(state as Record<string, unknown>).stdout =
+						"=== Pushed registry/example:dev ===\n=== Digest: sha256:abc123def456 ===\nDIGEST_OUTPUT:sha256:abc123def456\n";
+				} else if (create?.includes("inspect")) {
+					// Resolve mode: simulate skopeo inspect output
+					(state as Record<string, unknown>).stdout =
+						"sha256:abc123def456";
+				}
+			}
+
+			resources.push({
+				type: args.type,
+				name: args.name,
+				inputs: state as Record<string, unknown>,
+			});
+
+			return {
+				id: `${args.name}-id`,
+				state,
+			};
+		},
+		call: (args) => args.inputs,
+	});
+});
+
+beforeEach(() => {
+	resources.length = 0;
+});
+
+function resolveOutput<T>(value: pulumi.Input<T>): Promise<T> {
+	return new Promise((resolve) => {
+		pulumi.output(value).apply((resolved) => {
+			resolve(resolved as T);
+			return resolved;
+		});
+	});
+}
+
+function byName(fragment: string): MockResource[] {
+	return resources.filter((resource) => resource.name.includes(fragment));
+}
+
+describe("NixImage", () => {
+	it("creates a Command resource for build mode with correct env vars", async () => {
+		const img = new NixImage("test-build", {
+			nixAttr: "packages.x86_64-linux.my-image",
+			imageName: "my-image",
+			imageTag: "dev",
+			artifactRegistryUrl: "us-east1-docker.pkg.dev/my-project/my-repo",
+			repoRoot: "/home/user/my-repo",
+		});
+
+		await resolveOutput(img.digest);
+
+		const cmds = byName("test-build-build-push");
+		expect(cmds).toHaveLength(1);
+
+		const cmd = cmds[0];
+		expect(cmd.type).toBe("command:local:Command");
+		expect(cmd.inputs.environment).toEqual({
+			NIX_ATTR: "packages.x86_64-linux.my-image",
+			IMAGE_NAME: "my-image",
+			IMAGE_TAG: "dev",
+			ARTIFACT_REGISTRY_URL: "us-east1-docker.pkg.dev/my-project/my-repo",
+			REPO_ROOT: "/home/user/my-repo",
+			RESULT_LINK: "result-test-build",
+			COMMAND_LOG_STEM: ".pulumi/command-logs/test-build",
+		});
+	});
+
+	it("creates a Command resource for resolve mode that inspects the image", async () => {
+		const img = new NixImage("test-resolve", {
+			nixAttr: "packages.x86_64-linux.my-image",
+			imageName: "my-image",
+			imageTag: "v1.0.0",
+			artifactRegistryUrl: "us-east1-docker.pkg.dev/my-project/my-repo",
+			repoRoot: "/home/user/my-repo",
+			mode: "resolve",
+		});
+
+		await resolveOutput(img.digest);
+
+		const cmds = byName("test-resolve-resolve");
+		expect(cmds).toHaveLength(1);
+
+		const cmd = cmds[0];
+		expect(cmd.type).toBe("command:local:Command");
+
+		const createCmd = cmd.inputs.create as string;
+		expect(createCmd).toContain("inspect");
+		expect(createCmd).toContain("my-image");
+		expect(createCmd).toContain("v1.0.0");
+	});
+
+	it("parses DIGEST_OUTPUT marker from stdout correctly", async () => {
+		const img = new NixImage("test-digest", {
+			nixAttr: "packages.x86_64-linux.my-image",
+			imageName: "my-image",
+			imageTag: "dev",
+			artifactRegistryUrl: "us-east1-docker.pkg.dev/my-project/my-repo",
+			repoRoot: "/home/user/my-repo",
+		});
+
+		const digest = await resolveOutput(img.digest);
+		expect(digest).toBe("sha256:abc123def456");
+	});
+
+	it("produces correct imageRef with digest", async () => {
+		const img = new NixImage("test-ref", {
+			nixAttr: "packages.x86_64-linux.my-image",
+			imageName: "my-image",
+			imageTag: "dev",
+			artifactRegistryUrl: "us-east1-docker.pkg.dev/my-project/my-repo",
+			repoRoot: "/home/user/my-repo",
+		});
+
+		const imageRef = await resolveOutput(img.imageRef);
+		expect(imageRef).toBe(
+			"us-east1-docker.pkg.dev/my-project/my-repo/my-image@sha256:abc123def456",
+		);
+	});
+
+	it("uses default triggers [imageTag] when no triggers specified", async () => {
+		const img = new NixImage("test-triggers-default", {
+			nixAttr: "packages.x86_64-linux.my-image",
+			imageName: "my-image",
+			imageTag: "dev",
+			artifactRegistryUrl: "us-east1-docker.pkg.dev/my-project/my-repo",
+			repoRoot: "/home/user/my-repo",
+		});
+
+		await resolveOutput(img.digest);
+
+		const cmds = byName("test-triggers-default-build-push");
+		expect(cmds).toHaveLength(1);
+
+		const triggers = cmds[0].inputs.triggers as string[];
+		expect(triggers).toEqual(["dev"]);
+	});
+
+	it("uses custom triggers when specified", async () => {
+		const img = new NixImage("test-triggers-custom", {
+			nixAttr: "packages.x86_64-linux.my-image",
+			imageName: "my-image",
+			imageTag: "dev",
+			artifactRegistryUrl: "us-east1-docker.pkg.dev/my-project/my-repo",
+			repoRoot: "/home/user/my-repo",
+			triggers: ["custom-trigger-1", "custom-trigger-2"],
+		});
+
+		await resolveOutput(img.digest);
+
+		const cmds = byName("test-triggers-custom-build-push");
+		expect(cmds).toHaveLength(1);
+
+		const triggers = cmds[0].inputs.triggers as string[];
+		expect(triggers).toEqual(["custom-trigger-1", "custom-trigger-2"]);
+	});
+
+	it("uses resolve mode default triggers [imageTag]", async () => {
+		const img = new NixImage("test-resolve-triggers", {
+			nixAttr: "packages.x86_64-linux.my-image",
+			imageName: "my-image",
+			imageTag: "v2.0.0",
+			artifactRegistryUrl: "us-east1-docker.pkg.dev/my-project/my-repo",
+			repoRoot: "/home/user/my-repo",
+			mode: "resolve",
+		});
+
+		await resolveOutput(img.digest);
+
+		const cmds = byName("test-resolve-triggers-resolve");
+		expect(cmds).toHaveLength(1);
+
+		const triggers = cmds[0].inputs.triggers as string[];
+		expect(triggers).toEqual(["v2.0.0"]);
+	});
+
+	it("produces correct imageRef in resolve mode", async () => {
+		const img = new NixImage("test-resolve-ref", {
+			nixAttr: "packages.x86_64-linux.my-image",
+			imageName: "my-image",
+			imageTag: "v1.0.0",
+			artifactRegistryUrl: "us-east1-docker.pkg.dev/my-project/my-repo",
+			repoRoot: "/home/user/my-repo",
+			mode: "resolve",
+		});
+
+		const imageRef = await resolveOutput(img.imageRef);
+		expect(imageRef).toBe(
+			"us-east1-docker.pkg.dev/my-project/my-repo/my-image@sha256:abc123def456",
+		);
+	});
+
+	it("registers outputs imageRef and digest", async () => {
+		const img = new NixImage("test-outputs", {
+			nixAttr: "packages.x86_64-linux.my-image",
+			imageName: "my-image",
+			imageTag: "dev",
+			artifactRegistryUrl: "us-east1-docker.pkg.dev/my-project/my-repo",
+			repoRoot: "/home/user/my-repo",
+		});
+
+		const digest = await resolveOutput(img.digest);
+		const imageRef = await resolveOutput(img.imageRef);
+
+		expect(digest).toBeTruthy();
+		expect(imageRef).toBeTruthy();
+		expect(imageRef).toContain(digest);
+	});
+
+	it("uses the sector7:nix:NixImage type token", async () => {
+		const img = new NixImage("test-type-token", {
+			nixAttr: "packages.x86_64-linux.my-image",
+			imageName: "my-image",
+			imageTag: "dev",
+			artifactRegistryUrl: "us-east1-docker.pkg.dev/my-project/my-repo",
+			repoRoot: "/home/user/my-repo",
+		});
+
+		await resolveOutput(img.digest);
+
+		const component = resources.find(
+			(r) => r.type === "sector7:nix:NixImage" && r.name === "test-type-token",
+		);
+		expect(component).toBeDefined();
+	});
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       '@pulumi/cloudflare':
         specifier: 6.14.0
         version: 6.14.0(typescript@5.9.3)
+      '@pulumi/command':
+        specifier: 1.2.1
+        version: 1.2.1(typescript@5.9.3)
       '@pulumi/gcp':
         specifier: 9.19.0
         version: 9.19.0(typescript@5.9.3)
@@ -450,6 +453,9 @@ packages:
 
   '@pulumi/cloudflare@6.14.0':
     resolution: {integrity: sha512-YKH9x7UsNg5iI92g9hVL893MzF8VS4W7nANFvr1TN99mQczPKNi0Z1abTBxyZ4DcB/JWi5zq+va7rJuKkuVr6Q==}
+
+  '@pulumi/command@1.2.1':
+    resolution: {integrity: sha512-mutNDIUYP67yCBYOVIidQyxuTwZDY9v/sx9EGbgIv4PXfyfolOKGgGLeoHEbI1lxRwaw2wbTZ3VNIynDnA5VKA==}
 
   '@pulumi/gcp@9.19.0':
     resolution: {integrity: sha512-93Slg9Lp4x/b2bPKp9e2xOuRhp0VcnRYNw3gAxbgyRgokppf/vDhTzmXMEGyJzsgrDXhA6iQQpkGyi4i8f979A==}
@@ -2148,6 +2154,14 @@ snapshots:
   '@protobufjs/utf8@1.1.0': {}
 
   '@pulumi/cloudflare@6.14.0(typescript@5.9.3)':
+    dependencies:
+      '@pulumi/pulumi': 3.230.0(typescript@5.9.3)
+    transitivePeerDependencies:
+      - supports-color
+      - ts-node
+      - typescript
+
+  '@pulumi/command@1.2.1(typescript@5.9.3)':
     dependencies:
       '@pulumi/pulumi': 3.230.0(typescript@5.9.3)
     transitivePeerDependencies:


### PR DESCRIPTION
## Summary

Adds a `NixImage` Pulumi ComponentResource and external bash script for nix2container image build-push, following the AccessGate pattern (ADR-016).

## What's included

- **Bash script**: `packages/sector7/scripts/nix-image-build-push.sh` — generic nix2container build+push with env var validation, logging, auth, and `DIGEST_OUTPUT:` marker
- **Script resolver**: `packages/sector7/scripts/index.ts` — resolves absolute path to shipped scripts
- **NixImage component**: `packages/sector7/nix-image/nix-image.ts` — Pulumi ComponentResource (type token `sector7:nix:NixImage`) with `build` and `resolve` modes
- **Module barrel**: `packages/sector7/nix-image/index.ts`
- **Tests**: `packages/sector7/tests/nix-image.test.ts` — 10 tests covering build mode, resolve mode, env vars, digest parsing, triggers, type token
- **ADR-017**: `docs/internal/designs/017-nix-image-component.md`
- **Package updates**: exports, files array, `@pulumi/command` dependency

## API

```ts
import { NixImage } from "@jmmaloney4/sector7/nix-image";

const img = new NixImage("lens-api", {
  nixAttr: "packages.x86_64-linux.lens-api-image",
  imageName: "lens-api",
  imageTag: "dev",
  artifactRegistryUrl: "us-east1-docker.pkg.dev/my-project/my-repo",
  repoRoot: "/home/user/my-repo",
});

// img.imageRef → "registry/lens-api@sha256:..."
// img.digest → "sha256:..."
```

## Verification

- `tsc --noEmit` passes
- All 39 tests pass (including 10 new NixImage tests)

## References

- Refs ergodicsystems/hq#135
- Follows pattern from ADR-016 (AccessGate extraction)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new Pulumi component that runs local build/push commands (including `gcloud` auth and `skopeo` operations) and adds `@pulumi/command` as a dependency, so failures or environment differences can impact deployments.
> 
> **Overview**
> Adds a new `NixImage` `ComponentResource` (`sector7:nix:NixImage`) that encapsulates nix2container container image publishing and returns `imageRef`/`digest`, supporting both **build+push** (external `bash` script) and **resolve-only** (inspect an existing tag) modes with tag-based triggers.
> 
> Introduces `packages/sector7/scripts/nix-image-build-push.sh` (env validation, logging, `gcloud` token auth, `skopeo copy`, and a `DIGEST_OUTPUT:` marker) plus a `getScriptPath` helper, wires new `nix-image`/`scripts` exports, and adds tests and an accepted ADR. Also adds `@pulumi/command` to `sector7` peer/dev deps and updates pnpm config/lockfile accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3766040f80db9663b0d8c450bf043887763932ed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->