### PR TITLE
feat: compile sector7 packages before release

### DIFF
--- a/.github/workflows/_dogfood-pnpm.yml
+++ b/.github/workflows/_dogfood-pnpm.yml
@@ -11,7 +11,7 @@ permissions:
   packages: write
 jobs:
   pnpm:
-    uses: jmmaloney4/sector7/.github/workflows/pnpm.yml@bc7846003f39ec61654d70f5cfd1413046b3b763 # main
+    uses: jmmaloney4/sector7/.github/workflows/pnpm.yml@2ba648fa404abb5104961d55e27b3ae1a26ea3a4 # main
     with:
       repository: ${{ github.repository }}
       ref: ${{ github.ref }}

--- a/.github/workflows/pnpm.yml
+++ b/.github/workflows/pnpm.yml
@@ -74,7 +74,7 @@ jobs:
           fi
       - name: Analyze packages (target=${{ inputs.target }})
         id: analyze
-        uses: jmmaloney4/sector7/.github/actions/analyze-pnpm-packages@bc7846003f39ec61654d70f5cfd1413046b3b763 # main
+        uses: jmmaloney4/sector7/.github/actions/analyze-pnpm-packages@2ba648fa404abb5104961d55e27b3ae1a26ea3a4 # main
         with:
           dry_run: ${{ inputs.dry_run }}
           target: ${{ inputs.target }}
@@ -157,6 +157,36 @@ jobs:
           echo "Packed artifacts:"
           ls -la *.tgz
         working-directory: ${{ matrix.package_path }}
+
+      - name: Verify compiled package tarball
+        if: inputs.dry_run != true && matrix.action == 'publish' && matrix.target == 'release'
+        shell: bash
+        working-directory: ${{ matrix.package_path }}
+        run: |
+          ASSET="${{ matrix.asset_name }}"
+          if [[ ! -f "$ASSET" ]]; then
+            echo "❌ Expected packed tarball not found: $ASSET"
+            exit 1
+          fi
+
+          tar -tzf "$ASSET" > /tmp/sector7-tarball-contents.txt
+
+          if awk '/^package\/.*\.ts$/ && $0 !~ /\.d\.ts$/ { print; found=1 } END { exit found ? 0 : 1 }' /tmp/sector7-tarball-contents.txt; then
+            echo "❌ Tarball contains raw TypeScript source files. Published packages must ship compiled JavaScript plus declarations."
+            exit 1
+          fi
+
+          if ! grep -qx 'package/dist/index.js' /tmp/sector7-tarball-contents.txt; then
+            echo "❌ Tarball is missing package/dist/index.js"
+            exit 1
+          fi
+
+          if ! grep -qx 'package/dist/index.d.ts' /tmp/sector7-tarball-contents.txt; then
+            echo "❌ Tarball is missing package/dist/index.d.ts"
+            exit 1
+          fi
+
+          echo "✅ Tarball contains compiled JavaScript and declarations only"
 
       - name: Resolve short SHA
         if: inputs.dry_run != true && matrix.action == 'publish' && matrix.target == 'release'

--- a/docs/internal/designs/019-compile-sector7-packages-before-distribution.md
+++ b/docs/internal/designs/019-compile-sector7-packages-before-distribution.md
@@ -1,0 +1,134 @@
+---
+id: ADR-019
+title: Compile sector7 Packages Before Distribution
+status: Proposed
+date: 2026-05-06
+deciders: [jmmaloney4]
+consulted: [addendalabs/yard]
+tags: [design, adr, pnpm, typescript, packaging]
+supersedes: []
+superseded_by: []
+links:
+  - "[ADR-018](./018-pnpm-release-tarball-artifacts.md)"
+  - https://github.com/addendalabs/yard/pull/1146
+---
+
+# Context
+
+ADR-018 made GitHub Release tarball assets the default distribution path for Sector7 pnpm packages. That fixed the Nix/pnpm failure mode where GitHub codeload or git dependencies required `git`, SSH, credentials, or installed the monorepo root instead of the package root.
+
+The first release tarball still shipped raw TypeScript source and exported `.ts` files directly:
+
+```json
+"exports": {
+  "./nix-image": {
+    "types": "./nix-image/index.ts",
+    "default": "./nix-image/index.ts"
+  }
+}
+```
+
+That works only when every consumer has a runtime TypeScript loader willing to transpile files under `node_modules`. Pulumi's `typescript: true` Node.js runtime uses `ts-node`, and `ts-node` ignores `node_modules` by default. A Yard deployment failed with:
+
+```text
+ERR_UNKNOWN_FILE_EXTENSION .ts .../node_modules/@jmmaloney4/sector7/nix-image/index.ts
+Hint: ts-node is configured to ignore this file.
+```
+
+This is a packaging problem, not a Yard runtime problem. Sector7 packages are runtime libraries. Consumers should not need custom loader flags, `ts-node` `skipIgnore`, or `tsx/esm` just because they import Sector7.
+
+In scope:
+
+- Sector7 package tarball shape.
+- Sector7 package export targets.
+- Release workflow checks that prevent uploading raw-source runtime packages.
+
+Out of scope:
+
+- Replacing TypeScript as Sector7's authoring language.
+- Publishing to npmjs or GitHub Packages.
+- Bundling Pulumi peer dependencies into Sector7.
+
+# Decision
+
+Sector7 packages MUST compile TypeScript before packaging.
+
+Published package tarballs MUST contain:
+
+- compiled JavaScript runtime files under `dist/`,
+- generated `.d.ts` declaration files under `dist/`,
+- non-TypeScript runtime assets needed by those compiled files, such as shell scripts.
+
+Published package tarballs MUST NOT expose raw `.ts` source files as runtime entrypoints.
+
+`package.json` exports MUST point runtime consumers at compiled `.js` files and TypeScript consumers at generated `.d.ts` files:
+
+```json
+"exports": {
+  "./nix-image": {
+    "types": "./dist/nix-image/index.d.ts",
+    "default": "./dist/nix-image/index.js"
+  }
+}
+```
+
+The release workflow MUST build packages before packing and MUST fail before upload if the packed tarball contains raw `.ts` runtime files or is missing `dist/index.js` / `dist/index.d.ts`.
+
+Sector7 MAY continue to publish as GitHub Release tarball assets per ADR-018. This ADR refines the contents of those tarballs, not the distribution channel.
+
+# Consequences
+
+## Positive
+
+- Consumers can import Sector7 from ordinary Node.js runtimes without custom TypeScript loaders.
+- Pulumi stacks can use their default TypeScript runtime without depending on `tsx/esm` or `ts-node` `skipIgnore`.
+- The package behaves like a normal npm package even when distributed as a GitHub Release tarball.
+- Generated declaration files give consumers a stable type surface decoupled from Sector7's source layout.
+- Release workflow validation catches regressions before a broken artifact is uploaded.
+
+## Negative
+
+- Releases now depend on a build step and can fail if TypeScript compilation fails.
+- Tarballs are larger because they include JavaScript, declaration files, and source maps.
+- Runtime assets such as shell scripts must be copied into `dist/` when compiled code resolves them relative to `import.meta.url`.
+- Source files are no longer the published contract; debugging may rely on source maps rather than direct `.ts` execution.
+
+# Alternatives
+
+- **Keep publishing raw TypeScript and require `tsx/esm` in consumers**: Fastest short-term fix. It works for Yard after changing Pulumi.yaml, but it leaks Sector7's packaging choice into every consumer and produces non-obvious failures in new stacks.
+- **Configure `ts-node` with `skipIgnore` or custom ignore patterns**: Keeps Pulumi's `typescript: true` runtime, but widens TypeScript transpilation across `node_modules`, is consumer-specific, and remains fragile across runtimes.
+- **Bundle Sector7 into a single JavaScript file**: Reduces package files but complicates Pulumi peer dependency handling and makes subpath exports less transparent. Sector7 should preserve normal package/module shape for now.
+- **Compile to `dist/` with declarations**: Standard package behavior. Slightly more release machinery, but consumers need no special runtime behavior. This is the selected option.
+
+# Security / Privacy / Compliance
+
+No credentials or private data are introduced. The release workflow should continue to use the existing GitHub token only for release asset upload. Build outputs must not include local paths, generated credentials, `.npmrc`, Pulumi stack state, or environment-specific files.
+
+# Operational Notes
+
+- `pnpm pack` should run the package `prepack` script locally and in CI, so manually created release artifacts have the same shape as CI-created artifacts.
+- The release workflow should inspect the packed tarball, not just the source tree. The artifact is the contract.
+- If a consumer reports `ERR_UNKNOWN_FILE_EXTENSION .ts` from `node_modules/@jmmaloney4/sector7`, treat that as a failed release packaging invariant.
+- If compiled code resolves non-JS assets with `import.meta.url`, copy those assets into the matching `dist/` directory during build.
+
+# Status Transitions
+
+- Amends ADR-018 by defining the required contents of release tarball assets.
+- ADR-018 remains the distribution-channel decision.
+
+# Implementation Notes
+
+- Add `packages/sector7/tsconfig.build.json` to emit JavaScript, declarations, declaration maps, and source maps to `dist/`.
+- Use TypeScript `rewriteRelativeImportExtensions` so source imports ending in `.ts` compile to `.js` import specifiers.
+- Update `packages/sector7/package.json` exports to point at `dist/**/*.js` and `dist/**/*.d.ts`.
+- Limit `files` to `dist` and README-level package metadata.
+- Add `build`, `clean`, and `prepack` scripts so local `pnpm pack` and release workflow `pnpm pack` both produce compiled artifacts.
+- Copy `scripts/*.sh` into `dist/scripts/` because `getScriptPath()` resolves next to compiled `dist/scripts/index.js`.
+- Update the reusable pnpm release workflow to validate compiled tarball shape before `gh release create`.
+
+# References
+
+- [ADR-018: pnpm Package Release Tarball Artifacts](./018-pnpm-release-tarball-artifacts.md)
+- Yard PR using Sector7 release tarball: https://github.com/addendalabs/yard/pull/1146
+- ts-node scope/ignore behavior: https://typestrong.org/ts-node/docs/scope
+- TypeScript `rewriteRelativeImportExtensions`: https://www.typescriptlang.org/tsconfig/#rewriteRelativeImportExtensions

--- a/package.json
+++ b/package.json
@@ -8,9 +8,9 @@
 		"packages/*"
 	],
 	"scripts": {
-		"build": "pnpm -r --if-present run build",
-		"test": "pnpm -r --if-present run test",
-		"clean": "pnpm -r --if-present run clean"
+		"build": "pnpm --filter './packages/*' -r --if-present run build",
+		"test": "pnpm --filter './packages/*' -r --if-present run test",
+		"clean": "pnpm --filter './packages/*' -r --if-present run clean"
 	},
 	"devDependencies": {
 		"typescript": "5.9.3",

--- a/packages/sector7/package.json
+++ b/packages/sector7/package.json
@@ -12,44 +12,42 @@
 	},
 	"exports": {
 		".": {
-			"types": "./index.ts",
-			"default": "./index.ts"
+			"types": "./dist/index.d.ts",
+			"default": "./dist/index.js"
 		},
 		"./access": {
-			"types": "./access/index.ts",
-			"default": "./access/index.ts"
+			"types": "./dist/access/index.d.ts",
+			"default": "./dist/access/index.js"
 		},
 		"./iam": {
-			"types": "./iam/index.ts",
-			"default": "./iam/index.ts"
+			"types": "./dist/iam/index.d.ts",
+			"default": "./dist/iam/index.js"
 		},
 		"./workersite": {
-			"types": "./workersite/index.ts",
-			"default": "./workersite/index.ts"
+			"types": "./dist/workersite/index.d.ts",
+			"default": "./dist/workersite/index.js"
 		},
 		"./r2": {
-			"types": "./r2/index.ts",
-			"default": "./r2/index.ts"
+			"types": "./dist/r2/index.d.ts",
+			"default": "./dist/r2/index.js"
 		},
 		"./nix-image": {
-			"types": "./nix-image/index.ts",
-			"default": "./nix-image/index.ts"
+			"types": "./dist/nix-image/index.d.ts",
+			"default": "./dist/nix-image/index.js"
 		},
 		"./scripts": {
-			"types": "./scripts/index.ts",
-			"default": "./scripts/index.ts"
+			"types": "./dist/scripts/index.d.ts",
+			"default": "./dist/scripts/index.js"
 		}
 	},
 	"files": [
-		"index.ts",
-		"access",
-		"iam",
-		"workersite",
-		"r2",
-		"nix-image",
-		"scripts"
+		"dist",
+		"README.md"
 	],
 	"scripts": {
+		"build": "pnpm run clean && tsc -p tsconfig.build.json && cp scripts/*.sh dist/scripts/",
+		"clean": "rimraf dist",
+		"prepack": "pnpm run build",
 		"test": "vitest run",
 		"test:watch": "vitest"
 	},

--- a/packages/sector7/package.json
+++ b/packages/sector7/package.json
@@ -45,7 +45,7 @@
 		"README.md"
 	],
 	"scripts": {
-		"build": "pnpm run clean && tsc -p tsconfig.build.json && cp scripts/*.sh dist/scripts/",
+		"build": "pnpm run clean && tsc -p tsconfig.build.json && node tools/copy-shell-scripts.mjs",
 		"clean": "rimraf dist",
 		"prepack": "pnpm run build",
 		"test": "vitest run",
@@ -62,6 +62,8 @@
 		"@pulumi/cloudflare": "6.14.0",
 		"@pulumi/gcp": "9.19.0",
 		"@pulumi/command": "1.2.1",
+		"rimraf": "6.1.3",
+		"typescript": "5.9.3",
 		"vitest": "4.1.2"
 	}
 }

--- a/packages/sector7/tests/nix-image.test.ts
+++ b/packages/sector7/tests/nix-image.test.ts
@@ -85,6 +85,8 @@ describe("NixImage", () => {
 			IMAGE_NAME: "my-image",
 			IMAGE_TAG: "dev",
 			ARTIFACT_REGISTRY_URL: "us-east1-docker.pkg.dev/my-project/my-repo",
+			AUTH_MODE: "gcloud",
+			SCRIPT_MODE: "build",
 			REPO_ROOT: "/home/user/my-repo",
 			RESULT_LINK: "result-test-build",
 			COMMAND_LOG_STEM: ".pulumi/command-logs/test-build",
@@ -110,10 +112,15 @@ describe("NixImage", () => {
 		expect(cmd.type).toBe("command:local:Command");
 
 		const createCmd = cmd.inputs.create as string;
-		expect(createCmd).toContain("inspect");
-		expect(createCmd).toContain("--format");
-		expect(createCmd).toContain("my-image");
-		expect(createCmd).toContain("v1.0.0");
+		expect(createCmd).toContain("nix-image-build-push.sh");
+		expect(cmd.inputs.environment).toMatchObject({
+			IMAGE_NAME: "my-image",
+			IMAGE_TAG: "v1.0.0",
+			ARTIFACT_REGISTRY_URL: "us-east1-docker.pkg.dev/my-project/my-repo",
+			AUTH_MODE: "gcloud",
+			SCRIPT_MODE: "resolve",
+			COMMAND_LOG_STEM: ".pulumi/command-logs/test-resolve",
+		});
 	});
 
 	it("parses DIGEST_OUTPUT marker from stdout correctly", async () => {

--- a/packages/sector7/tools/copy-shell-scripts.mjs
+++ b/packages/sector7/tools/copy-shell-scripts.mjs
@@ -6,10 +6,10 @@ const outputDir = join("dist", "scripts");
 
 mkdirSync(outputDir, { recursive: true });
 
-for (const file of readdirSync(sourceDir)) {
-	if (!file.endsWith(".sh")) {
+for (const entry of readdirSync(sourceDir, { withFileTypes: true })) {
+	if (!entry.isFile() || !entry.name.endsWith(".sh")) {
 		continue;
 	}
 
-	copyFileSync(join(sourceDir, file), join(outputDir, file));
+	copyFileSync(join(sourceDir, entry.name), join(outputDir, entry.name));
 }

--- a/packages/sector7/tools/copy-shell-scripts.mjs
+++ b/packages/sector7/tools/copy-shell-scripts.mjs
@@ -1,0 +1,15 @@
+import { copyFileSync, mkdirSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+
+const sourceDir = "scripts";
+const outputDir = join("dist", "scripts");
+
+mkdirSync(outputDir, { recursive: true });
+
+for (const file of readdirSync(sourceDir)) {
+	if (!file.endsWith(".sh")) {
+		continue;
+	}
+
+	copyFileSync(join(sourceDir, file), join(outputDir, file));
+}

--- a/packages/sector7/tsconfig.build.json
+++ b/packages/sector7/tsconfig.build.json
@@ -7,21 +7,18 @@
 		"sourceMap": true,
 		"outDir": "dist",
 		"rootDir": ".",
-		"rewriteRelativeImportExtensions": true
+		"rewriteRelativeImportExtensions": true,
+		"inlineSources": true
 	},
 	"include": [
-		"index.ts",
-		"access/**/*.ts",
-		"iam/**/*.ts",
-		"workersite/**/*.ts",
-		"r2/**/*.ts",
-		"nix-image/**/*.ts",
-		"scripts/**/*.ts"
+		"**/*.ts"
 	],
 	"exclude": [
+		"dist/**",
 		"node_modules/**",
 		"tests/**/*.ts",
 		"examples/**/*.ts",
+		"vitest.config.ts",
 		"**/barrel-guard.ts"
 	]
 }

--- a/packages/sector7/tsconfig.build.json
+++ b/packages/sector7/tsconfig.build.json
@@ -1,0 +1,27 @@
+{
+	"extends": "./tsconfig.json",
+	"compilerOptions": {
+		"noEmit": false,
+		"declaration": true,
+		"declarationMap": true,
+		"sourceMap": true,
+		"outDir": "dist",
+		"rootDir": ".",
+		"rewriteRelativeImportExtensions": true
+	},
+	"include": [
+		"index.ts",
+		"access/**/*.ts",
+		"iam/**/*.ts",
+		"workersite/**/*.ts",
+		"r2/**/*.ts",
+		"nix-image/**/*.ts",
+		"scripts/**/*.ts"
+	],
+	"exclude": [
+		"node_modules/**",
+		"tests/**/*.ts",
+		"examples/**/*.ts",
+		"**/barrel-guard.ts"
+	]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,12 @@ importers:
       '@pulumi/pulumi':
         specifier: 3.230.0
         version: 3.230.0(typescript@5.9.3)
+      rimraf:
+        specifier: 6.1.3
+        version: 6.1.3
+      typescript:
+        specifier: 5.9.3
+        version: 5.9.3
       vitest:
         specifier: 4.1.2
         version: 4.1.2(@opentelemetry/api@1.9.0)(@types/node@24.12.2)(vite@7.3.1(@types/node@24.12.2))


### PR DESCRIPTION
## Summary

Sector7 should publish normal runtime packages: compiled JavaScript plus declaration files, not raw TypeScript entrypoints that require downstream loaders to transpile `node_modules`.

This PR:

- adds ADR-019 for the package-shape decision
- adds a `tsconfig.build.json` for `packages/sector7`
- updates package exports from raw `.ts` to `dist/**/*.js` + `dist/**/*.d.ts`
- adds `build`, `clean`, and `prepack` scripts so local and CI `pnpm pack` produce compiled artifacts
- copies runtime shell scripts into `dist/scripts/` so `getScriptPath()` still works after compilation
- updates the reusable pnpm release workflow to reject tarballs that contain raw `.ts` runtime files or lack `dist/index.js` / `dist/index.d.ts`
- bumps pnpm dogfood pins to the latest main revision so the target-aware pnpm workflow is used
- refreshes stale NixImage tests for the current script-based build/resolve implementation

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm -r --if-present run build`
- `pnpm --filter ./packages/* test`
- `pnpm pack` from `packages/sector7`
- verified packed tarball contains `dist/index.js` and `dist/index.d.ts`
- verified packed tarball does not contain raw `.ts` runtime files
- installed the tarball into a throwaway consumer and imported:
  - `@jmmaloney4/sector7/nix-image`
  - `@jmmaloney4/sector7/workersite`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the published package surface (`exports`/`files`) and adds CI checks that can block releases if the build or tarball validation is wrong.
> 
> **Overview**
> Sector7 packages are now built before distribution: `@jmmaloney4/sector7` switches subpath `exports` from raw `.ts` entrypoints to compiled `dist/**/*.js` plus `dist/**/*.d.ts`, and narrows published contents to `dist/` (with `prepack` running the new build).
> 
> The package gains a dedicated `tsconfig.build.json` and a build step that also copies runtime `.sh` scripts into `dist/` to keep script-based helpers working after compilation; `NixImage` tests are updated to match the script/env-based implementation.
> 
> Release automation is tightened: the reusable `pnpm` workflow now verifies the packed tarball contains compiled outputs and no raw `.ts` sources before uploading, and the dogfood workflow/action pins are bumped; root `pnpm` scripts are filtered to `./packages/*` and lockfile updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8dde5ccf43c5c969daace189cf6bc99000acc835. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->