### PR TITLE
fix: avoid immutable browser cache for stable asset names

### DIFF
--- a/packages/sector7/package.json
+++ b/packages/sector7/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@jmmaloney4/sector7",
-	"version": "0.7.0",
+	"version": "0.8.2",
 	"description": "Reusable Pulumi components for infrastructure management",
 	"license": "MPL-2.0",
 	"publishConfig": {

--- a/packages/sector7/tests/worker-site-script.test.ts
+++ b/packages/sector7/tests/worker-site-script.test.ts
@@ -1,6 +1,16 @@
 import { describe, expect, it } from "vitest";
 import { generateWorkerScript } from "../workersite/worker-site-script.ts";
 
+const extractFingerprintMatcher = (script: string): ((key: string) => boolean) => {
+	const match = script.match(
+		/function isFingerprintAssetKey\(key\) \{[\s\S]*?\n\}/,
+	);
+	expect(match).not.toBeNull();
+	return new Function(`${match![0]}; return isFingerprintAssetKey;`)() as (
+		key: string,
+	) => boolean;
+};
+
 describe("generateWorkerScript", () => {
 	it("produces a basic fetch handler with no prefix or redirects", () => {
 		const script = generateWorkerScript("R2_BUCKET");
@@ -28,7 +38,13 @@ describe("generateWorkerScript", () => {
 			"public, max-age=0, s-maxage=${maxAge}, must-revalidate",
 		);
 		expect(script).toContain("public, max-age=31536000, immutable");
-		expect(script).toContain("return /(?:[.-])[A-Za-z0-9_-]{8,}");
-		expect(script).toContain(".test(base);");
+
+		const isFingerprintAssetKey = extractFingerprintMatcher(script);
+		expect(isFingerprintAssetKey("assets/index-B_PaUjV8.js")).toBe(true);
+		expect(isFingerprintAssetKey("assets/app.a1b2c3d4.css")).toBe(true);
+		expect(isFingerprintAssetKey("assets/app-a1b2c3d4.js")).toBe(true);
+		expect(isFingerprintAssetKey("styles.css")).toBe(false);
+		expect(isFingerprintAssetKey("index.html")).toBe(false);
+		expect(isFingerprintAssetKey("favicon.svg")).toBe(false);
 	});
 });

--- a/packages/sector7/tests/worker-site-script.test.ts
+++ b/packages/sector7/tests/worker-site-script.test.ts
@@ -42,9 +42,13 @@ describe("generateWorkerScript", () => {
 		const isFingerprintAssetKey = extractFingerprintMatcher(script);
 		expect(isFingerprintAssetKey("assets/index-B_PaUjV8.js")).toBe(true);
 		expect(isFingerprintAssetKey("assets/app.a1b2c3d4.css")).toBe(true);
-		expect(isFingerprintAssetKey("assets/app-a1b2c3d4.js")).toBe(true);
+		expect(isFingerprintAssetKey("assets/app-a1b2c3d4.js")).toBe(false);
 		expect(isFingerprintAssetKey("styles.css")).toBe(false);
 		expect(isFingerprintAssetKey("index.html")).toBe(false);
 		expect(isFingerprintAssetKey("favicon.svg")).toBe(false);
+		expect(isFingerprintAssetKey("my-component.js")).toBe(false);
+		expect(isFingerprintAssetKey("lodash-throttle.js")).toBe(false);
+		expect(isFingerprintAssetKey("inter-variable.woff2")).toBe(false);
+		expect(isFingerprintAssetKey("release-20260511.css")).toBe(false);
 	});
 });

--- a/packages/sector7/tests/worker-site-script.test.ts
+++ b/packages/sector7/tests/worker-site-script.test.ts
@@ -19,4 +19,16 @@ describe("generateWorkerScript", () => {
 		expect(script).toContain('redirectUrl.hostname = "example.com"');
 		expect(script).toContain("Response.redirect");
 	});
+
+	it("uses browser-safe cache headers for non-fingerprinted files", () => {
+		const script = generateWorkerScript("R2_BUCKET");
+
+		expect(script).toContain("isFingerprintAssetKey(objectKey)");
+		expect(script).toContain(
+			"public, max-age=0, s-maxage=${maxAge}, must-revalidate",
+		);
+		expect(script).toContain("public, max-age=31536000, immutable");
+		expect(script).toContain("return /(?:[.-])[A-Za-z0-9_-]{8,}");
+		expect(script).toContain(".test(base);");
+	});
 });

--- a/packages/sector7/workersite/worker-site-script.ts
+++ b/packages/sector7/workersite/worker-site-script.ts
@@ -189,7 +189,7 @@ function isFingerprintAssetKey(key) {
 	// Treat common bundler output names as content-fingerprinted:
 	// app.a1b2c3d4.css, app-a1b2c3d4.js, index-B_PaUjV8.js.
 	const base = key.substring(key.lastIndexOf('/') + 1);
-	return /(?:[.-])[A-Za-z0-9_-]{8,}\\.[A-Za-z0-9]+$/.test(base);
+	return /(?:\\.[A-Fa-f0-9]{8,}|-(?=[A-Za-z0-9_-]{8,}\\.)(?=[A-Za-z0-9_-]*[0-9])(?=[A-Za-z0-9_-]*[A-Z_])[A-Za-z0-9_-]{8,})\\.[A-Za-z0-9]+$/.test(base);
 }
 
 function guessContentType(key) {

--- a/packages/sector7/workersite/worker-site-script.ts
+++ b/packages/sector7/workersite/worker-site-script.ts
@@ -156,12 +156,19 @@ function createResponse(object, objectKey, status, cacheStatus, env) {
 	// ETag for cache validation
 	headers.set('ETag', object.httpEtag);
 
-	// Cache-Control: no-store when TTL is 0, otherwise public with TTL + immutable
+	// Cache-Control strategy:
+	// - TTL 0 disables both browser and edge caching.
+	// - Fingerprinted assets are safe to cache aggressively in browsers.
+	// - Non-fingerprinted files must revalidate in browsers, but may still use
+	//   shared edge cache through s-maxage. This avoids stale styles/scripts when
+	//   sites use stable names like styles.css.
 	const maxAge = env.CACHE_TTL_SECONDS || '31536000';
 	if (maxAge === '0') {
 		headers.set('Cache-Control', 'no-store');
+	} else if (isFingerprintAssetKey(objectKey)) {
+		headers.set('Cache-Control', 'public, max-age=31536000, immutable');
 	} else {
-		headers.set('Cache-Control', \`public, max-age=\${maxAge}, immutable\`);
+		headers.set('Cache-Control', \`public, max-age=0, s-maxage=\${maxAge}, must-revalidate\`);
 	}
 
 	// Last-Modified
@@ -178,6 +185,13 @@ function createResponse(object, objectKey, status, cacheStatus, env) {
 /**
  * Guess content type from file extension
  */
+function isFingerprintAssetKey(key) {
+	// Treat common bundler output names as content-fingerprinted:
+	// app.a1b2c3d4.css, app-a1b2c3d4.js, index-B_PaUjV8.js.
+	const base = key.substring(key.lastIndexOf('/') + 1);
+	return /(?:[.-])[A-Za-z0-9_-]{8,}\.[A-Za-z0-9]+$/.test(base);
+}
+
 function guessContentType(key) {
 	// Get the basename (after last '/')
 	const base = key.substring(key.lastIndexOf('/') + 1);

--- a/packages/sector7/workersite/worker-site-script.ts
+++ b/packages/sector7/workersite/worker-site-script.ts
@@ -189,7 +189,7 @@ function isFingerprintAssetKey(key) {
 	// Treat common bundler output names as content-fingerprinted:
 	// app.a1b2c3d4.css, app-a1b2c3d4.js, index-B_PaUjV8.js.
 	const base = key.substring(key.lastIndexOf('/') + 1);
-	return /(?:[.-])[A-Za-z0-9_-]{8,}\.[A-Za-z0-9]+$/.test(base);
+	return /(?:[.-])[A-Za-z0-9_-]{8,}\\.[A-Za-z0-9]+$/.test(base);
 }
 
 function guessContentType(key) {


### PR DESCRIPTION
## Summary

Fix WorkerSite browser cache headers for sites that use stable asset names like `styles.css`.

Previously WorkerSite returned `Cache-Control: public, max-age=<ttl>, immutable` for every R2 object. That is only safe for content-fingerprinted files. For addendalabs.com, `styles.css` is a stable filename, so an existing browser could keep the old CSS for 4 hours after deployment even though the edge cache purge succeeded.

## What changed

- TTL `0` still returns `no-store`.
- Fingerprinted bundle output names still get `public, max-age=31536000, immutable`.
- Non-fingerprinted files now get `public, max-age=0, s-maxage=<ttl>, must-revalidate`.
  - Browsers revalidate each load.
  - Shared caches may still cache for the configured TTL.
  - Host-scoped `purgeZoneCache` clears the edge copy after deploy.

## Test plan

- `corepack pnpm --dir packages/sector7 test` — 83/83 passing
- `corepack pnpm --dir packages/sector7 build` — passing

## Follow-up

After merge, release `@jmmaloney4/sector7` v0.8.2 and bump yard's `deploy/www/addendalabs.com` package to the new tarball.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes `Cache-Control` behavior for all WorkerSite-served objects, which can affect client/edge caching and performance if the fingerprint detection or header logic is wrong.
> 
> **Overview**
> Updates generated WorkerSite responses to distinguish between *fingerprinted* and *non-fingerprinted* asset names when setting `Cache-Control`: TTL `0` remains `no-store`, fingerprinted assets get `public, max-age=31536000, immutable`, and all other files switch to `public, max-age=0, s-maxage=<ttl>, must-revalidate`.
> 
> Adds an `isFingerprintAssetKey` matcher to the worker script and expands tests to validate both the emitted header strings and the fingerprint detection behavior. Bumps `@jmmaloney4/sector7` version to `0.8.2`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 23a1c236aaca62790be216e9d8b468bbb7935e5f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->