### PR TITLE
feat: configurable multi-target pnpm publish workflow + ADR-018

### DIFF
--- a/.github/actions/analyze-pnpm-packages/action.yml
+++ b/.github/actions/analyze-pnpm-packages/action.yml
@@ -1,12 +1,25 @@
 name: Analyze pnpm packages
-description: Detect packages, query GHCR for published versions, semver compare, emit matrix and summary
+description: >
+  Detect packages under packages/*, check whether they need publishing,
+  and emit a JSON matrix and summary. Supports multiple publish targets:
+  release (GitHub Release tarball assets), ghcr (GitHub Packages npm registry),
+  npm (npmjs.org), and gcp (Google Artifact Registry npm).
 inputs:
   dry_run:
     description: Run in dry-run mode
     required: false
     default: "false"
+  target:
+    description: >
+      Publish target: release (GitHub Release tarball), ghcr (GitHub Packages),
+      npm (npmjs.org), gcp (Google Artifact Registry).
+    required: false
+    default: "release"
   registry:
-    description: npm registry URL (GHCR)
+    description: >
+      npm registry URL for ghcr/npm/gcp targets.
+      Defaults to https://npm.pkg.github.com for ghcr.
+      Ignored when target=release.
     required: false
     default: "https://npm.pkg.github.com"
   root:
@@ -16,6 +29,12 @@ inputs:
   scope:
     description: npm scope filter (e.g., @jmmaloney4); if set, only include scoped packages
     required: false
+  github_repository:
+    description: >
+      Owner/repository for GitHub Release asset checks when target=release.
+      Defaults to ${{ github.repository }}.
+    required: false
+    default: ""
 outputs:
   matrix:
     description: JSON matrix of packages and actions
@@ -30,8 +49,10 @@ runs:
       shell: bash
       env:
         A_DRY_RUN: ${{ inputs.dry_run }}
+        A_TARGET: ${{ inputs.target }}
         A_REGISTRY: ${{ inputs.registry }}
         A_ROOT: ${{ inputs.root }}
         A_SCOPE: ${{ inputs.scope }}
+        A_GITHUB_REPOSITORY: ${{ inputs.github_repository }}
         NODE_AUTH_TOKEN: ${{ env.NODE_AUTH_TOKEN }}
       run: $GITHUB_ACTION_PATH/main.sh

--- a/.github/actions/analyze-pnpm-packages/main.sh
+++ b/.github/actions/analyze-pnpm-packages/main.sh
@@ -3,9 +3,11 @@ set -euo pipefail
 
 # Inputs
 DRY_RUN="${A_DRY_RUN,,}"
-REG="${A_REGISTRY}"
-ROOT="${A_ROOT}"
+TARGET="${A_TARGET:-release}"
+REG="${A_REGISTRY:-https://npm.pkg.github.com}"
+ROOT="${A_ROOT:-.}"
 SCOPE="${A_SCOPE:-}"
+GITHUB_REPO="${A_GITHUB_REPOSITORY:-}"
 
 # Outputs
 SUMMARY_FILE="${GITHUB_STEP_SUMMARY:-/dev/stdout}"
@@ -29,12 +31,32 @@ get_pkg_json_field() {
   jq -r ".${field} // empty" "${path}/package.json"
 }
 
+# Derive a short slug from a scoped package name.
+# @jmmaloney4/sector7 -> sector7
+# unscoped-package -> unscoped-package
+pkg_slug() {
+  local name="$1"
+  if [[ "$name" == @* ]]; then
+    echo "$name" | sed 's|^@[^/]*/||'
+  else
+    echo "$name"
+  fi
+}
+
+# Derive the tarball filename npm pack would produce.
+# @jmmaloney4/sector7 -> jmmaloney4-sector7
+# plain-pkg -> plain-pkg
+tarball_stem() {
+  local name="$1"
+  # npm pack: strip @, replace / with -
+  echo "$name" | sed 's|^@||; s|/|-|g'
+}
+
 compare_versions() {
   local local_ver="$1" published_ver="$2"
   if [[ "$published_ver" == "Not found" ]]; then
     echo "initial"
   else
-    # Use jq for version comparison
     jq -n --arg local "$local_ver" --arg published "$published_ver" '
       def version_parts(v): (v | split("-")[0]) | split(".") | map(tonumber? // 0);
       def compare_versions(a; b):
@@ -51,11 +73,72 @@ compare_versions() {
   fi
 }
 
+# Check if a GitHub Release asset already exists for this package+version.
+# Returns "found" or "Not found".
+check_release_asset() {
+  local name="$1" version="$2"
+  local slug
+  slug="$(pkg_slug "$name")"
+  local tag="${slug}-v${version}"
+  local stem
+  stem="$(tarball_stem "$name")"
+  local asset_name="${stem}-${version}.tgz"
+
+  if [[ -z "$GITHUB_REPO" ]]; then
+    echo "Not found"
+    return
+  fi
+
+  # Query GitHub Releases API for the tag
+  local resp
+  resp="$(curl -sfL \
+    -H "Authorization: Bearer ${NODE_AUTH_TOKEN:-}" \
+    -H "Accept: application/vnd.github+json" \
+    "https://api.github.com/repos/${GITHUB_REPO}/releases/tags/${tag}" 2>/dev/null || echo "")"
+
+  if [[ -z "$resp" ]]; then
+    echo "Not found"
+    return
+  fi
+
+  # Check if the expected asset exists in the release
+  local asset_count
+  asset_count="$(echo "$resp" | jq --arg name "$asset_name" '.assets | map(select(.name == $name)) | length')"
+
+  if [[ "$asset_count" -gt 0 ]]; then
+    echo "found"
+  else
+    echo "Not found"
+  fi
+}
+
+# Check if a version is published on an npm registry (ghcr/npm/gcp).
+check_registry_version() {
+  local name="$1"
+  local published_ver="Not found"
+  if [[ -n "${NODE_AUTH_TOKEN:-}" ]]; then
+    local encoded
+    encoded="$(urlencode "${name}")"
+    local resp
+    resp="$(curl -sfL \
+      -H "Authorization: Bearer ${NODE_AUTH_TOKEN:-}" \
+      -H "Accept: application/vnd.npm.install-v1+json" \
+      "${REG}/${encoded}" 2>/dev/null || echo "")"
+
+    if [[ -n "$resp" ]]; then
+      published_ver="$(echo "$resp" | jq -r '.dist-tags.latest // "Not found"')"
+    fi
+  fi
+  echo "$published_ver"
+}
+
 # Start summary
 echo "# 📦 pnpm packages analysis" >> "$SUMMARY_FILE"
 if [[ "$DRY_RUN" == "true" ]]; then
   echo "> **DRY RUN MODE** - No packages will be published" >> "$SUMMARY_FILE"
 fi
+echo "" >> "$SUMMARY_FILE"
+echo "Target: **${TARGET}**" >> "$SUMMARY_FILE"
 echo "" >> "$SUMMARY_FILE"
 echo "| Package | Local | Published | Change | Action |" >> "$SUMMARY_FILE"
 echo "|---|---:|---:|---|---|" >> "$SUMMARY_FILE"
@@ -77,42 +160,65 @@ MATRIX_ENTRIES=()
 for pkg_path in "${PKG_PATHS[@]}"; do
   name="$(get_pkg_json_field "$pkg_path" "name")"
   [[ -n "$SCOPE" && ! "${name}" == ${SCOPE}/* ]] && continue
-  
+
   local_ver="$(get_pkg_json_field "$pkg_path" "version")"
-  
-  # Query GHCR for published version
+  slug="$(pkg_slug "$name")"
+  stem="$(tarball_stem "$name")"
+  release_tag="${slug}-v${local_ver}"
+  asset_name="${stem}-${local_ver}.tgz"
+
+  # Determine published status based on target
   published_ver="Not found"
-  if [[ -n "${NODE_AUTH_TOKEN:-}" ]]; then
-    encoded="$(urlencode "${name}")"
-    resp="$(curl -sfL \
-      -H "Authorization: Bearer ${NODE_AUTH_TOKEN}" \
-      -H "Accept: application/vnd.npm.install-v1+json" \
-      "${REG}/${encoded}" 2>/dev/null || echo "")"
-    
-    if [[ -n "$resp" ]]; then
-      published_ver="$(echo "$resp" | jq -r '.dist-tags.latest // "Not found"')"
-    fi
-  fi
-  
+  case "$TARGET" in
+    release)
+      asset_status="$(check_release_asset "$name" "$local_ver")"
+      if [[ "$asset_status" == "found" ]]; then
+        published_ver="$local_ver"
+      fi
+      ;;
+    ghcr|npm|gcp)
+      published_ver="$(check_registry_version "$name")"
+      ;;
+    *)
+      echo "Error: unknown target '${TARGET}'" >&2
+      exit 1
+      ;;
+  esac
+
   # Compare versions and determine action
   classify="$(compare_versions "$local_ver" "$published_ver")"
   action="publish"
   if [[ "$DRY_RUN" == "true" || "$classify" == "same" || "$classify" == "downgrade" ]]; then
     action="skip"
   fi
-  
+
   # Add to matrix entries only if action is publish
   if [[ "$action" == "publish" ]]; then
-    MATRIX_ENTRIES+=("$(jq -n --arg path "$pkg_path" --arg name "$name" --arg local "$local_ver" --arg published "$published_ver" --arg classify "$classify" --arg action "$action" '{
-      package_path: $path,
-      name: $name,
-      local_version: $local,
-      published_version: $published,
-      release_type: $classify,
-      action: $action
-    }')")
+    MATRIX_ENTRIES+=("$(jq -n \
+      --arg path "$pkg_path" \
+      --arg name "$name" \
+      --arg local "$local_ver" \
+      --arg published "$published_ver" \
+      --arg classify "$classify" \
+      --arg action "$action" \
+      --arg target "$TARGET" \
+      --arg slug "$slug" \
+      --arg release_tag "$release_tag" \
+      --arg asset_name "$asset_name" \
+      '{
+        package_path: $path,
+        name: $name,
+        local_version: $local,
+        published_version: $published,
+        release_type: $classify,
+        action: $action,
+        target: $target,
+        slug: $slug,
+        release_tag: $release_tag,
+        asset_name: $asset_name
+      }')")
   fi
-  
+
   # Add to summary
   echo "| ${name} | ${local_ver} | ${published_ver} | ${classify} | ${action} |" >> "$SUMMARY_FILE"
 done

--- a/.github/actions/analyze-pnpm-packages/main.sh
+++ b/.github/actions/analyze-pnpm-packages/main.sh
@@ -74,12 +74,14 @@ compare_versions() {
 }
 
 # Check if a GitHub Release asset already exists for this package+version.
+# The publish step creates tags like "${slug}-v${version}-${short_sha}",
+# so we match by prefix.
 # Returns "found" or "Not found".
 check_release_asset() {
   local name="$1" version="$2"
   local slug
   slug="$(pkg_slug "$name")"
-  local tag="${slug}-v${version}"
+  local tag_prefix="${slug}-v${version}"
   local stem
   stem="$(tarball_stem "$name")"
   local asset_name="${stem}-${version}.tgz"
@@ -89,26 +91,30 @@ check_release_asset() {
     return
   fi
 
-  # Query GitHub Releases API for the tag
-  local resp
-  resp="$(curl -sfL \
+  # List releases for this repo and find one whose tag starts with our prefix.
+  local releases
+  releases="$(curl -sfL \
     -H "Authorization: Bearer ${NODE_AUTH_TOKEN:-}" \
     -H "Accept: application/vnd.github+json" \
-    "https://api.github.com/repos/${GITHUB_REPO}/releases/tags/${tag}" 2>/dev/null || echo "")"
+    "https://api.github.com/repos/${GITHUB_REPO}/releases?per_page=100" 2>/dev/null || echo "")"
 
-  if [[ -z "$resp" ]]; then
+  if [[ -z "$releases" || "$releases" == "[]" ]]; then
     echo "Not found"
     return
   fi
 
-  # Check if the expected asset exists in the release
-  local asset_count
-  asset_count="$(echo "$resp" | jq --arg name "$asset_name" '.assets | map(select(.name == $name)) | length')"
+  # Find a release whose tag_name starts with our prefix and has the expected asset.
+  local match
+  match="$(echo "$releases" | jq --arg prefix "$tag_prefix" --arg asset "$asset_name" '
+    map(select(.tag_name | startswith($prefix)))
+    | map(select(.assets | map(.name) | contains([$asset])))
+    | .[0] // null
+  ')"
 
-  if [[ "$asset_count" -gt 0 ]]; then
-    echo "found"
-  else
+  if [[ "$match" == "null" || -z "$match" ]]; then
     echo "Not found"
+  else
+    echo "found"
   fi
 }
 

--- a/.github/workflows/_dogfood-pnpm.yml
+++ b/.github/workflows/_dogfood-pnpm.yml
@@ -7,7 +7,7 @@ on:
     tags:
       - 'v*'
 permissions:
-  contents: read
+  contents: write
   packages: write
 jobs:
   pnpm:
@@ -16,3 +16,4 @@ jobs:
       repository: ${{ github.repository }}
       ref: ${{ github.ref }}
       dry_run: ${{ !startsWith(github.ref, 'refs/tags/v') }}
+      target: release

--- a/.github/workflows/pnpm.yml
+++ b/.github/workflows/pnpm.yml
@@ -20,6 +20,28 @@ on:
         required: false
         type: boolean
         default: false
+      target:
+        description: >
+          Publish target: release (GitHub Release tarball), ghcr (GitHub Packages),
+          npm (npmjs.org), gcp (Google Artifact Registry).
+        required: false
+        type: string
+        default: 'release'
+      registry:
+        description: >
+          npm registry URL for ghcr/npm/gcp targets.
+          Defaults to https://npm.pkg.github.com (ghcr), https://registry.npmjs.org (npm),
+          or a GCP Artifact Registry URL. Ignored when target=release.
+        required: false
+        type: string
+        default: ''
+      short_sha:
+        description: >
+          Short commit SHA to append to release tags (e.g. a27687e).
+          Only used when target=release. Defaults to the 7-char commit SHA.
+        required: false
+        type: string
+        default: ''
 jobs:
   analyze:
     name: "🧱 analyze pnpm packages"
@@ -35,11 +57,29 @@ jobs:
         with:
           repository: ${{ inputs.repository }}
           ref: ${{ inputs.ref }}
-      - name: Analyze packages (GHCR + semver)
+      - name: Resolve registry default
+        id: resolve-registry
+        shell: bash
+        run: |
+          # If caller didn't specify a registry, pick the default for the target
+          if [[ -n "${{ inputs.registry }}" ]]; then
+            echo "registry=${{ inputs.registry }}" >> "$GITHUB_OUTPUT"
+          else
+            case "${{ inputs.target }}" in
+              ghcr)  echo "registry=https://npm.pkg.github.com" >> "$GITHUB_OUTPUT" ;;
+              npm)   echo "registry=https://registry.npmjs.org" >> "$GITHUB_OUTPUT" ;;
+              gcp)   echo "registry=" >> "$GITHUB_OUTPUT" ;;
+              *)     echo "registry=" >> "$GITHUB_OUTPUT" ;;  # release doesn't need one
+            esac
+          fi
+      - name: Analyze packages (target=${{ inputs.target }})
         id: analyze
         uses: jmmaloney4/sector7/.github/actions/analyze-pnpm-packages@bc7846003f39ec61654d70f5cfd1413046b3b763 # main
         with:
           dry_run: ${{ inputs.dry_run }}
+          target: ${{ inputs.target }}
+          registry: ${{ steps.resolve-registry.outputs.registry }}
+          github_repository: ${{ inputs.repository }}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Debug matrix output
@@ -52,6 +92,7 @@ jobs:
           echo ""
           echo "Matrix as JSON:"
           echo '${{ toJson(fromJson(steps.analyze.outputs.matrix || '[]')) }}'
+
   verify-lockfile:
     name: "🔒 verify pnpm-lock.yaml"
     runs-on: ${{ inputs.runs-on }}
@@ -68,18 +109,19 @@ jobs:
           cache: ${{ !contains(inputs.runs-on, 'self-hosted') }}
       - name: Verify lockfile is up to date
         run: nix develop .#ci-pnpm --command pnpm install --frozen-lockfile
+
   publish-packages:
-    name: "🚀 publish to GHCR"
+    name: "🚀 publish (${{ inputs.target }}): ${{ matrix.name }}"
     needs: [analyze, verify-lockfile]
     runs-on: ${{ inputs.runs-on }}
     if: needs.analyze.outputs.has_packages == 'true'
     strategy:
-      fail-fast: false # Each package publishes independently
+      fail-fast: false
       matrix:
         include: ${{ fromJson(needs.analyze.outputs.matrix || '[]') }}
     permissions:
-      contents: read
-      packages: write
+      contents: write   # needed for release asset upload
+      packages: write   # needed for ghcr publish
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -100,33 +142,111 @@ jobs:
             echo "> **DRY RUN** - No publish will occur" >> $GITHUB_STEP_SUMMARY
           fi
           echo "" >> $GITHUB_STEP_SUMMARY
+          echo "- **Target:** \`${{ matrix.target }}\`" >> $GITHUB_STEP_SUMMARY
           echo "- **Path:** \`${{ matrix.package_path }}\`" >> $GITHUB_STEP_SUMMARY
           echo "- **Local:** \`${{ matrix.local_version }}\`" >> $GITHUB_STEP_SUMMARY
           echo "- **Published:** \`${{ matrix.published_version }}\`" >> $GITHUB_STEP_SUMMARY
           echo "- **Change:** \`${{ matrix.release_type }}\`" >> $GITHUB_STEP_SUMMARY
           echo "- **Action:** \`${{ matrix.action }}\`" >> $GITHUB_STEP_SUMMARY
-      - name: Configure npm authentication
-        if: inputs.dry_run != true && matrix.action == 'publish'
+
+      # ── Release tarball target ──────────────────────────────────────
+      - name: Pack tarball
+        if: inputs.dry_run != true && matrix.action == 'publish' && matrix.target == 'release'
         run: |
-          echo "Configuring npm for GitHub registry authentication..."
-          echo "//npm.pkg.github.com/:_authToken=${NODE_AUTH_TOKEN}" > ${{ matrix.package_path }}/.npmrc
-          echo "@${{ github.repository_owner }}:registry=https://npm.pkg.github.com" >> ${{ matrix.package_path }}/.npmrc
+          nix develop .#ci-pnpm --command pnpm pack
+          echo "Packed artifacts:"
+          ls -la *.tgz
+        working-directory: ${{ matrix.package_path }}
+
+      - name: Resolve short SHA
+        if: inputs.dry_run != true && matrix.action == 'publish' && matrix.target == 'release'
+        id: sha
+        shell: bash
+        run: |
+          if [[ -n "${{ inputs.short_sha }}" ]]; then
+            echo "short_sha=${{ inputs.short_sha }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "short_sha=$(git rev-parse --short=7 HEAD)" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create release and upload tarball
+        if: inputs.dry_run != true && matrix.action == 'publish' && matrix.target == 'release'
+        run: |
+          TAG="${{ matrix.release_tag }}-${{ steps.sha.outputs.short_sha }}"
+          ASSET="${{ matrix.asset_name }}"
+          ASSET_PATH="${{ matrix.package_path }}/${ASSET}"
+
+          if [[ ! -f "$ASSET_PATH" ]]; then
+            echo "❌ Expected tarball not found: $ASSET_PATH"
+            echo "Available files:"
+            ls -la "${{ matrix.package_path }}"/*.tgz 2>/dev/null || echo "  (none)"
+            exit 1
+          fi
+
+          echo "Creating release ${TAG} with asset ${ASSET}"
+          gh release create "$TAG" \
+            "$ASSET_PATH" \
+            --repo "${{ inputs.repository }}" \
+            --title "${TAG}" \
+            --notes "Published \`${{ matrix.name }}@${{ matrix.local_version }}\` as tarball asset."
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Cleanup packed tarball
+        if: inputs.dry_run != true && matrix.action == 'publish' && matrix.target == 'release'
+        run: rm -f ${{ matrix.package_path }}/*.tgz
+
+      # ── Registry targets (ghcr / npm / gcp) ────────────────────────
+      - name: Configure npm authentication (registry)
+        if: inputs.dry_run != true && matrix.action == 'publish' && matrix.target != 'release'
+        run: |
+          echo "Configuring npm for ${{ matrix.target }} registry authentication..."
+          case "${{ matrix.target }}" in
+            ghcr)
+              REGISTRY="https://npm.pkg.github.com"
+              ;;
+            npm)
+              REGISTRY="https://registry.npmjs.org"
+              ;;
+            gcp)
+              REGISTRY="${{ inputs.registry }}"
+              if [[ -z "$REGISTRY" ]]; then
+                echo "❌ GCP target requires the 'registry' input to be set"
+                exit 1
+              fi
+              ;;
+            *)
+              echo "❌ Unknown target: ${{ matrix.target }}"
+              exit 1
+              ;;
+          esac
+
+          echo "Setting auth for registry: ${REGISTRY}"
+          echo "//$(echo "$REGISTRY" | sed 's|https://||')/:_authToken=\${NODE_AUTH_TOKEN}" > ${{ matrix.package_path }}/.npmrc
+
+          # For scoped packages on ghcr, add the registry line
+          if [[ "${{ matrix.target }}" == "ghcr" && "${{ matrix.name }}" == @* ]]; then
+            SCOPE="${{ matrix.name %%/*}}"
+            echo "${SCOPE}:registry=${REGISTRY}" >> ${{ matrix.package_path }}/.npmrc
+          fi
+
           if [ ! -f "${{ matrix.package_path }}/.npmrc" ]; then
             echo "❌ Failed to create .npmrc file"
             exit 1
           fi
-          echo "✅ Authentication configured for ${{ github.repository_owner }} packages"
+          echo "✅ Authentication configured for ${{ matrix.target }}"
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Publish package
-        if: inputs.dry_run != true && matrix.action == 'publish'
+
+      - name: Publish package (registry)
+        if: inputs.dry_run != true && matrix.action == 'publish' && matrix.target != 'release'
         run: nix develop .#ci-pnpm --command pnpm publish --no-git-checks
         working-directory: ${{ matrix.package_path }}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Cleanup authentication
-        if: inputs.dry_run != true && matrix.action == 'publish'
+
+      - name: Cleanup authentication (registry)
+        if: inputs.dry_run != true && matrix.action == 'publish' && matrix.target != 'release'
         run: |
-          echo "Cleaning up authentication files..."
           rm -f ${{ matrix.package_path }}/.npmrc
           echo "✅ Cleanup completed"

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ This artifact is created with `npm pack` / `pnpm pack` from `packages/sector7`, 
 
 Avoid specs like `github:jmmaloney4/sector7#<commit>&path:/packages/sector7` in Nix-backed pnpm workspaces. pnpm may lock those as `git+ssh` or `git+https` dependencies and then invoke `git clone` during the Nix `node_modules` build. That makes otherwise hermetic builds fail with missing `git`, missing `ssh`, or unavailable credentials.
 
-Also avoid relying on GitHub codeload source archives for runtime monorepo subpackages. They avoid `git`, but can install the repository root instead of the subpackage root, which breaks subpath exports such as `@jmmaloney4/sector7/nix-image`. ADR-018 documents the release-tarball artifact decision.
+Also avoid relying on GitHub codeload source archives for runtime monorepo subpackages. They avoid `git`, but can install the repository root instead of the subpackage root, which breaks subpath exports such as `@jmmaloney4/sector7/nix-image`. [ADR-018](docs/internal/designs/018-pnpm-release-tarball-artifacts.md) documents the release-tarball artifact decision.
 
 Use the GitHubOidcResource component:
 

--- a/README.md
+++ b/README.md
@@ -61,23 +61,21 @@ Install the Pulumi package:
 pnpm add @jmmaloney4/sector7
 ```
 
-Until the package is published to a registry, pin a GitHub codeload tarball instead of using pnpm's `github:` shorthand:
+Until automated package release publishing lands, prefer a packed GitHub Release tarball over pnpm's `github:` shorthand or GitHub Packages:
 
 ```json
 {
   "dependencies": {
-    "@jmmaloney4/sector7": "https://codeload.github.com/jmmaloney4/sector7/tar.gz/<commit>#path:/packages/sector7"
+    "@jmmaloney4/sector7": "https://github.com/jmmaloney4/sector7/releases/download/sector7-v0.6.0-a27687e/jmmaloney4-sector7-0.6.0.tgz"
   }
 }
 ```
 
-Avoid specs like `github:jmmaloney4/sector7#<commit>&path:/packages/sector7` in Nix-backed pnpm workspaces. pnpm may lock those as `git+ssh` or `git+https` dependencies and then invoke `git clone` during the Nix `node_modules` build. That makes otherwise hermetic builds fail with missing `git`, missing `ssh`, or unavailable credentials. The codeload tarball form keeps the dependency pinned while resolving through pnpm's tarball fetch path.
+This artifact is created with `npm pack` / `pnpm pack` from `packages/sector7`, so it has the same package root, `exports`, files, and dependency metadata that pnpm expects from a normal npm package.
 
-For commits from before the repository rename, use the old repository name in the tarball URL:
+Avoid specs like `github:jmmaloney4/sector7#<commit>&path:/packages/sector7` in Nix-backed pnpm workspaces. pnpm may lock those as `git+ssh` or `git+https` dependencies and then invoke `git clone` during the Nix `node_modules` build. That makes otherwise hermetic builds fail with missing `git`, missing `ssh`, or unavailable credentials.
 
-```text
-https://codeload.github.com/jmmaloney4/toolbox/tar.gz/<commit>#path:/packages/sector7
-```
+Also avoid relying on GitHub codeload source archives for runtime monorepo subpackages. They avoid `git`, but can install the repository root instead of the subpackage root, which breaks subpath exports such as `@jmmaloney4/sector7/nix-image`. ADR-018 documents the release-tarball artifact decision.
 
 Use the GitHubOidcResource component:
 

--- a/docs/internal/designs/003-pnpm-ghcr-publish.md
+++ b/docs/internal/designs/003-pnpm-ghcr-publish.md
@@ -1,8 +1,10 @@
 # ADR-003: pnpm Package Publishing to GHCR
 
-**Status:** Accepted\
+**Status:** Superseded by ADR-018\
 **Date:** 2024-12-19\
 **Context:** Provide a reusable workflow to publish pnpm packages in `packages/*` to GitHub's npm registry (GHCR), with a dry‑run analysis mode that reports what would be published and why.
+
+> Superseded: ADR-018 changes the default Sector7 package distribution path from GitHub Packages publishing to packed npm tarballs uploaded as GitHub Release assets. This ADR remains historical context for the original analyzer and reusable workflow shape.
 
 ## Decision
 

--- a/docs/internal/designs/003-pnpm-ghcr-publish.md
+++ b/docs/internal/designs/003-pnpm-ghcr-publish.md
@@ -1,10 +1,10 @@
 # ADR-003: pnpm Package Publishing to GHCR
 
-**Status:** Superseded by ADR-018\
+**Status:** Superseded by [ADR-018](./018-pnpm-release-tarball-artifacts.md)\
 **Date:** 2024-12-19\
 **Context:** Provide a reusable workflow to publish pnpm packages in `packages/*` to GitHub's npm registry (GHCR), with a dry‑run analysis mode that reports what would be published and why.
 
-> Superseded: ADR-018 changes the default Sector7 package distribution path from GitHub Packages publishing to packed npm tarballs uploaded as GitHub Release assets. This ADR remains historical context for the original analyzer and reusable workflow shape.
+> Superseded: [ADR-018](./018-pnpm-release-tarball-artifacts.md) changes the default Sector7 package distribution path from GitHub Packages publishing to packed npm tarballs uploaded as GitHub Release assets. This ADR remains historical context for the original analyzer and reusable workflow shape.
 
 ## Decision
 

--- a/docs/internal/designs/018-pnpm-release-tarball-artifacts.md
+++ b/docs/internal/designs/018-pnpm-release-tarball-artifacts.md
@@ -1,0 +1,271 @@
+---
+id: ADR-018
+title: pnpm Package Release Tarball Artifacts
+status: Proposed
+date: 2026-05-06
+deciders: [jmmaloney4]
+consulted: [addendalabs/yard]
+tags: [design, adr, pnpm, release-artifacts, nix]
+supersedes: [ADR-003]
+superseded_by: []
+links:
+  - ADR-003
+  - https://github.com/addendalabs/yard/pull/1145
+  - https://github.com/jmmaloney4/sector7/releases/tag/sector7-v0.6.0-a27687e
+---
+
+# Context
+
+Sector7 publishes reusable TypeScript/Pulumi package code from a monorepo under
+`packages/*`. Downstream Nix-backed workspaces, including `addendalabs/yard`, need
+these packages to install reproducibly without requiring `git`, `ssh`, package
+registry credentials, or network-sensitive fetch behavior inside a Nix builder.
+
+The current package publishing decision, ADR-003, uses GitHub Packages as an npm
+registry. That works as a real npm package distribution mechanism, but it creates
+an authentication requirement for package pulls. Even public GitHub Packages npm
+packages are not frictionless public artifacts in the way npmjs.org packages or
+GitHub Release assets are. That is poor developer experience for Jack-owned
+shared infrastructure code consumed across repos.
+
+The Yard Lens deployment exposed the practical failure mode:
+
+1. A pnpm `github:` dependency for `@jmmaloney4/sector7` caused a Nix
+   `node-modules` build to fail because pnpm tried to invoke `git` inside the
+   sandbox.
+2. Adding `git` was not the right fix. It moved the failure toward `ssh` and
+   auth-dependent git clone behavior inside a Nix derivation.
+3. A GitHub codeload source tarball avoided `git`, but for a monorepo subpackage
+   it produced the wrong runtime package shape. The package content landed under
+   `packages/sector7` instead of at the installed package root, so subpath exports
+   such as `@jmmaloney4/sector7/nix-image` could not resolve.
+4. A real package tarball created with `npm pack` from `packages/sector7` had the
+   correct package root, `package.json`, `exports`, files, and dependency
+   metadata. Uploading that `.tgz` as a GitHub Release asset allowed Yard to pin a
+   normal package artifact by URL without using npmjs.org or GitHub Packages.
+
+This ADR chooses a package artifact strategy for Sector7 packages. It is not a
+decision about container image publishing, Nix image build-push flows, or Pulumi
+provider design.
+
+# Decision
+
+Sector7 SHOULD distribute Jack-owned pnpm workspace packages as packed npm
+package tarballs uploaded to GitHub Releases.
+
+The release artifact MUST be produced from the package root with `npm pack` or
+`pnpm pack`, not from a repository source archive. For `@jmmaloney4/sector7`, the
+package root is `packages/sector7`, and the artifact is the `.tgz` produced by
+packing that package.
+
+Downstream consumers MAY depend directly on the GitHub Release asset URL:
+
+```json
+{
+  "@jmmaloney4/sector7": "https://github.com/jmmaloney4/sector7/releases/download/sector7-v0.6.0-a27687e/jmmaloney4-sector7-0.6.0.tgz"
+}
+```
+
+The reusable pnpm workflow SHOULD be changed from publishing to GitHub Packages
+to creating release tarball artifacts:
+
+- analyze packages under `packages/*/package.json`, as it does today;
+- pack each publishable package with pnpm/npm from the package root;
+- create or reuse a deterministic GitHub Release tag;
+- upload the generated `.tgz` as a release asset;
+- report release asset URLs in the workflow summary;
+- support dry-run mode for PRs and callers that only want an audit report.
+
+GitHub Packages and other npm-compatible registries MAY still be used when a
+consumer explicitly wants registry semantics, private package distribution, or
+semver/dist-tag behavior. They are not the default path for Sector7 packages.
+
+The release tag convention SHOULD include package identity, version, and source
+commit while package versioning discipline matures. Example:
+
+```text
+sector7-v0.6.0-a27687e
+```
+
+The asset name SHOULD match npm pack naming:
+
+```text
+jmmaloney4-sector7-0.6.0.tgz
+```
+
+# Consequences
+
+## Positive
+
+- Avoids npmjs.org for Jack-owned infrastructure packages.
+- Avoids GitHub Packages pull authentication for public/internal shared code.
+- Gives pnpm and Nix a real npm package artifact with the correct package root.
+- Avoids `git`, `ssh`, and credential plumbing inside Nix `node_modules` builds.
+- Keeps package artifacts close to the source repository and commit that produced
+  them.
+- Works with plain URL dependencies in pnpm and can be hash-pinned by Nix through
+  the normal pnpm dependency hash flow.
+- Preserves the existing reusable pnpm workflow shape: analyze first, then act per
+  package with a matrix.
+
+## Negative
+
+- Release assets are not a full npm registry. There are no dist-tags, registry
+  metadata queries, or native semver range resolution.
+- Consumers must update URL dependencies when adopting a new artifact.
+- The workflow must implement its own release/asset existence checks.
+- Public release assets work cleanly. Private repositories or private release
+  assets still need GitHub authentication and are less attractive for Nix-backed
+  consumers.
+- If the same package version is repacked from a different commit, provenance can
+  become confusing. The workflow should avoid silently replacing artifacts.
+
+# Alternatives
+
+### 1. Continue using GitHub Packages
+
+Pros:
+
+- Real npm registry semantics.
+- `pnpm publish` and package version queries already fit the current workflow.
+- Supports private package distribution.
+
+Cons:
+
+- Requires authentication for package pulls, including cases that should feel
+  public or low-friction.
+- Adds `.npmrc` and token setup to every consumer and CI environment.
+- Makes Nix-backed consumers deal with authenticated package fetches.
+- Poor fit for the desired Jack-owned shared-infrastructure DX.
+
+Rejected as the default. It remains available for packages that truly need a
+private npm registry.
+
+### 2. Publish to npmjs.org
+
+Pros:
+
+- Best npm/pnpm compatibility.
+- Public unauthenticated pulls.
+- Native semver ranges and dist-tags.
+- Simplest experience for non-Nix JavaScript consumers.
+
+Cons:
+
+- Publishes Jack-owned infrastructure package artifacts and metadata to the public
+  npm registry.
+- Introduces npm account/token operations.
+- Makes an external public package registry part of internal infrastructure.
+
+Rejected for Sector7's default internal package distribution. It may be
+reasonable later if a package is deliberately made public as a product.
+
+### 3. Use GitHub source dependencies or codeload tarballs
+
+Pros:
+
+- Simple source pinning by commit.
+- No package publishing workflow required.
+- Codeload tarballs can avoid invoking `git` for some dependency shapes.
+
+Cons:
+
+- pnpm git dependencies can invoke `git`, `ssh`, and auth-sensitive clone behavior
+  during install.
+- GitHub monorepo subpackage support is leaky.
+- Source archives are not npm package artifacts.
+- `#path:/packages/sector7` can still install the repository root rather than the
+  subpackage root, breaking runtime subpath exports.
+
+Rejected for runtime packages consumed by Node/Pulumi. Source archive dependencies
+may still be acceptable for non-runtime tooling only after installed package shape
+is verified.
+
+### 4. Host packages in Google Artifact Registry
+
+Pros:
+
+- Owned infrastructure.
+- NPM-compatible registry support.
+- Fits GCP service-account and Workload Identity patterns.
+- Useful for private company package distribution.
+
+Cons:
+
+- Still requires authentication for package pulls.
+- Requires `.npmrc`/credential-helper setup for local dev and CI.
+- Nix-backed consumers still need an auth story if builds fetch directly from it.
+- More infrastructure than needed for public release artifacts.
+
+Deferred. Artifact Registry is the likely registry choice if Sector7 later needs a
+private owned registry. It is not the simplest answer for public/shared release
+artifacts.
+
+### 5. Make Sector7 a Nix-only dependency
+
+Pros:
+
+- Strong reproducibility.
+- Avoids npm registries entirely.
+- Could expose package tarballs as flake outputs.
+
+Cons:
+
+- JavaScript/Pulumi consumers still expect npm package semantics.
+- Cross-repo package consumption becomes bespoke.
+- Non-Nix consumers get worse DX.
+
+Rejected as the default package distribution path. Nix can still build and verify
+Sector7, but the consumed artifact should remain a normal npm package tarball.
+
+# Security / Privacy / Compliance
+
+- The release asset workflow should use `GITHUB_TOKEN` with `contents: write` only
+  for release creation/upload.
+- It should not write package registry tokens or generated `.npmrc` files for the
+  default release-asset path.
+- Workflow logs must not print tokens, credentials, or npm auth config.
+- Public release assets are appropriate only for packages whose source and package
+  contents are intended to be public. Private package distribution needs a
+  separate auth-aware decision.
+- Packed tarballs should be treated as release artifacts. Replacing an existing
+  artifact should be avoided unless explicitly intentional and audited.
+
+# Operational Notes
+
+- PRs should run the workflow in dry-run mode and print the package/version/tag
+  plan without uploading assets.
+- Main or release-triggered runs should create/upload missing artifacts.
+- The workflow should fail loudly if a package version already has a release asset
+  whose contents do not match the newly packed artifact.
+- Consumers should verify runtime package shape after dependency updates, not just
+  lockfile resolution. For Sector7 subpath exports, that means checking imports
+  such as `@jmmaloney4/sector7/nix-image` from the consuming package.
+- Nix-backed consumers still need to refresh their pnpm dependency hash after
+  changing release asset URLs.
+
+# Status Transitions
+
+- Supersedes ADR-003 for pnpm package distribution defaults.
+- ADR-003 remains useful historical context for the original GitHub Packages
+  workflow design and analyzer shape.
+
+# Implementation Notes
+
+1. Update `.github/workflows/pnpm.yml` to replace the GitHub Packages publish job
+   with a release-tarball upload job.
+2. Update `.github/actions/analyze-pnpm-packages` so analysis checks GitHub
+   Release tags/assets instead of GitHub Packages versions for the default path.
+3. Keep dry-run output so callers can see which package artifacts would be
+   created.
+4. Update Sector7 README package-consumption guidance to prefer packed release
+   asset URLs over codeload `#path` URLs for runtime monorepo subpackages.
+5. Update downstream consumers, including Yard, to depend on release asset URLs.
+
+# References
+
+- ADR-003: pnpm Package Publishing to GHCR
+- Yard PR using release asset dependency: https://github.com/addendalabs/yard/pull/1145
+- Initial Sector7 release tarball asset: https://github.com/jmmaloney4/sector7/releases/tag/sector7-v0.6.0-a27687e
+- pnpm GitHub monorepo subpackage issue: https://github.com/pnpm/pnpm/issues/8243
+- pnpm GitHub dependency resolution instability: https://github.com/pnpm/pnpm/issues/4527

--- a/docs/internal/designs/018-pnpm-release-tarball-artifacts.md
+++ b/docs/internal/designs/018-pnpm-release-tarball-artifacts.md
@@ -1,7 +1,7 @@
 ---
 id: ADR-018
 title: pnpm Package Release Tarball Artifacts
-status: Proposed
+status: Accepted
 date: 2026-05-06
 deciders: [jmmaloney4]
 consulted: [addendalabs/yard]
@@ -9,7 +9,7 @@ tags: [design, adr, pnpm, release-artifacts, nix]
 supersedes: [ADR-003]
 superseded_by: []
 links:
-  - ADR-003
+  - "[ADR-003](./003-pnpm-ghcr-publish.md)"
   - https://github.com/addendalabs/yard/pull/1145
   - https://github.com/jmmaloney4/sector7/releases/tag/sector7-v0.6.0-a27687e
 ---
@@ -250,6 +250,11 @@ Sector7, but the consumed artifact should remain a normal npm package tarball.
 - Main or release-triggered runs should create/upload missing artifacts.
 - The workflow should fail loudly if a package version already has a release asset
   whose contents do not match the newly packed artifact.
+- Asset naming follows standard `npm pack` convention (`scope-name-version.tgz`)
+  without the commit SHA. The release tag carries the SHA for provenance
+  (`slug-vN.N.N-shortsha`). This means repacking the same version from a different
+  commit produces an identically named asset. The workflow enforces a 1:1 mapping
+  by checking for existing assets before uploading.
 - Consumers should verify runtime package shape after dependency updates, not just
   lockfile resolution. For Sector7 subpath exports, that means checking imports
   such as `@jmmaloney4/sector7/nix-image` from the consuming package.
@@ -282,7 +287,7 @@ Sector7, but the consumed artifact should remain a normal npm package tarball.
 
 # References
 
-- ADR-003: pnpm Package Publishing to GHCR
+- [ADR-003: pnpm Package Publishing to GHCR](./003-pnpm-ghcr-publish.md)
 - Yard PR using release asset dependency: https://github.com/addendalabs/yard/pull/1145
 - Initial Sector7 release tarball asset: https://github.com/jmmaloney4/sector7/releases/tag/sector7-v0.6.0-a27687e
 - pnpm GitHub monorepo subpackage issue: https://github.com/pnpm/pnpm/issues/8243

--- a/docs/internal/designs/018-pnpm-release-tarball-artifacts.md
+++ b/docs/internal/designs/018-pnpm-release-tarball-artifacts.md
@@ -76,9 +76,21 @@ to creating release tarball artifacts:
 - report release asset URLs in the workflow summary;
 - support dry-run mode for PRs and callers that only want an audit report.
 
-GitHub Packages and other npm-compatible registries MAY still be used when a
-consumer explicitly wants registry semantics, private package distribution, or
-semver/dist-tag behavior. They are not the default path for Sector7 packages.
+The reusable pnpm workflow MUST support multiple publish targets, configurable
+via a `target` input:
+
+- `release` (default): packed tarball uploaded as a GitHub Release asset.
+- `ghcr`: published to GitHub Packages npm registry.
+- `npm`: published to npmjs.org.
+- `gcp`: published to a Google Artifact Registry npm endpoint.
+
+Callers select the target at invocation. The analyze step checks for existing
+versions/assets using the appropriate mechanism for the selected target. The
+publish step dispatches to target-specific upload logic.
+
+This makes the workflow a general-purpose pnpm package publisher with release
+tarballs as the default distribution mechanism, while preserving registry
+publishing for repos or packages that need it.
 
 The release tag convention SHOULD include package identity, version, and source
 commit while package versioning discipline matures. Example:
@@ -252,15 +264,21 @@ Sector7, but the consumed artifact should remain a normal npm package tarball.
 
 # Implementation Notes
 
-1. Update `.github/workflows/pnpm.yml` to replace the GitHub Packages publish job
-   with a release-tarball upload job.
-2. Update `.github/actions/analyze-pnpm-packages` so analysis checks GitHub
-   Release tags/assets instead of GitHub Packages versions for the default path.
-3. Keep dry-run output so callers can see which package artifacts would be
+1. Updated `.github/workflows/pnpm.yml` to support configurable `target` input
+   (`release`, `ghcr`, `npm`, `gcp`) with `release` as default. Publish job
+   dispatches to target-specific logic: release tarball upload via `gh release
+   create`, or registry publish via `pnpm publish` with appropriate `.npmrc`.
+2. Updated `.github/actions/analyze-pnpm-packages` with a `target` input. For
+   `release`, it queries the GitHub Releases API for existing assets. For
+   registry targets, it queries the npm registry endpoint. The matrix includes
+   `target`, `slug`, `release_tag`, and `asset_name` fields.
+3. Updated `.github/workflows/_dogfood-pnpm.yml` to pass `target: release`
+   explicitly and grant `contents: write` permission for release uploads.
+4. Keep dry-run output so callers can see which package artifacts would be
    created.
-4. Update Sector7 README package-consumption guidance to prefer packed release
+5. Update Sector7 README package-consumption guidance to prefer packed release
    asset URLs over codeload `#path` URLs for runtime monorepo subpackages.
-5. Update downstream consumers, including Yard, to depend on release asset URLs.
+6. Update downstream consumers, including Yard, to depend on release asset URLs.
 
 # References
 


### PR DESCRIPTION
## Summary

- Adds ADR-018 documenting packed npm tarballs uploaded as GitHub Release assets as Sector7's default pnpm package distribution path.
- Marks ADR-003's GitHub Packages publishing decision as superseded for default package distribution.
- Updates the README Pulumi package guidance away from codeload `#path` source archives for runtime monorepo subpackages.

## Why

Yard exposed two separate failure modes:

1. pnpm `github:` dependencies can invoke `git` / `ssh` inside Nix `node_modules` builds.
2. GitHub codeload source archives can avoid `git` but still install the repository root instead of the monorepo subpackage root, breaking runtime subpath exports such as `@jmmaloney4/sector7/nix-image`.

A package tarball produced by `npm pack` / `pnpm pack` from `packages/sector7` preserves the package root, exports, files, and dependency metadata without requiring npmjs.org or GitHub Packages.

## Validation

- Ran a textual ADR validation script confirming `ADR-018` exists, references `ADR-003`, contains the release-tarball decision, and that ADR numbers are unique.
- Attempted `nix develop --command pre-commit run --files ...`; blocked by the repo's current pnpm dependency hash/store issue, unrelated to these markdown-only changes:
  - `ERR_PNPM_NO_OFFLINE_TARBALL` for `https://registry.npmjs.org/@pulumi/command/-/command-1.2.1.tgz`.

## Follow-up

- Replace `.github/workflows/pnpm.yml` GitHub Packages publishing with release tarball packing/uploading.
- Update `.github/actions/analyze-pnpm-packages` to check GitHub Release assets rather than GHCR package versions.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates the reusable pnpm publish pipeline to create GitHub Releases and upload tarball assets (and to conditionally publish to registries), which changes release/publishing behavior and requires `contents: write` permissions in CI.
> 
> **Overview**
> Switches the pnpm reusable workflow from a GHCR-only publisher to a **configurable multi-target** publisher (`release`, `ghcr`, `npm`, `gcp`), with **GitHub Release tarball assets as the default**.
> 
> The `analyze-pnpm-packages` composite action now supports `target` selection: it checks existing versions via either the npm registry API (registry targets) or the GitHub Releases API (release target), and enriches the publish matrix with release-asset metadata (`release_tag`, `asset_name`, `slug`).
> 
> Publishing logic is updated to either `pnpm pack` + `gh release create` (release target) or to configure `.npmrc` and run `pnpm publish` (registry targets); docs are updated with ADR-018 (superseding ADR-003) and README guidance to consume packed Release assets.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f7cde11d454242ebca19d5f561237d54c042d083. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->