### PR TITLE
fix: version WorkerSite cache keys

### DIFF
--- a/packages/sector7/package.json
+++ b/packages/sector7/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@jmmaloney4/sector7",
-	"version": "0.8.2",
+	"version": "0.8.3",
 	"description": "Reusable Pulumi components for infrastructure management",
 	"license": "MPL-2.0",
 	"publishConfig": {

--- a/packages/sector7/tests/worker-site-script.test.ts
+++ b/packages/sector7/tests/worker-site-script.test.ts
@@ -51,4 +51,12 @@ describe("generateWorkerScript", () => {
 		expect(isFingerprintAssetKey("inter-variable.woff2")).toBe(false);
 		expect(isFingerprintAssetKey("release-20260511.css")).toBe(false);
 	});
+
+	it("versions Cache API keys independently from public request URLs", () => {
+		const script = generateWorkerScript("R2_BUCKET");
+
+		expect(script).toContain("const cacheVersion = env.CACHE_KEY_VERSION || 'default';");
+		expect(script).toContain("cacheUrl.searchParams.set('__workersite_cache_version', cacheVersion);");
+		expect(script).toContain("new Request(cacheUrl.toString(), { method: 'GET' })");
+	});
 });

--- a/packages/sector7/tests/worker-site.test.ts
+++ b/packages/sector7/tests/worker-site.test.ts
@@ -248,6 +248,34 @@ describe("WorkerSite", () => {
 		expect(bucketBinding?.bucketName).toBe("bucket-assets");
 	});
 
+	it("binds cache key version when provided", async () => {
+		const site = new WorkerSite("versioned-cache-site", {
+			accountId: "account-123",
+			zoneId: "zone-123",
+			name: "versioned-cache-site",
+			domains: ["versioned.example.com"],
+			r2Bucket: { bucketName: "versioned-assets" },
+			cacheKeyVersion: "asset-fingerprint-123",
+		});
+
+		await resolveOutput(site.worker.id);
+
+		const worker = byName("-worker").find(
+			(resource) => resource.name === "versioned-cache-site-worker",
+		);
+		expect(worker).toBeDefined();
+		const bindings = worker!.inputs.bindings as Array<Record<string, unknown>>;
+		const cacheKeyBinding = bindings.find(
+			(binding) => binding.name === "CACHE_KEY_VERSION",
+		);
+
+		expect(cacheKeyBinding).toMatchObject({
+			name: "CACHE_KEY_VERSION",
+			text: "asset-fingerprint-123",
+			type: "plain_text",
+		});
+	});
+
 	it("validates github-org access requirements", () => {
 		expect(
 			() =>

--- a/packages/sector7/workersite/worker-site-script.ts
+++ b/packages/sector7/workersite/worker-site-script.ts
@@ -94,7 +94,7 @@ ${redirectBlock ? `\n${redirectBlock}\n` : ""}
 			let cacheKey;
 
 			if (cacheEnabled) {
-				const cacheUrl = new URL(url.toString());
+				const cacheUrl = new URL(url);
 				cacheUrl.searchParams.set('__workersite_cache_version', cacheVersion);
 				cacheKey = new Request(cacheUrl.toString(), { method: 'GET' });
 				response = await cache.match(cacheKey);

--- a/packages/sector7/workersite/worker-site-script.ts
+++ b/packages/sector7/workersite/worker-site-script.ts
@@ -86,11 +86,14 @@ ${redirectBlock ? `\n${redirectBlock}\n` : ""}
 			// 3. Cache API check (requires custom domain)
 			// Skip caching entirely when TTL is 0.
 			const cacheEnabled = env.CACHE_TTL_SECONDS !== '0';
+			const cacheVersion = env.CACHE_KEY_VERSION || 'default';
 			let response;
 
 			// Shared cache objects used for both lookup (step 3) and storage (step 7)
 			const cache = cacheEnabled ? caches.default : undefined;
-			const cacheKey = cacheEnabled ? new Request(url.toString(), { method: 'GET' }) : undefined;
+			const cacheUrl = new URL(url.toString());
+			cacheUrl.searchParams.set('__workersite_cache_version', cacheVersion);
+			const cacheKey = cacheEnabled ? new Request(cacheUrl.toString(), { method: 'GET' }) : undefined;
 
 			if (cacheEnabled) {
 				response = await cache.match(cacheKey);

--- a/packages/sector7/workersite/worker-site-script.ts
+++ b/packages/sector7/workersite/worker-site-script.ts
@@ -91,11 +91,12 @@ ${redirectBlock ? `\n${redirectBlock}\n` : ""}
 
 			// Shared cache objects used for both lookup (step 3) and storage (step 7)
 			const cache = cacheEnabled ? caches.default : undefined;
-			const cacheUrl = new URL(url.toString());
-			cacheUrl.searchParams.set('__workersite_cache_version', cacheVersion);
-			const cacheKey = cacheEnabled ? new Request(cacheUrl.toString(), { method: 'GET' }) : undefined;
+			let cacheKey;
 
 			if (cacheEnabled) {
+				const cacheUrl = new URL(url.toString());
+				cacheUrl.searchParams.set('__workersite_cache_version', cacheVersion);
+				cacheKey = new Request(cacheUrl.toString(), { method: 'GET' });
 				response = await cache.match(cacheKey);
 
 				if (response) {

--- a/packages/sector7/workersite/worker-site.ts
+++ b/packages/sector7/workersite/worker-site.ts
@@ -440,6 +440,10 @@ export class WorkerSite extends pulumi.ComponentResource {
 		const prefix = args.r2Bucket.prefix
 			? pulumi.output(args.r2Bucket.prefix)
 			: undefined;
+		const cacheKeyVersion = pulumi
+			.output(args.cacheKeyVersion)
+			.apply((version) => version ?? "default");
+
 		// Resolve observability defaults via pulumi.all so that nested flags
 		// cascade from their parent: logs.enabled defaults to observability
 		// enabled, invocationLogs defaults to logs.enabled, etc.  This avoids
@@ -525,7 +529,7 @@ export class WorkerSite extends pulumi.ComponentResource {
 					},
 					{
 						name: "CACHE_KEY_VERSION",
-						text: args.cacheKeyVersion ?? "default",
+						text: cacheKeyVersion,
 						type: "plain_text",
 					},
 					...extraBindings,

--- a/packages/sector7/workersite/worker-site.ts
+++ b/packages/sector7/workersite/worker-site.ts
@@ -243,6 +243,18 @@ export interface WorkerSiteArgs {
 	cacheTtlSeconds?: pulumi.Input<number>;
 
 	/**
+	 * Cache key namespace/version for Worker Cache API entries.
+	 *
+	 * Worker Cache API entries are keyed by URL and are not reliably invalidated
+	 * by Cloudflare zone purges. Pass a deterministic asset-manifest fingerprint
+	 * here when the Worker serves stable filenames from R2, so asset payload or
+	 * metadata changes move requests to a fresh edge-cache namespace.
+	 *
+	 * @default "default"
+	 */
+	cacheKeyVersion?: pulumi.Input<string>;
+
+	/**
 	 * Host-level HTTP redirect rules injected into the generated Worker script.
 	 * Evaluated before R2 serving.  Ignored when `workerScript` is set.
 	 *
@@ -509,6 +521,11 @@ export class WorkerSite extends pulumi.ComponentResource {
 						text: pulumi
 							.output(cacheTtl)
 							.apply((ttl: number) => ttl.toString()),
+						type: "plain_text",
+					},
+					{
+						name: "CACHE_KEY_VERSION",
+						text: args.cacheKeyVersion ?? "default",
 						type: "plain_text",
 					},
 					...extraBindings,


### PR DESCRIPTION
## Summary

Add a WorkerSite cache key version binding and use it in the internal Worker Cache API key.

## Root cause

WorkerSite previously used the public request URL as the `caches.default` key. That made cached responses survive changes to Worker cache semantics and, in practice, host-scoped Cloudflare zone purges did not reliably clear entries written through the Worker Cache API.

This caused addendalabs.com to keep serving a cached `/` response with old `Cache-Control` headers even after the Worker script and R2 object were updated.

## Fix

- Add `cacheKeyVersion?: pulumi.Input<string>` to `WorkerSiteArgs`.
- Bind it into the Worker as `CACHE_KEY_VERSION`, defaulting to `default`.
- Add `__workersite_cache_version=<CACHE_KEY_VERSION>` to the internal `caches.default` key.
- Keep the public request URL unchanged.

Callers serving stable R2 filenames can now pass a deterministic asset-manifest fingerprint so payload or metadata changes move requests into a fresh Worker cache namespace.

## Test plan

- `corepack pnpm --dir packages/sector7 test`: 85/85 passing
- `corepack pnpm --dir packages/sector7 build`: passing

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes edge caching behavior for `WorkerSite` by altering Cache API key construction and introducing a new binding; misconfiguration could lead to unexpected cache misses or stale content if not set as intended.
> 
> **Overview**
> Adds an optional `cacheKeyVersion` to `WorkerSite` and binds it into the Worker as `CACHE_KEY_VERSION` (defaulting to `"default"`).
> 
> Updates the generated Worker script to version `caches.default` entries by appending `__workersite_cache_version=<version>` to the internal cache lookup/put URL while keeping the public request URL unchanged, and adds tests covering the new binding and cache-key behavior.
> 
> Bumps `@jmmaloney4/sector7` from `0.8.2` to `0.8.3`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2657e0689061c0f2e106883b74d7952e2a572f7a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->