### PR TITLE
fix: guard dynamic resource provider options

### DIFF
--- a/packages/sector7/r2/index.ts
+++ b/packages/sector7/r2/index.ts
@@ -1,6 +1,7 @@
 export {
 	type AssetConfig,
 	type AssetFile,
+	type DynamicResourceOptions,
 	R2Object,
 	type R2ObjectInputs,
 	type StaticAssetFile,

--- a/packages/sector7/r2/r2object.ts
+++ b/packages/sector7/r2/r2object.ts
@@ -321,15 +321,14 @@ const rejectCloudProviderOptions = (
 ): void => {
 	if (!opts) return;
 
-	const maybeProviderOptions = opts as CustomResourceOptions & {
-		providers?: unknown;
-	};
 	const hasProvider =
-		Object.prototype.hasOwnProperty.call(maybeProviderOptions, "provider") &&
-		maybeProviderOptions.provider !== undefined;
+		Object.prototype.hasOwnProperty.call(opts, "provider") &&
+		opts.provider !== undefined;
+	// `providers` is not on CustomResourceOptions but may be present at runtime
+	// if a ComponentResourceOptions was passed (JS doesn't enforce nominal types).
 	const hasProviders =
-		Object.prototype.hasOwnProperty.call(maybeProviderOptions, "providers") &&
-		maybeProviderOptions.providers !== undefined;
+		Object.prototype.hasOwnProperty.call(opts, "providers") &&
+		(opts as Record<string, unknown>).providers !== undefined;
 	if (!hasProvider && !hasProviders) return;
 
 	throw new Error(
@@ -339,10 +338,15 @@ const rejectCloudProviderOptions = (
 };
 
 const omitCloudProviderOptions = (
-	opts?: ComponentResourceOptions,
+	opts?: CustomResourceOptions,
 ): DynamicResourceOptions | undefined => {
 	if (!opts) return undefined;
-	const { provider: _provider, providers: _providers, ...dynamicOpts } = opts;
+	// Cast to pick both `provider` (on CustomResourceOptions) and `providers`
+	// (may be present at runtime from ComponentResourceOptions).
+	const { provider: _provider, providers: _providers, ...dynamicOpts } =
+		opts as CustomResourceOptions & {
+			providers?: unknown;
+		};
 	return dynamicOpts;
 };
 

--- a/packages/sector7/r2/r2object.ts
+++ b/packages/sector7/r2/r2object.ts
@@ -11,6 +11,19 @@ import {
 	type Resource,
 } from "@pulumi/pulumi";
 
+/**
+ * Resource options accepted by sector7 dynamic resources.
+ *
+ * Pulumi dynamic resources are executed by the Node.js dynamic provider runtime,
+ * not by a cloud provider plugin. Passing `provider` or `providers` makes Pulumi
+ * route the resource through the wrong provider bridge, which fails with a
+ * misleading `pulumi-nodejs:dynamic:Resource` unknown-token error.
+ */
+export type DynamicResourceOptions = Omit<
+	CustomResourceOptions,
+	"provider" | "providers"
+>;
+
 // ---------------------------------------------------------------------------
 // AWS Signature Version 4 — minimal implementation for S3 PUT/DELETE only.
 // Uses node:crypto (dynamically imported) and global fetch(). No external deps.
@@ -302,6 +315,37 @@ interface R2ObjectState extends R2ObjectArgs {
 	etag: string;
 }
 
+const rejectCloudProviderOptions = (
+	resourceName: string,
+	opts?: CustomResourceOptions,
+): void => {
+	if (!opts) return;
+
+	const maybeProviderOptions = opts as CustomResourceOptions & {
+		providers?: unknown;
+	};
+	const hasProvider =
+		Object.prototype.hasOwnProperty.call(maybeProviderOptions, "provider") &&
+		maybeProviderOptions.provider !== undefined;
+	const hasProviders =
+		Object.prototype.hasOwnProperty.call(maybeProviderOptions, "providers") &&
+		maybeProviderOptions.providers !== undefined;
+	if (!hasProvider && !hasProviders) return;
+
+	throw new Error(
+		`${resourceName} is a Pulumi dynamic resource; do not pass provider/providers. ` +
+			"Pass provider options only to cloud provider resources, and use parent/dependsOn for dynamic resource ordering.",
+	);
+};
+
+const omitCloudProviderOptions = (
+	opts?: ComponentResourceOptions,
+): DynamicResourceOptions | undefined => {
+	if (!opts) return undefined;
+	const { provider: _provider, providers: _providers, ...dynamicOpts } = opts;
+	return dynamicOpts;
+};
+
 // ---------------------------------------------------------------------------
 // File helpers
 // ---------------------------------------------------------------------------
@@ -535,8 +579,9 @@ export class R2Object extends dynamic.Resource {
 	constructor(
 		name: string,
 		args: R2ObjectInputs,
-		opts?: CustomResourceOptions,
+		opts?: DynamicResourceOptions,
 	) {
+		rejectCloudProviderOptions("R2Object", opts);
 		super(r2ObjectProvider, name, { etag: undefined, ...args }, opts);
 	}
 }
@@ -568,11 +613,12 @@ export function uploadAssets(
 	args: UploadAssetsArgs,
 	opts?: ComponentResourceOptions,
 ): R2Object[] {
-	// Use caller-provided opts as the base for child resources so that
-	// options like `protect`, `provider`, `aliases` etc. are forwarded.
+	// Use caller-provided opts as the base for Cloudflare resources, but do not
+	// forward cloud-provider options into Pulumi dynamic resources.
 	const tokenOpts = { ...opts };
+	const dynamicOpts = omitCloudProviderOptions(opts);
 	const r2ObjectOpts = {
-		...opts,
+		...dynamicOpts,
 		dependsOn: pulumi
 			.all([opts?.dependsOn ?? [], args.dependsOn ?? []])
 			.apply(([optDep, argDep]) => {
@@ -892,8 +938,9 @@ class ZoneCachePurge extends dynamic.Resource {
 	constructor(
 		name: string,
 		args: PurgeZoneCacheArgs,
-		opts?: CustomResourceOptions,
+		opts?: DynamicResourceOptions,
 	) {
+		rejectCloudProviderOptions("purgeZoneCache", opts);
 		// Merge dependsOn from both args and opts so caller-provided
 		// dependencies aren't silently dropped.
 		const mergedOpts = pulumi.mergeOptions(opts ?? {}, {
@@ -925,12 +972,13 @@ class ZoneCachePurge extends dynamic.Resource {
  *
  * @param name - Pulumi resource name.
  * @param args - Zone cache purge configuration.
- * @param opts - Pulumi custom resource options.
+ * @param opts - Pulumi custom resource options. Do not pass provider/providers;
+ *   this is a Node.js dynamic resource, not a Cloudflare provider resource.
  */
 export function purgeZoneCache(
 	name: string,
 	args: PurgeZoneCacheArgs,
-	opts?: CustomResourceOptions,
+	opts?: DynamicResourceOptions,
 ): ZoneCachePurge {
 	return new ZoneCachePurge(name, args, opts);
 }

--- a/packages/sector7/tests/r2object.test.ts
+++ b/packages/sector7/tests/r2object.test.ts
@@ -20,19 +20,67 @@ type R2ObjectProvider = {
 	}>;
 };
 
-let provider: R2ObjectProvider | undefined;
+type DynamicResourceCall = {
+	name: string;
+	opts: Record<string, unknown> | undefined;
+	provider: R2ObjectProvider;
+};
 
-vi.mock("@pulumi/pulumi", () => ({
-	dynamic: {
-		Resource: class {
-			constructor(resourceProvider: R2ObjectProvider) {
-				provider = resourceProvider;
-			}
+type AccountTokenCall = {
+	name: string;
+	opts: Record<string, unknown> | undefined;
+};
+
+let provider: R2ObjectProvider | undefined;
+const dynamicResourceCalls: DynamicResourceCall[] = [];
+const accountTokenCalls: AccountTokenCall[] = [];
+
+vi.mock("@pulumi/pulumi", () => {
+	const output = <T>(value: T) => ({
+		apply: <U>(fn: (value: T) => U) => fn(value),
+	});
+
+	return {
+		all: <T>(value: T) => output(value),
+		output,
+		mergeOptions: (
+			left: Record<string, unknown>,
+			right: Record<string, unknown>,
+		) => ({ ...left, ...right }),
+		dynamic: {
+			Resource: class {
+				constructor(
+					resourceProvider: R2ObjectProvider,
+					name: string,
+					_args: Record<string, unknown>,
+					opts?: Record<string, unknown>,
+				) {
+					provider = resourceProvider;
+					dynamicResourceCalls.push({ name, opts, provider: resourceProvider });
+				}
+			},
 		},
+	};
+});
+
+vi.mock("@pulumi/cloudflare", () => ({
+	AccountToken: class {
+		public readonly id = "token-id";
+		public readonly value = {
+			apply: (fn: (value: string) => string | Promise<string>) => fn("token-value"),
+		};
+
+		constructor(
+			name: string,
+			_args: Record<string, unknown>,
+			opts?: Record<string, unknown>,
+		) {
+			accountTokenCalls.push({ name, opts });
+		}
 	},
 }));
 
-import { R2Object } from "../r2/r2object.ts";
+import { purgeZoneCache, R2Object, uploadAssets } from "../r2/r2object.ts";
 
 const createArgs = (filePath: string) => ({
 	accountId: "account-123",
@@ -44,12 +92,16 @@ const createArgs = (filePath: string) => ({
 	secretAccessKey: "secret-key",
 });
 
+const cloudProviderOpt = { provider: { urn: "cloudflare-provider" } };
+
 describe("R2Object provider", () => {
 	let tempDir: string;
 
 	beforeEach(() => {
 		tempDir = mkdtempSync(join(tmpdir(), "r2object-test-"));
 		provider = undefined;
+		dynamicResourceCalls.length = 0;
+		accountTokenCalls.length = 0;
 		new R2Object("asset", createArgs(join(tempDir, "bootstrap.txt")));
 	});
 
@@ -107,5 +159,65 @@ describe("R2Object provider", () => {
 			replaces: [],
 			deleteBeforeReplace: true,
 		});
+	});
+
+	it("rejects cloud provider options when R2Object is constructed directly", () => {
+		expect(
+			() => new R2Object("asset", createArgs(join(tempDir, "index.html")), cloudProviderOpt),
+		).toThrow(/R2Object is a Pulumi dynamic resource; do not pass provider\/providers/);
+	});
+});
+
+describe("uploadAssets", () => {
+	beforeEach(() => {
+		provider = undefined;
+		dynamicResourceCalls.length = 0;
+		accountTokenCalls.length = 0;
+	});
+
+	it("keeps provider options on the Cloudflare token but strips them from dynamic R2 objects", () => {
+		uploadAssets(
+			"site",
+			{
+				accountId: "account-123",
+				bucketName: "bucket-123",
+				files: [
+					{
+						key: "index.html",
+						filePath: "/tmp/index.html",
+						contentType: "text/html; charset=utf-8",
+					},
+				],
+			},
+			cloudProviderOpt,
+		);
+
+		expect(accountTokenCalls).toHaveLength(1);
+		expect(accountTokenCalls[0].opts).toMatchObject(cloudProviderOpt);
+		expect(dynamicResourceCalls).toHaveLength(1);
+		expect(dynamicResourceCalls[0].opts).not.toHaveProperty("provider");
+		expect(dynamicResourceCalls[0].opts).not.toHaveProperty("providers");
+	});
+});
+
+describe("purgeZoneCache", () => {
+	beforeEach(() => {
+		provider = undefined;
+		dynamicResourceCalls.length = 0;
+		accountTokenCalls.length = 0;
+	});
+
+	it("rejects cloud provider options with a clear dynamic-resource error", () => {
+		expect(() =>
+			purgeZoneCache(
+				"purge",
+				{
+					zoneId: "zone-123",
+					apiToken: "token",
+					trigger: "asset-hash",
+				},
+				cloudProviderOpt,
+			),
+		).toThrow(/purgeZoneCache is a Pulumi dynamic resource; do not pass provider\/providers/);
 	});
 });


### PR DESCRIPTION
## Summary
- Add a `DynamicResourceOptions` type that omits Pulumi `provider` / `providers` for Node.js dynamic resources.
- Add a runtime guard so direct `R2Object` / `purgeZoneCache` misuse fails with a clear error instead of Pulumi's `pf/tfbridge` unknown-token failure.
- Keep `uploadAssets` accepting provider options for the Cloudflare `AccountToken`, but strip those options before constructing dynamic `R2Object` children.

## Why
A consumer can accidentally pass a Cloudflare provider option into `purgeZoneCache` because nearby sector7 resources do need that provider option. Pulumi then routes `pulumi-nodejs:dynamic:Resource` through the Terraform bridge and fails with:

```text
[pf/tfbridge] unknown resource token: pulumi-nodejs:dynamic:Resource
```

That points at the dynamic resource token rather than the real cause: provider-option leakage into a Node.js dynamic resource.

This PR makes the API harder to misuse and gives JS / unsafe TS callers a direct error message.

## Test Plan
- [x] `corepack pnpm --dir packages/sector7 test`
- [x] `corepack pnpm --dir packages/sector7 build`

Fixes #178

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Pulumi resource option handling for `R2Object`/`purgeZoneCache` and `uploadAssets`, which can affect deployment behavior if callers previously relied on passing `provider/providers` through options.
> 
> **Overview**
> **Prevents accidental misuse of Pulumi dynamic resources** by introducing `DynamicResourceOptions` (omitting `provider/providers`) and adding a runtime guard that throws a clear error when those options are passed to `R2Object` or `purgeZoneCache`.
> 
> Updates `uploadAssets` to keep `provider` options for the Cloudflare `AccountToken` resource while stripping them from child dynamic `R2Object` resources, and adds tests to assert both the stripping behavior and the new rejection errors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2d69a9d6cba77d5579ede995b834655c62c4f57b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->