### PR TITLE
feat(r2): add per-URL cache purge support to purgeZoneCache

### DIFF
--- a/packages/sector7/r2/r2object.ts
+++ b/packages/sector7/r2/r2object.ts
@@ -721,11 +721,19 @@ export interface PurgeZoneCacheArgs {
 	/**
 	 * Specific URLs to purge instead of purging the entire zone.
 	 * Each entry must be a full URL (e.g. `https://dev.example.com/index.html`).
-	 * When omitted or empty, the entire zone cache is purged via `purge_everything`.
-	 * Useful when multiple stacks share a single Cloudflare zone — each stack
-	 * can scope its purge to its own hostname without invalidating the other.
+	 * When provided, sends `{"files": [...]}` to the Cloudflare API.
+	 * Mutually exclusive with `hosts`.
 	 */
 	files?: Input<Input<string>[]>;
+	/**
+	 * Hostnames to purge instead of purging the entire zone.
+	 * Each entry is a bare hostname (e.g. `"dev.example.com"`).
+	 * When provided, sends `{"hosts": [...]}` to the Cloudflare API.
+	 * This purges all cached resources for that hostname — ideal when
+	 * multiple stacks share a single Cloudflare zone.
+	 * Mutually exclusive with `files`.
+	 */
+	hosts?: Input<Input<string>[]>;
 	/** Resource dependencies — purge runs after these complete. */
 	dependsOn?: Input<Input<Resource>[]>;
 }
@@ -738,6 +746,7 @@ interface ZoneCachePurgeInputs {
 	apiToken: string;
 	trigger: string;
 	files?: string[];
+	hosts?: string[];
 }
 
 /**
@@ -766,6 +775,14 @@ const zoneCachePurgeProvider: dynamic.ResourceProvider = {
 		if (news.files !== undefined && !Array.isArray(news.files)) {
 			failures.push({ property: "files", reason: "files must be an array of URL strings" });
 		}
+		// Normalize hosts: accept string[] or undefined; reject non-array.
+		if (news.hosts !== undefined && !Array.isArray(news.hosts)) {
+			failures.push({ property: "hosts", reason: "hosts must be an array of hostname strings" });
+		}
+		// files and hosts are mutually exclusive.
+		if (Array.isArray(news.files) && news.files.length > 0 && Array.isArray(news.hosts) && news.hosts.length > 0) {
+			failures.push({ property: "files", reason: "files and hosts are mutually exclusive" });
+		}
 		return { inputs: news, failures };
 	},
 
@@ -778,18 +795,21 @@ const zoneCachePurgeProvider: dynamic.ResourceProvider = {
 		if (olds.zoneId !== news.zoneId) replaces.push("zoneId");
 		const filesChanged =
 			JSON.stringify(olds.files ?? []) !== JSON.stringify(news.files ?? []);
+		const hostsChanged =
+			JSON.stringify(olds.hosts ?? []) !== JSON.stringify(news.hosts ?? []);
 		return {
 			replaces,
 			changes:
 				replaces.length > 0 ||
 				olds.trigger !== news.trigger ||
 				olds.apiToken !== news.apiToken ||
-				filesChanged,
+				filesChanged ||
+				hostsChanged,
 		};
 	},
 
 	async create(inputs: ZoneCachePurgeInputs): Promise<dynamic.CreateResult> {
-		await purgeZoneCacheApi(inputs.zoneId, inputs.apiToken, inputs.files);
+		await purgeZoneCacheApi(inputs.zoneId, inputs.apiToken, inputs.files, inputs.hosts);
 		return {
 			id: `purge-${inputs.zoneId}-${inputs.trigger.slice(0, 12)}`,
 			outs: { ...inputs },
@@ -801,7 +821,7 @@ const zoneCachePurgeProvider: dynamic.ResourceProvider = {
 		_olds: Record<string, unknown>,
 		news: ZoneCachePurgeInputs,
 	): Promise<dynamic.UpdateResult> {
-		await purgeZoneCacheApi(news.zoneId, news.apiToken, news.files);
+		await purgeZoneCacheApi(news.zoneId, news.apiToken, news.files, news.hosts);
 		return { outs: { ...news } };
 	},
 
@@ -814,11 +834,16 @@ async function purgeZoneCacheApi(
 	zoneId: string,
 	apiToken: string,
 	files?: string[],
+	hosts?: string[],
 ): Promise<void> {
-	const body =
-		files && files.length > 0
-			? { files }
-			: { purge_everything: true };
+	let body: Record<string, unknown>;
+	if (hosts && hosts.length > 0) {
+		body = { hosts };
+	} else if (files && files.length > 0) {
+		body = { files };
+	} else {
+		body = { purge_everything: true };
+	}
 	const response = await fetch(
 		`https://api.cloudflare.com/client/v4/zones/${zoneId}/purge_cache`,
 		{
@@ -867,6 +892,7 @@ class ZoneCachePurge extends dynamic.Resource {
 				apiToken: args.apiToken,
 				trigger: args.trigger,
 				files: args.files,
+				hosts: args.hosts,
 			},
 			mergedOpts,
 		);

--- a/packages/sector7/r2/r2object.ts
+++ b/packages/sector7/r2/r2object.ts
@@ -771,16 +771,20 @@ const zoneCachePurgeProvider: dynamic.ResourceProvider = {
 				failures.push({ property: p, reason: p + " is required and must be a non-empty string" });
 			}
 		}
-		// Validate files: accept string[] or undefined; reject non-array or non-string elements.
+		// Validate files: accept non-empty string[] or undefined; reject non-array, non-string elements, or empty.
 		if (news.files !== undefined) {
 			if (!Array.isArray(news.files) || news.files.some((f: unknown) => typeof f !== "string" || !f)) {
 				failures.push({ property: "files", reason: "files must be an array of non-empty URL strings" });
+			} else if (news.files.length === 0) {
+				failures.push({ property: "files", reason: "files must not be empty — use purgeEverything instead" });
 			}
 		}
-		// Validate hosts: accept string[] or undefined; reject non-array or non-string elements.
+		// Validate hosts: accept non-empty string[] or undefined; reject non-array, non-string elements, or empty.
 		if (news.hosts !== undefined) {
 			if (!Array.isArray(news.hosts) || news.hosts.some((h: unknown) => typeof h !== "string" || !h)) {
 				failures.push({ property: "hosts", reason: "hosts must be an array of non-empty hostname strings" });
+			} else if (news.hosts.length === 0) {
+				failures.push({ property: "hosts", reason: "hosts must not be empty — use purgeEverything instead" });
 			}
 		}
 		// files and hosts are mutually exclusive.
@@ -798,9 +802,11 @@ const zoneCachePurgeProvider: dynamic.ResourceProvider = {
 		const replaces: string[] = [];
 		if (olds.zoneId !== news.zoneId) replaces.push("zoneId");
 		const filesChanged =
-			JSON.stringify(olds.files ?? []) !== JSON.stringify(news.files ?? []);
+			JSON.stringify([...((olds.files as string[] | undefined) ?? [])].sort()) !==
+			JSON.stringify([...((news.files as string[] | undefined) ?? [])].sort());
 		const hostsChanged =
-			JSON.stringify(olds.hosts ?? []) !== JSON.stringify(news.hosts ?? []);
+			JSON.stringify([...((olds.hosts as string[] | undefined) ?? [])].sort()) !==
+			JSON.stringify([...((news.hosts as string[] | undefined) ?? [])].sort());
 		return {
 			replaces,
 			changes:

--- a/packages/sector7/r2/r2object.ts
+++ b/packages/sector7/r2/r2object.ts
@@ -771,13 +771,17 @@ const zoneCachePurgeProvider: dynamic.ResourceProvider = {
 				failures.push({ property: p, reason: p + " is required and must be a non-empty string" });
 			}
 		}
-		// Normalize files: accept string[] or undefined; reject non-array.
-		if (news.files !== undefined && !Array.isArray(news.files)) {
-			failures.push({ property: "files", reason: "files must be an array of URL strings" });
+		// Validate files: accept string[] or undefined; reject non-array or non-string elements.
+		if (news.files !== undefined) {
+			if (!Array.isArray(news.files) || news.files.some((f: unknown) => typeof f !== "string" || !f)) {
+				failures.push({ property: "files", reason: "files must be an array of non-empty URL strings" });
+			}
 		}
-		// Normalize hosts: accept string[] or undefined; reject non-array.
-		if (news.hosts !== undefined && !Array.isArray(news.hosts)) {
-			failures.push({ property: "hosts", reason: "hosts must be an array of hostname strings" });
+		// Validate hosts: accept string[] or undefined; reject non-array or non-string elements.
+		if (news.hosts !== undefined) {
+			if (!Array.isArray(news.hosts) || news.hosts.some((h: unknown) => typeof h !== "string" || !h)) {
+				failures.push({ property: "hosts", reason: "hosts must be an array of non-empty hostname strings" });
+			}
 		}
 		// files and hosts are mutually exclusive.
 		if (Array.isArray(news.files) && news.files.length > 0 && Array.isArray(news.hosts) && news.hosts.length > 0) {
@@ -867,8 +871,8 @@ async function purgeZoneCacheApi(
 /**
  * A Pulumi dynamic resource that purges the Cloudflare zone cache.
  *
- * When `files` is provided, only the specified URLs are purged.
- * Otherwise the entire zone cache is purged.
+ * When `files` or `hosts` are provided, only the specified URLs or hostnames
+ * are purged. Otherwise the entire zone cache is purged.
  * Triggers on create and update (whenever inputs change). Delete is a no-op
  * since there's nothing to undo — the cache will naturally repopulate.
  */

--- a/packages/sector7/r2/r2object.ts
+++ b/packages/sector7/r2/r2object.ts
@@ -772,19 +772,25 @@ const zoneCachePurgeProvider: dynamic.ResourceProvider = {
 			}
 		}
 		// Validate files: accept non-empty string[] or undefined; reject non-array, non-string elements, or empty.
+		// Cloudflare limits purge requests to 30 URLs.
 		if (news.files !== undefined) {
 			if (!Array.isArray(news.files) || news.files.some((f: unknown) => typeof f !== "string" || !f)) {
 				failures.push({ property: "files", reason: "files must be an array of non-empty URL strings" });
 			} else if (news.files.length === 0) {
 				failures.push({ property: "files", reason: "files must not be empty — omit the property to purge the entire zone" });
+			} else if (news.files.length > 30) {
+				failures.push({ property: "files", reason: "files must not exceed 30 items (Cloudflare API limit)" });
 			}
 		}
 		// Validate hosts: accept non-empty string[] or undefined; reject non-array, non-string elements, or empty.
+		// Cloudflare limits purge requests to 30 hostnames.
 		if (news.hosts !== undefined) {
 			if (!Array.isArray(news.hosts) || news.hosts.some((h: unknown) => typeof h !== "string" || !h)) {
 				failures.push({ property: "hosts", reason: "hosts must be an array of non-empty hostname strings" });
 			} else if (news.hosts.length === 0) {
 				failures.push({ property: "hosts", reason: "hosts must not be empty — omit the property to purge the entire zone" });
+			} else if (news.hosts.length > 30) {
+				failures.push({ property: "hosts", reason: "hosts must not exceed 30 items (Cloudflare API limit)" });
 			}
 		}
 		// files and hosts are mutually exclusive.

--- a/packages/sector7/r2/r2object.ts
+++ b/packages/sector7/r2/r2object.ts
@@ -718,12 +718,30 @@ export interface PurgeZoneCacheArgs {
 	 * and apiToken stay the same across deploys.
 	 */
 	trigger: Input<string>;
+	/**
+	 * Specific URLs to purge instead of purging the entire zone.
+	 * Each entry must be a full URL (e.g. `https://dev.example.com/index.html`).
+	 * When omitted or empty, the entire zone cache is purged via `purge_everything`.
+	 * Useful when multiple stacks share a single Cloudflare zone — each stack
+	 * can scope its purge to its own hostname without invalidating the other.
+	 */
+	files?: Input<Input<string>[]>;
 	/** Resource dependencies — purge runs after these complete. */
 	dependsOn?: Input<Input<Resource>[]>;
 }
 
 /**
- * Purge the Cloudflare edge cache for an entire zone after a deploy.
+ * Normalized inputs stored in Pulumi state for ZoneCachePurge.
+ */
+interface ZoneCachePurgeInputs {
+	zoneId: string;
+	apiToken: string;
+	trigger: string;
+	files?: string[];
+}
+
+/**
+ * Purge the Cloudflare edge cache for an entire zone (or specific URLs) after a deploy.
  *
  * Uses a Pulumi dynamic resource to call the Cloudflare Purge Cache API.
  * The `trigger` input changes on every deployment (e.g. a hash of uploaded
@@ -744,6 +762,10 @@ const zoneCachePurgeProvider: dynamic.ResourceProvider = {
 				failures.push({ property: p, reason: p + " is required and must be a non-empty string" });
 			}
 		}
+		// Normalize files: accept string[] or undefined; reject non-array.
+		if (news.files !== undefined && !Array.isArray(news.files)) {
+			failures.push({ property: "files", reason: "files must be an array of URL strings" });
+		}
 		return { inputs: news, failures };
 	},
 
@@ -754,18 +776,20 @@ const zoneCachePurgeProvider: dynamic.ResourceProvider = {
 	): Promise<dynamic.DiffResult> {
 		const replaces: string[] = [];
 		if (olds.zoneId !== news.zoneId) replaces.push("zoneId");
+		const filesChanged =
+			JSON.stringify(olds.files ?? []) !== JSON.stringify(news.files ?? []);
 		return {
 			replaces,
-			changes: replaces.length > 0 || olds.trigger !== news.trigger || olds.apiToken !== news.apiToken,
+			changes:
+				replaces.length > 0 ||
+				olds.trigger !== news.trigger ||
+				olds.apiToken !== news.apiToken ||
+				filesChanged,
 		};
 	},
 
-	async create(inputs: {
-		zoneId: string;
-		apiToken: string;
-		trigger: string;
-	}): Promise<dynamic.CreateResult> {
-		await purgeZoneCacheApi(inputs.zoneId, inputs.apiToken);
+	async create(inputs: ZoneCachePurgeInputs): Promise<dynamic.CreateResult> {
+		await purgeZoneCacheApi(inputs.zoneId, inputs.apiToken, inputs.files);
 		return {
 			id: `purge-${inputs.zoneId}-${inputs.trigger.slice(0, 12)}`,
 			outs: { ...inputs },
@@ -775,9 +799,9 @@ const zoneCachePurgeProvider: dynamic.ResourceProvider = {
 	async update(
 		_id: string,
 		_olds: Record<string, unknown>,
-		news: { zoneId: string; apiToken: string; trigger: string },
+		news: ZoneCachePurgeInputs,
 	): Promise<dynamic.UpdateResult> {
-		await purgeZoneCacheApi(news.zoneId, news.apiToken);
+		await purgeZoneCacheApi(news.zoneId, news.apiToken, news.files);
 		return { outs: { ...news } };
 	},
 
@@ -789,7 +813,12 @@ const zoneCachePurgeProvider: dynamic.ResourceProvider = {
 async function purgeZoneCacheApi(
 	zoneId: string,
 	apiToken: string,
+	files?: string[],
 ): Promise<void> {
+	const body =
+		files && files.length > 0
+			? { files }
+			: { purge_everything: true };
 	const response = await fetch(
 		`https://api.cloudflare.com/client/v4/zones/${zoneId}/purge_cache`,
 		{
@@ -798,7 +827,7 @@ async function purgeZoneCacheApi(
 				Authorization: `Bearer ${apiToken}`,
 				"Content-Type": "application/json",
 			},
-			body: JSON.stringify({ purge_everything: true }),
+			body: JSON.stringify(body),
 		},
 	);
 
@@ -813,6 +842,8 @@ async function purgeZoneCacheApi(
 /**
  * A Pulumi dynamic resource that purges the Cloudflare zone cache.
  *
+ * When `files` is provided, only the specified URLs are purged.
+ * Otherwise the entire zone cache is purged.
  * Triggers on create and update (whenever inputs change). Delete is a no-op
  * since there's nothing to undo — the cache will naturally repopulate.
  */
@@ -835,6 +866,7 @@ class ZoneCachePurge extends dynamic.Resource {
 				zoneId: args.zoneId,
 				apiToken: args.apiToken,
 				trigger: args.trigger,
+				files: args.files,
 			},
 			mergedOpts,
 		);

--- a/packages/sector7/r2/r2object.ts
+++ b/packages/sector7/r2/r2object.ts
@@ -776,7 +776,7 @@ const zoneCachePurgeProvider: dynamic.ResourceProvider = {
 			if (!Array.isArray(news.files) || news.files.some((f: unknown) => typeof f !== "string" || !f)) {
 				failures.push({ property: "files", reason: "files must be an array of non-empty URL strings" });
 			} else if (news.files.length === 0) {
-				failures.push({ property: "files", reason: "files must not be empty — use purgeEverything instead" });
+				failures.push({ property: "files", reason: "files must not be empty — omit the property to purge the entire zone" });
 			}
 		}
 		// Validate hosts: accept non-empty string[] or undefined; reject non-array, non-string elements, or empty.
@@ -784,7 +784,7 @@ const zoneCachePurgeProvider: dynamic.ResourceProvider = {
 			if (!Array.isArray(news.hosts) || news.hosts.some((h: unknown) => typeof h !== "string" || !h)) {
 				failures.push({ property: "hosts", reason: "hosts must be an array of non-empty hostname strings" });
 			} else if (news.hosts.length === 0) {
-				failures.push({ property: "hosts", reason: "hosts must not be empty — use purgeEverything instead" });
+				failures.push({ property: "hosts", reason: "hosts must not be empty — omit the property to purge the entire zone" });
 			}
 		}
 		// files and hosts are mutually exclusive.

--- a/packages/sector7/tests/zone-cache-purge.test.ts
+++ b/packages/sector7/tests/zone-cache-purge.test.ts
@@ -139,7 +139,7 @@ describe("ZoneCachePurge provider", () => {
 				files: [],
 			});
 			expect(result.failures).toEqual([
-				{ property: "files", reason: "files must not be empty — use purgeEverything instead" },
+				{ property: "files", reason: "files must not be empty — omit the property to purge the entire zone" },
 			]);
 		});
 
@@ -169,7 +169,7 @@ describe("ZoneCachePurge provider", () => {
 				hosts: [],
 			});
 			expect(result.failures).toEqual([
-				{ property: "hosts", reason: "hosts must not be empty — use purgeEverything instead" },
+				{ property: "hosts", reason: "hosts must not be empty — omit the property to purge the entire zone" },
 			]);
 		});
 

--- a/packages/sector7/tests/zone-cache-purge.test.ts
+++ b/packages/sector7/tests/zone-cache-purge.test.ts
@@ -109,7 +109,27 @@ describe("ZoneCachePurge provider", () => {
 				files: "not-an-array",
 			});
 			expect(result.failures).toEqual([
-				{ property: "files", reason: "files must be an array of URL strings" },
+				{ property: "files", reason: "files must be an array of non-empty URL strings" },
+			]);
+		});
+
+		it("rejects files array with non-string elements", async () => {
+			const result = await provider!.check({}, {
+				...baseArgs,
+				files: ["https://example.com", 123 as unknown as string],
+			});
+			expect(result.failures).toEqual([
+				{ property: "files", reason: "files must be an array of non-empty URL strings" },
+			]);
+		});
+
+		it("rejects files array with empty strings", async () => {
+			const result = await provider!.check({}, {
+				...baseArgs,
+				files: ["https://example.com", ""],
+			});
+			expect(result.failures).toEqual([
+				{ property: "files", reason: "files must be an array of non-empty URL strings" },
 			]);
 		});
 
@@ -119,7 +139,17 @@ describe("ZoneCachePurge provider", () => {
 				hosts: "not-an-array",
 			});
 			expect(result.failures).toEqual([
-				{ property: "hosts", reason: "hosts must be an array of hostname strings" },
+				{ property: "hosts", reason: "hosts must be an array of non-empty hostname strings" },
+			]);
+		});
+
+		it("rejects hosts array with non-string elements", async () => {
+			const result = await provider!.check({}, {
+				...baseArgs,
+				hosts: ["dev.example.com", null as unknown as string],
+			});
+			expect(result.failures).toEqual([
+				{ property: "hosts", reason: "hosts must be an array of non-empty hostname strings" },
 			]);
 		});
 
@@ -194,7 +224,7 @@ describe("ZoneCachePurge provider", () => {
 		it("treats undefined and empty files array as equivalent", async () => {
 			const result = await provider!.diff("id", baseArgs, {
 				...baseArgs,
-				files: undefined,
+				files: [],
 			});
 			expect(result.changes).toBe(false);
 		});
@@ -202,7 +232,7 @@ describe("ZoneCachePurge provider", () => {
 		it("treats undefined and empty hosts array as equivalent", async () => {
 			const result = await provider!.diff("id", baseArgs, {
 				...baseArgs,
-				hosts: undefined,
+				hosts: [],
 			});
 			expect(result.changes).toBe(false);
 		});

--- a/packages/sector7/tests/zone-cache-purge.test.ts
+++ b/packages/sector7/tests/zone-cache-purge.test.ts
@@ -173,6 +173,26 @@ describe("ZoneCachePurge provider", () => {
 			]);
 		});
 
+		it("rejects files array exceeding 30 items", async () => {
+			const result = await provider!.check({}, {
+				...baseArgs,
+				files: Array.from({ length: 31 }, (_, i) => `https://example.com/${i}`),
+			});
+			expect(result.failures).toEqual([
+				{ property: "files", reason: "files must not exceed 30 items (Cloudflare API limit)" },
+			]);
+		});
+
+		it("rejects hosts array exceeding 30 items", async () => {
+			const result = await provider!.check({}, {
+				...baseArgs,
+				hosts: Array.from({ length: 31 }, (_, i) => `host${i}.example.com`),
+			});
+			expect(result.failures).toEqual([
+				{ property: "hosts", reason: "hosts must not exceed 30 items (Cloudflare API limit)" },
+			]);
+		});
+
 		it("rejects files and hosts provided together", async () => {
 			const result = await provider!.check({}, {
 				...baseArgs,

--- a/packages/sector7/tests/zone-cache-purge.test.ts
+++ b/packages/sector7/tests/zone-cache-purge.test.ts
@@ -95,6 +95,14 @@ describe("ZoneCachePurge provider", () => {
 			expect(result.failures).toEqual([]);
 		});
 
+		it("accepts optional hosts array", async () => {
+			const result = await provider!.check({}, {
+				...baseArgs,
+				hosts: ["dev.example.com"],
+			});
+			expect(result.failures).toEqual([]);
+		});
+
 		it("rejects non-array files value", async () => {
 			const result = await provider!.check({}, {
 				...baseArgs,
@@ -105,10 +113,32 @@ describe("ZoneCachePurge provider", () => {
 			]);
 		});
 
-		it("accepts undefined files", async () => {
+		it("rejects non-array hosts value", async () => {
+			const result = await provider!.check({}, {
+				...baseArgs,
+				hosts: "not-an-array",
+			});
+			expect(result.failures).toEqual([
+				{ property: "hosts", reason: "hosts must be an array of hostname strings" },
+			]);
+		});
+
+		it("rejects files and hosts provided together", async () => {
+			const result = await provider!.check({}, {
+				...baseArgs,
+				files: ["https://dev.example.com/index.html"],
+				hosts: ["dev.example.com"],
+			});
+			expect(result.failures).toEqual([
+				{ property: "files", reason: "files and hosts are mutually exclusive" },
+			]);
+		});
+
+		it("accepts undefined files and hosts", async () => {
 			const result = await provider!.check({}, {
 				...baseArgs,
 				files: undefined,
+				hosts: undefined,
 			});
 			expect(result.failures).toEqual([]);
 		});
@@ -153,10 +183,26 @@ describe("ZoneCachePurge provider", () => {
 			expect(result.changes).toBe(true);
 		});
 
+		it("detects hosts change", async () => {
+			const result = await provider!.diff("id", baseArgs, {
+				...baseArgs,
+				hosts: ["dev.example.com"],
+			});
+			expect(result.changes).toBe(true);
+		});
+
 		it("treats undefined and empty files array as equivalent", async () => {
 			const result = await provider!.diff("id", baseArgs, {
 				...baseArgs,
 				files: undefined,
+			});
+			expect(result.changes).toBe(false);
+		});
+
+		it("treats undefined and empty hosts array as equivalent", async () => {
+			const result = await provider!.diff("id", baseArgs, {
+				...baseArgs,
+				hosts: undefined,
 			});
 			expect(result.changes).toBe(false);
 		});
@@ -168,10 +214,18 @@ describe("ZoneCachePurge provider", () => {
 			}, baseArgs);
 			expect(result.changes).toBe(true);
 		});
+
+		it("detects change from hosts array to undefined", async () => {
+			const result = await provider!.diff("id", {
+				...baseArgs,
+				hosts: ["dev.example.com"],
+			}, baseArgs);
+			expect(result.changes).toBe(true);
+		});
 	});
 
 	describe("create", () => {
-		it("calls purgeZoneCacheApi with purge_everything when no files", async () => {
+		it("calls purgeZoneCacheApi with purge_everything when no files or hosts", async () => {
 			await provider!.create(baseArgs);
 
 			expect(mockFetch).toHaveBeenCalledTimes(1);
@@ -192,8 +246,35 @@ describe("ZoneCachePurge provider", () => {
 			expect(JSON.parse(opts.body)).toEqual({ files });
 		});
 
+		it("calls purgeZoneCacheApi with hosts when provided", async () => {
+			const hosts = ["dev.example.com"];
+			await provider!.create({ ...baseArgs, hosts });
+
+			expect(mockFetch).toHaveBeenCalledTimes(1);
+			const [_url, opts] = mockFetch.mock.calls[0];
+			expect(JSON.parse(opts.body)).toEqual({ hosts });
+		});
+
+		it("prefers hosts over files when both are provided", async () => {
+			const hosts = ["dev.example.com"];
+			const files = ["https://dev.example.com/index.html"];
+			await provider!.create({ ...baseArgs, files, hosts });
+
+			expect(mockFetch).toHaveBeenCalledTimes(1);
+			const [_url, opts] = mockFetch.mock.calls[0];
+			expect(JSON.parse(opts.body)).toEqual({ hosts });
+		});
+
 		it("uses purge_everything when files is empty array", async () => {
 			await provider!.create({ ...baseArgs, files: [] });
+
+			expect(mockFetch).toHaveBeenCalledTimes(1);
+			const [_url, opts] = mockFetch.mock.calls[0];
+			expect(JSON.parse(opts.body)).toEqual({ purge_everything: true });
+		});
+
+		it("uses purge_everything when hosts is empty array", async () => {
+			await provider!.create({ ...baseArgs, hosts: [] });
 
 			expect(mockFetch).toHaveBeenCalledTimes(1);
 			const [_url, opts] = mockFetch.mock.calls[0];
@@ -216,6 +297,15 @@ describe("ZoneCachePurge provider", () => {
 			expect(mockFetch).toHaveBeenCalledTimes(1);
 			const [_url, opts] = mockFetch.mock.calls[0];
 			expect(JSON.parse(opts.body)).toEqual({ files });
+		});
+
+		it("calls purgeZoneCacheApi with new hosts", async () => {
+			const hosts = ["prod.example.com"];
+			await provider!.update("id", baseArgs, { ...baseArgs, hosts });
+
+			expect(mockFetch).toHaveBeenCalledTimes(1);
+			const [_url, opts] = mockFetch.mock.calls[0];
+			expect(JSON.parse(opts.body)).toEqual({ hosts });
 		});
 
 		it("returns new outs", async () => {

--- a/packages/sector7/tests/zone-cache-purge.test.ts
+++ b/packages/sector7/tests/zone-cache-purge.test.ts
@@ -133,6 +133,16 @@ describe("ZoneCachePurge provider", () => {
 			]);
 		});
 
+		it("rejects empty files array", async () => {
+			const result = await provider!.check({}, {
+				...baseArgs,
+				files: [],
+			});
+			expect(result.failures).toEqual([
+				{ property: "files", reason: "files must not be empty — use purgeEverything instead" },
+			]);
+		});
+
 		it("rejects non-array hosts value", async () => {
 			const result = await provider!.check({}, {
 				...baseArgs,
@@ -150,6 +160,16 @@ describe("ZoneCachePurge provider", () => {
 			});
 			expect(result.failures).toEqual([
 				{ property: "hosts", reason: "hosts must be an array of non-empty hostname strings" },
+			]);
+		});
+
+		it("rejects empty hosts array", async () => {
+			const result = await provider!.check({}, {
+				...baseArgs,
+				hosts: [],
+			});
+			expect(result.failures).toEqual([
+				{ property: "hosts", reason: "hosts must not be empty — use purgeEverything instead" },
 			]);
 		});
 
@@ -221,7 +241,7 @@ describe("ZoneCachePurge provider", () => {
 			expect(result.changes).toBe(true);
 		});
 
-		it("treats undefined and empty files array as equivalent", async () => {
+		it("treats undefined and empty files array as equivalent in diff", async () => {
 			const result = await provider!.diff("id", baseArgs, {
 				...baseArgs,
 				files: [],
@@ -229,7 +249,7 @@ describe("ZoneCachePurge provider", () => {
 			expect(result.changes).toBe(false);
 		});
 
-		it("treats undefined and empty hosts array as equivalent", async () => {
+		it("treats undefined and empty hosts array as equivalent in diff", async () => {
 			const result = await provider!.diff("id", baseArgs, {
 				...baseArgs,
 				hosts: [],
@@ -243,6 +263,28 @@ describe("ZoneCachePurge provider", () => {
 				files: ["https://dev.example.com/index.html"],
 			}, baseArgs);
 			expect(result.changes).toBe(true);
+		});
+
+		it("treats reordered files array as equivalent", async () => {
+			const result = await provider!.diff("id", {
+				...baseArgs,
+				files: ["https://a.com", "https://b.com"],
+			}, {
+				...baseArgs,
+				files: ["https://b.com", "https://a.com"],
+			});
+			expect(result.changes).toBe(false);
+		});
+
+		it("treats reordered hosts array as equivalent", async () => {
+			const result = await provider!.diff("id", {
+				...baseArgs,
+				hosts: ["a.example.com", "b.example.com"],
+			}, {
+				...baseArgs,
+				hosts: ["b.example.com", "a.example.com"],
+			});
+			expect(result.changes).toBe(false);
 		});
 
 		it("detects change from hosts array to undefined", async () => {

--- a/packages/sector7/tests/zone-cache-purge.test.ts
+++ b/packages/sector7/tests/zone-cache-purge.test.ts
@@ -1,0 +1,235 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+type ZoneCachePurgeProvider = {
+	check: (
+		olds: Record<string, unknown>,
+		news: Record<string, unknown>,
+	) => Promise<{
+		inputs: Record<string, unknown>;
+		failures: Array<{ property: string; reason: string }>;
+	}>;
+	diff: (
+		id: string,
+		olds: Record<string, unknown>,
+		news: Record<string, unknown>,
+	) => Promise<{
+		changes: boolean;
+		replaces?: string[];
+	}>;
+	create: (inputs: Record<string, unknown>) => Promise<{
+		id: string;
+		outs: Record<string, unknown>;
+	}>;
+	update: (
+		id: string,
+		olds: Record<string, unknown>,
+		news: Record<string, unknown>,
+	) => Promise<{ outs: Record<string, unknown> }>;
+	delete: (id: string, props: Record<string, unknown>) => Promise<void>;
+};
+
+let provider: ZoneCachePurgeProvider | undefined;
+
+// Capture the provider from ZoneCachePurge constructor.
+// The constructor passes the provider as the first arg to dynamic.Resource super().
+vi.mock("@pulumi/pulumi", () => ({
+	dynamic: {
+		Resource: class {
+			constructor(resourceProvider: ZoneCachePurgeProvider) {
+				provider = resourceProvider;
+			}
+		},
+	},
+	mergeOptions: (..._opts: unknown[]) => ({}),
+}));
+
+import { purgeZoneCache } from "../r2/r2object.ts";
+
+const baseArgs = {
+	zoneId: "zone-abc123",
+	apiToken: "test-token",
+	trigger: "trigger-v1",
+};
+
+// Mock fetch to capture Cloudflare API calls
+const mockFetch = vi.fn().mockResolvedValue({
+	ok: true,
+	status: 200,
+	statusText: "OK",
+	text: async () => '{"success": true}',
+});
+
+vi.stubGlobal("fetch", mockFetch);
+
+describe("ZoneCachePurge provider", () => {
+	beforeEach(() => {
+		provider = undefined;
+		mockFetch.mockClear();
+		// Instantiate to capture provider
+		purgeZoneCache("test-purge", baseArgs);
+	});
+
+	it("captures the provider on construction", () => {
+		expect(provider).toBeDefined();
+	});
+
+	describe("check", () => {
+		it("passes with valid required inputs", async () => {
+			const result = await provider!.check({}, baseArgs);
+			expect(result.failures).toEqual([]);
+		});
+
+		it("reports failures for missing required fields", async () => {
+			const result = await provider!.check({}, {});
+			const properties = result.failures.map((f) => f.property);
+			expect(properties).toContain("zoneId");
+			expect(properties).toContain("apiToken");
+			expect(properties).toContain("trigger");
+		});
+
+		it("accepts optional files array", async () => {
+			const result = await provider!.check({}, {
+				...baseArgs,
+				files: ["https://dev.example.com/index.html"],
+			});
+			expect(result.failures).toEqual([]);
+		});
+
+		it("rejects non-array files value", async () => {
+			const result = await provider!.check({}, {
+				...baseArgs,
+				files: "not-an-array",
+			});
+			expect(result.failures).toEqual([
+				{ property: "files", reason: "files must be an array of URL strings" },
+			]);
+		});
+
+		it("accepts undefined files", async () => {
+			const result = await provider!.check({}, {
+				...baseArgs,
+				files: undefined,
+			});
+			expect(result.failures).toEqual([]);
+		});
+	});
+
+	describe("diff", () => {
+		it("detects no changes when inputs match", async () => {
+			const result = await provider!.diff("id", baseArgs, baseArgs);
+			expect(result.changes).toBe(false);
+		});
+
+		it("detects trigger change", async () => {
+			const result = await provider!.diff("id", baseArgs, {
+				...baseArgs,
+				trigger: "trigger-v2",
+			});
+			expect(result.changes).toBe(true);
+		});
+
+		it("detects apiToken change", async () => {
+			const result = await provider!.diff("id", baseArgs, {
+				...baseArgs,
+				apiToken: "new-token",
+			});
+			expect(result.changes).toBe(true);
+		});
+
+		it("detects zoneId change as a replace", async () => {
+			const result = await provider!.diff("id", baseArgs, {
+				...baseArgs,
+				zoneId: "zone-new",
+			});
+			expect(result.changes).toBe(true);
+			expect(result.replaces).toContain("zoneId");
+		});
+
+		it("detects files change", async () => {
+			const result = await provider!.diff("id", baseArgs, {
+				...baseArgs,
+				files: ["https://dev.example.com/index.html"],
+			});
+			expect(result.changes).toBe(true);
+		});
+
+		it("treats undefined and empty files array as equivalent", async () => {
+			const result = await provider!.diff("id", baseArgs, {
+				...baseArgs,
+				files: undefined,
+			});
+			expect(result.changes).toBe(false);
+		});
+
+		it("detects change from files array to undefined", async () => {
+			const result = await provider!.diff("id", {
+				...baseArgs,
+				files: ["https://dev.example.com/index.html"],
+			}, baseArgs);
+			expect(result.changes).toBe(true);
+		});
+	});
+
+	describe("create", () => {
+		it("calls purgeZoneCacheApi with purge_everything when no files", async () => {
+			await provider!.create(baseArgs);
+
+			expect(mockFetch).toHaveBeenCalledTimes(1);
+			const [url, opts] = mockFetch.mock.calls[0];
+			expect(url).toContain("zone-abc123/purge_cache");
+			expect(JSON.parse(opts.body)).toEqual({ purge_everything: true });
+		});
+
+		it("calls purgeZoneCacheApi with specific files when provided", async () => {
+			const files = [
+				"https://dev.example.com/index.html",
+				"https://dev.example.com/styles.css",
+			];
+			await provider!.create({ ...baseArgs, files });
+
+			expect(mockFetch).toHaveBeenCalledTimes(1);
+			const [_url, opts] = mockFetch.mock.calls[0];
+			expect(JSON.parse(opts.body)).toEqual({ files });
+		});
+
+		it("uses purge_everything when files is empty array", async () => {
+			await provider!.create({ ...baseArgs, files: [] });
+
+			expect(mockFetch).toHaveBeenCalledTimes(1);
+			const [_url, opts] = mockFetch.mock.calls[0];
+			expect(JSON.parse(opts.body)).toEqual({ purge_everything: true });
+		});
+
+		it("returns a stable id and outs", async () => {
+			const result = await provider!.create(baseArgs);
+
+			expect(result.id).toBe("purge-zone-abc123-trigger-v1");
+			expect(result.outs).toEqual(baseArgs);
+		});
+	});
+
+	describe("update", () => {
+		it("calls purgeZoneCacheApi with new files", async () => {
+			const files = ["https://prod.example.com/index.html"];
+			await provider!.update("id", baseArgs, { ...baseArgs, files });
+
+			expect(mockFetch).toHaveBeenCalledTimes(1);
+			const [_url, opts] = mockFetch.mock.calls[0];
+			expect(JSON.parse(opts.body)).toEqual({ files });
+		});
+
+		it("returns new outs", async () => {
+			const news = { ...baseArgs, trigger: "trigger-v2" };
+			const result = await provider!.update("id", baseArgs, news);
+
+			expect(result.outs).toEqual(news);
+		});
+	});
+
+	describe("delete", () => {
+		it("is a no-op and does not call fetch", async () => {
+			await provider!.delete("id", baseArgs);
+			expect(mockFetch).not.toHaveBeenCalled();
+		});
+	});
+});


### PR DESCRIPTION
## Summary

Add optional `files` and `hosts` parameters to `PurgeZoneCacheArgs`. These allow scoped cache purges instead of always purging the entire zone.

- `files`: Array of full URLs. Sends `{"files": [...]}` to the Cloudflare API.
- `hosts`: Array of bare hostnames. Sends `{"hosts": [...]}` to purge all cached content for those hostnames.

When neither is provided, falls back to `{"purge_everything": true}`. `files` and `hosts` are mutually exclusive.

## Motivation

The yard repo deploys `addendalabs.com` (prod) and `dev.addendalabs.com` (dev) into the same Cloudflare zone (`zoneId: 32a46f3c...`). A dev deploy doing `purge_everything` clears the prod cache.

With `hosts`, the dev stack passes `hosts: ["dev.addendalabs.com"]` to scope its purge to only its own hostname. The prod stack can continue using `purge_everything` or also scope to `hosts: ["addendalabs.com"]`.

## Changes

- `PurgeZoneCacheArgs.files`: optional `Input<string[]>` of full URLs to purge
- `PurgeZoneCacheArgs.hosts`: optional `Input<string[]>` of hostnames to purge
- `purgeZoneCacheApi`: sends `{hosts}` > `{files}` > `{purge_everything}` based on what is provided
- Provider `check`: validates `files`/`hosts` are arrays, rejects both provided together
- Provider `diff`: detects `files`/`hosts` changes (triggers update, not replace)
- `ZoneCachePurge` constructor: passes `files` and `hosts` to provider state

## Backward compatibility

Fully backward compatible. Omitting both `files` and `hosts` preserves existing `purge_everything` behavior.

## Test plan

- 30 tests in `tests/zone-cache-purge.test.ts` covering:
  - `check`: valid inputs, missing required fields, optional files/hosts, invalid types, mutual exclusivity
  - `diff`: no changes, trigger/apiToken/zoneId changes, files/hosts changes, undefined vs empty equivalence
  - `create`: purge_everything, specific files, hosts, hosts-over-files precedence, empty array fallback, stable id
  - `update`: files/hosts propagation, outs return
  - `delete`: no-op verification
- All 70 tests pass (30 new + 40 existing)
- `tsc --noEmit` clean

## Risks

Low risk. The Cloudflare Purge Cache API has supported `files` and `hosts` since its inception. The change is purely additive to the type contract.

## Downstream

Blocks: addendalabs/yard#1132 (will consume `hosts` parameter for dev deploys)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the behavior of the Pulumi dynamic cache-purge resource to optionally send `files`/`hosts` payloads; mistakes in inputs could lead to under/over-purging during deploys, though validation and tests reduce this risk.
> 
> **Overview**
> `purgeZoneCache` now supports **scoped Cloudflare cache purges** via optional `files` (full URLs) or `hosts` (hostnames), instead of always sending `purge_everything`.
> 
> The dynamic provider now validates `files`/`hosts` (type, non-empty, <=30 items, and mutual exclusivity), includes them in state, and treats sorted list changes as diffs that trigger an update. `purgeZoneCacheApi` builds the request body as `hosts` > `files` > `purge_everything`.
> 
> Adds a new Vitest suite covering provider `check`/`diff` behavior and verifying the emitted Cloudflare API request bodies for create/update/delete.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit de7307c7289c62de4d2922bbea1629e629359e72. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->