### PR TITLE
feat: NixOutput component + refactor NixImage to compose it

### DIFF
--- a/docs/internal/designs/adr-nix-output-component.md
+++ b/docs/internal/designs/adr-nix-output-component.md
@@ -1,0 +1,212 @@
+---
+id: ADR-018
+title: NixOutput Component — Declarative Nix Store Path Resolution
+status: Accepted
+date: 2026-05-13
+deciders: [jmmaloney4]
+tags: [design, adr, nix]
+supersedes: []
+superseded_by: []
+links: [ADR-017]
+---
+
+# Context
+
+ADR-017 created a `NixImage` ComponentResource that combines two concerns:
+
+1. Resolving and building a nix derivation to produce a store path.
+2. Pushing the resulting nix2container image to a registry.
+
+The component is named `NixBuild`-adjacent in spirit (it builds images). Under the hood it uses `command.local.Command` to run `nix build` imperatively. This mixes a declarative contract ("I need an image at this reference") with an imperative description of how to produce it.
+
+Other use cases will need store paths without pushing images — static site tarballs, compiled binaries, compiled documentation, data assets — but the current component is locked to the image workflow.
+
+# Decision
+
+Create a new ComponentResource called `NixOutput` that encapsulates the store-path resolution step independently of the image push step.
+
+## Naming: `NixOutput`, not `NixBuild`
+
+The name describes what the resource provides, not how it produces it.
+
+- `NixBuild` describes a process: "run `nix build` on this attribute."
+- `NixOutput` describes a contract: "give me the store path for this flake attribute."
+
+The imperative implementation (`nix build`, `nix resolve`, or whatever is necessary) is internal to the component. A Pulumi program that declares a `NixOutput` is not making a promise about the build process — it is declaring that a store path must exist and be available as a resource output.
+
+This follows the Pulumi philosophy: resources describe desired state, the provider figures out how to reach it.
+
+## Type token
+
+`sector7:nix:NixOutput`
+
+## Interface
+
+```ts
+export interface NixOutputArgs {
+  /** Flake attribute path (e.g. "packages.x86_64-linux.lens-api-image") */
+  nixAttr: pulumi.Input<string>;
+  /**
+   * Absolute path to the repo root containing the flake.
+   */
+  repoRoot: pulumi.Input<string>;
+  /**
+   * Select a named output from a multi-output nix derivation.
+   * Nix derivations can produce outputs like `out`, `dev`, `docs`.
+   * Use this to select a specific output: `myapp#docs`.
+   * Only meaningful when the underlying derivation is a multi-output
+   * derivation. Ignored (no-op) for single-output derivations.
+   */
+  subOutput?: pulumi.Input<string>;
+  /**
+   * Select a sub-path within the resolved store path.
+   * The store path is the root output; this picks a file or directory
+   * inside it. Example: if `storePath` resolves to
+   * `/nix/store/...-myapp-docs/`, then `subPath: "assets/style.css"`
+   * produces `/nix/store/...-myapp-docs/assets/style.css`.
+   * Equivalent to `path.resolve(storePath, subPath)` in Node or
+   * `${storePath}/${subPath}` in bash, resolved to an absolute path.
+   * The path must exist within the output derivation.
+   */
+  subPath?: pulumi.Input<string>;
+  /** Additional trigger values */
+  triggers?: pulumi.Input<string>[];
+  /**
+   * "resolve" = resolve the output path without building (default).
+   * Fast — just evaluates the flake to find the store path.
+   * Fails if the derivation hasn't been built yet and isn't cached
+   * locally (nix eval cannot produce a store path without evaluating
+   * the derivation, which requires building).
+   *
+   * "build"   = ensure the output exists by building the derivation.
+   * Runs `nix build` before resolving. Expensive but guarantees the
+   * output is in the local store.
+   */
+  mode?: "resolve" | "build";
+  /** Extra environment variables to pass to the build command. */
+  env?: Record<string, pulumi.Input<string>>;
+}
+
+export class NixOutput extends pulumi.ComponentResource {
+  /** The /nix/store/... store path of the built/resolved output */
+  public readonly storePath: pulumi.Output<string>;
+
+  constructor(
+    name: string,
+    args: NixOutputArgs,
+    opts?: pulumi.ComponentResourceOptions,
+  ) { ... }
+}
+```
+
+### Key differences from current `NixImageArgs`:
+
+- Removed `imageName`, `imageTag`, `artifactRegistryUrl`, `authMode` (image-specific).
+- Removed `resultLink` (an internal detail of the shell script; the output is the store path, not a symlink name).
+- Default mode is `"resolve"` — resolve the attribute path without triggering a build. Consumers who need the derivation built should pass `"build"`.
+- Output is `storePath` instead of `imageRef` + `digest`.
+- Added `subOutput` to select a named output from a multi-output derivation.
+- Added `subPath` to select a file or directory within the resolved store path.
+
+## Relationship to NixImage
+
+`NixImage` becomes a composition of `NixOutput` + push:
+
+```
+NixImage (refactored)
+  if mode == "resolve":
+    Use skopeo inspect to resolve digest of existing tag.
+    Does NOT create a NixOutput child.
+
+  if mode == "build":
+    1. Create NixOutput child (gets storePath)
+    2. Run skopeo push from storePath to registry
+    3. Parse digest from skopeo output
+
+  outputs: imageRef, digest (unchanged)
+```
+
+This makes `NixImage` a composition pattern — it builds an output and then pushes it. The build step is no longer baked into the same command as the push.
+
+## Implementation: two scripts, one component
+
+Split the existing `nix-image-build-push.sh` into two scripts:
+
+1. **`nix-output-resolve.sh`** (new) — resolves and/or builds a nix attribute.
+   - Outputs `STORE_PATH_OUTPUT:<storepath>` to stdout.
+   - Accepts env vars: `NIX_ATTR`, `REPO_ROOT`, `SCRIPT_MODE` ("resolve" or "build").
+   - In "build" mode: `nix build ${REPO_ROOT}#${NIX_ATTR} -L`
+   - In "resolve" mode: `nix eval --raw ${REPO_ROOT}#${NIX_ATTR}`
+   - Creates log files under `COMMAND_LOG_STEM`.
+
+2. **`nix-image-push.sh`** (extracted from existing script) — pushes a store path to a registry.
+   - Outputs `DIGEST_OUTPUT:<sha256:...>` to stdout.
+   - Accepts env vars: `IMAGE_NAME`, `IMAGE_TAG`, `ARTIFACT_REGISTRY_URL`, `AUTH_MODE`, `STORE_PATH`, `COMMAND_LOG_STEM`.
+   - Does NOT accept `NIX_ATTR` or `REPO_ROOT`.
+
+The `NixOutput` component runs `nix-output-resolve.sh`. The refactored `NixImage` component runs `nix-output-resolve.sh` (via NixOutput) + `nix-image-push.sh`.
+
+## Trigger semantics
+
+Default trigger for `NixOutput` is `nixAttr` (the attribute path as a string). This means changing the attribute — e.g. from `packages.x86_64-linux.lens-api-image` to `packages.x86_64-linux.lens-api-v2-image` — will trigger a rebuild.
+
+Consumers who need finer-grained triggering (e.g. flake lock hash, git commit SHA) can pass `triggers` directly.
+
+For `NixImage`, the default trigger remains `imageTag` since that's the deployment-level signal that matters. Additional triggers can be layered in.
+
+# Consequences
+
+## Positive
+
+- **Declarative API**: `NixOutput` says "I need this nix output's store path." The implementation details (nix build, nix eval, nix resolve) are internal.
+- **Composable**: Other components (NixImage, NixTarball, NixStaticSite) can depend on `NixOutput` as a building block.
+- **General-purpose**: Any nix attribute that produces a derivable output can be represented, not just nix2container images.
+- **Resolve-first default**: The default mode is "resolve" — if the derivation already exists in the store, no build is triggered. This is the correct Pulumi-aligned default: declare desired state, only build if necessary.
+- **Cleaner separation of concerns**: Image push logic no longer shares a command with nix build logic. Each step has its own command, its own triggers, its own error surface.
+
+## Negative / Risks
+
+- **Two commands instead of one**: Splitting build and push introduces two state entries and two command resources. A failed push after a successful build means the build output is rebuilt on the next apply (unless `resultLink` caching or a proper `onFailure` strategy is used). This is acceptable but worth noting.
+- **State bloat**: The store path output (a long `/nix/store/...` string) will be stored in Pulumi state. Not a practical concern for size, but the change in store path on each build means state will drift between applies.
+- **Migration**: Existing `NixImage` consumers get the same interface — no API break. But the internal command changes (two scripts instead of one, different env vars) means the test suite and any manual testing of the scripts need to pass.
+- **`resolve` mode in NixImage**: When `NixImage` is in "resolve" mode (digest-only, image already pushed elsewhere), it should NOT create a `NixOutput` child. It should just run `skopeo inspect`. This means the refactored `NixImage` has two code paths — one that composes `NixOutput` + push, and one that just does skopeo inspect.
+
+## Alternative names considered
+
+### `NixDerivation`
+Describes the nix concept precisely. But "derivation" is a nix internals term that leaks implementation detail. Not all outputs are top-level derivations — some are sub-output paths from multi-output derivations.
+
+### `NixPackage`
+Concise and common in nix parlance. But "package" implies a specific kind of output (a full derivation result), not the general case of any flake attribute.
+
+### `NixStorePath`
+Explicitly states the output type. A bit verbose and technically descriptive rather than declarative.
+
+### `NixOutput` (selected)
+Balances declarative intent ("output" of the nix system) with generality. An output is whatever the attribute path resolves to. The name doesn't imply a specific nix concept — it's a contract about the result, not the mechanism.
+
+# Security / Privacy / Compliance
+
+- The script runs `nix build` or `nix eval` on user-supplied flake paths. The `repoRoot` and `nixAttr` values must be controlled (they are Pulumi inputs, not user-facing).
+- No credentials are involved in the build step — auth is only needed for the push step, which lives in a separate component/script.
+- Store path values in Pulumi state are not secrets.
+
+# Status Transitions
+
+- 2026-05-13: Proposed
+- 2026-05-13: Accepted — all open questions resolved, implementation in progress
+
+# Resolved Questions
+
+1. **Should `NixOutput` have a `subOutput` arg?** Yes. Added `subOutput` to select named outputs from multi-output derivations. Implemented as `nixAttr^subOutput` syntax passed to the shell script via `SUB_OUTPUT` env var.
+
+2. **What happens on `pulumi preview`?** `NixOutput` with `mode="build"` shows a diff on preview because `command.local.Command` doesn't execute during preview. This is expected and consistent with how NixImage worked before. Document in the README.
+
+3. **Should `NixOutput` support caching?** No explicit caching in the component. Nix daemon cache handles this naturally. The `--no-link --print-out-paths` build approach doesn't create symlinks to clean up. Leave caching to the nix daemon.
+
+# References
+
+- ADR-017: NixImage Pulumi Component for nix2container Build-Push
+- `packages/sector7/nix-image/nix-image.ts`: current implementation
+- `packages/sector7/scripts/nix-image-build-push.sh`: current shell script
+- `packages/sector7/tests/nix-image.test.ts`: current test suite

--- a/packages/sector7/index.ts
+++ b/packages/sector7/index.ts
@@ -3,3 +3,4 @@ export * as iam from "./iam/index.ts";
 export * as workersite from "./workersite/index.ts";
 export * as nixImage from "./nix-image/index.ts";
 export * as monitor from "./monitor/index.ts";
+export * as nixOutput from "./nix-output/index.ts";

--- a/packages/sector7/nix-image/nix-image.ts
+++ b/packages/sector7/nix-image/nix-image.ts
@@ -81,7 +81,7 @@ export class NixImage extends pulumi.ComponentResource {
 			}, { parent: this });
 
 			this.digest = resolveCmd.stdout.apply((stdout: string) => {
-				const match = stdout.match(/DIGEST_OUTPUT:(sha256:[a-f0-9]+)/);
+				const match = stdout.trim().match(/DIGEST_OUTPUT:(sha256:[a-f0-9]+)/);
 				if (!match) {
 					throw new Error(`Could not parse DIGEST_OUTPUT from resolve output for ${name}`);
 				}
@@ -106,11 +106,11 @@ export class NixImage extends pulumi.ComponentResource {
 					SCRIPT_MODE: "push",
 					STORE_PATH: nixOutput.storePath,
 				},
-				triggers: [args.imageTag, ...(args.triggers ?? [])],
-			}, { parent: this });
+				triggers: pulumi.all([args.imageTag, nixOutput.storePath, ...(args.triggers ?? [])]),
+		}, { parent: this });
 
 			this.digest = pushCmd.stdout.apply((stdout: string) => {
-				const match = stdout.match(/DIGEST_OUTPUT:(sha256:[a-f0-9]+)/);
+				const match = stdout.trim().match(/DIGEST_OUTPUT:(sha256:[a-f0-9]+)/);
 				if (!match) {
 					throw new Error(`Could not parse DIGEST_OUTPUT from push output for ${name}`);
 				}

--- a/packages/sector7/nix-image/nix-image.ts
+++ b/packages/sector7/nix-image/nix-image.ts
@@ -61,12 +61,12 @@ export class NixImage extends pulumi.ComponentResource {
 		const authMode = args.authMode ?? "gcloud";
 
 		const baseEnv: Record<string, pulumi.Input<string>> = {
+			...(args.env ?? {}),
 			IMAGE_NAME: args.imageName,
 			IMAGE_TAG: args.imageTag,
 			ARTIFACT_REGISTRY_URL: args.artifactRegistryUrl,
 			AUTH_MODE: authMode,
 			COMMAND_LOG_STEM: commandLogStem,
-			...(args.env ?? {}),
 		};
 
 		if (mode === "resolve") {

--- a/packages/sector7/nix-image/nix-image.ts
+++ b/packages/sector7/nix-image/nix-image.ts
@@ -1,6 +1,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as command from "@pulumi/command";
 import { getScriptPath } from "../scripts/index.ts";
+import { NixOutput } from "../nix-output/nix-output.ts";
 
 export interface NixImageArgs {
 	/** Flake attribute path (e.g. "packages.x86_64-linux.lens-api-image") */
@@ -53,7 +54,7 @@ export class NixImage extends pulumi.ComponentResource {
 			aliases: [...aliases, ...(opts?.aliases ?? [])],
 		});
 
-		const scriptPath = getScriptPath("nix-image-build-push.sh");
+		const pushScriptPath = getScriptPath("nix-image-push.sh");
 		const commandLogStem = `.pulumi/command-logs/${name}`;
 
 		const mode = args.mode ?? "build";
@@ -71,7 +72,7 @@ export class NixImage extends pulumi.ComponentResource {
 		if (mode === "resolve") {
 			// Resolve-only: authenticate and inspect the already-pushed image
 			const resolveCmd = new command.local.Command(`${name}-resolve`, {
-				create: pulumi.interpolate`bash "${scriptPath}"`,
+				create: pulumi.interpolate`bash "${pushScriptPath}"`,
 				environment: {
 					...baseEnv,
 					SCRIPT_MODE: "resolve",
@@ -88,28 +89,33 @@ export class NixImage extends pulumi.ComponentResource {
 			});
 			this.imageRef = pulumi.interpolate`${args.artifactRegistryUrl}/${args.imageName}@${this.digest}`;
 		} else {
-			// Build + push
-			const buildCmd = new command.local.Command(`${name}-build-push`, {
-				create: pulumi.interpolate`bash "${scriptPath}"`,
+			// Build + push: compose NixOutput for the build step, then push
+			const nixOutput = new NixOutput(`${name}-build`, {
+				nixAttr: args.nixAttr,
+				repoRoot: args.repoRoot,
+				mode: "build",
+				triggers: [args.imageTag, ...(args.triggers ?? [])],
+				env: args.env,
+			}, { parent: this });
+
+			// Push the built image from the store path
+			const pushCmd = new command.local.Command(`${name}-push`, {
+				create: pulumi.interpolate`bash "${pushScriptPath}"`,
 				environment: {
 					...baseEnv,
-					SCRIPT_MODE: "build",
-					NIX_ATTR: args.nixAttr,
-					REPO_ROOT: args.repoRoot,
-					RESULT_LINK: `result-${name}`,
+					SCRIPT_MODE: "push",
+					STORE_PATH: nixOutput.storePath,
 				},
 				triggers: [args.imageTag, ...(args.triggers ?? [])],
 			}, { parent: this });
 
-			// Parse DIGEST_OUTPUT: from stdout
-			this.digest = buildCmd.stdout.apply((stdout: string) => {
+			this.digest = pushCmd.stdout.apply((stdout: string) => {
 				const match = stdout.match(/DIGEST_OUTPUT:(sha256:[a-f0-9]+)/);
 				if (!match) {
-					throw new Error(`Could not parse DIGEST_OUTPUT from build output for ${name}`);
+					throw new Error(`Could not parse DIGEST_OUTPUT from push output for ${name}`);
 				}
 				return match[1];
 			});
-
 			this.imageRef = pulumi.interpolate`${args.artifactRegistryUrl}/${args.imageName}@${this.digest}`;
 		}
 

--- a/packages/sector7/nix-output/index.ts
+++ b/packages/sector7/nix-output/index.ts
@@ -1,0 +1,1 @@
+export { NixOutput, type NixOutputArgs } from "./nix-output.ts";

--- a/packages/sector7/nix-output/nix-output.ts
+++ b/packages/sector7/nix-output/nix-output.ts
@@ -68,13 +68,13 @@ export class NixOutput extends pulumi.ComponentResource {
 		const mode = args.mode ?? "resolve";
 
 		const env: Record<string, pulumi.Input<string>> = {
+			...(args.env ?? {}),
 			NIX_ATTR: args.nixAttr,
 			REPO_ROOT: args.repoRoot,
 			SCRIPT_MODE: mode,
 			COMMAND_LOG_STEM: commandLogStem,
 			...(args.subOutput ? { SUB_OUTPUT: args.subOutput } : {}),
 			...(args.subPath ? { SUB_PATH: args.subPath } : {}),
-			...(args.env ?? {}),
 		};
 
 		const cmd = new command.local.Command(`${name}-resolve`, {

--- a/packages/sector7/nix-output/nix-output.ts
+++ b/packages/sector7/nix-output/nix-output.ts
@@ -84,7 +84,7 @@ export class NixOutput extends pulumi.ComponentResource {
 		}, { parent: this });
 
 		this.storePath = cmd.stdout.apply((stdout: string) => {
-			const match = stdout.match(/STORE_PATH_OUTPUT:(\/nix\/store\/[^\s]+)/);
+			const match = stdout.trim().match(/STORE_PATH_OUTPUT:(\/nix\/store\/[^\s]+)/);
 			if (!match) {
 				throw new Error(
 					`Could not parse STORE_PATH_OUTPUT from output for ${name}`,

--- a/packages/sector7/nix-output/nix-output.ts
+++ b/packages/sector7/nix-output/nix-output.ts
@@ -1,0 +1,100 @@
+import * as pulumi from "@pulumi/pulumi";
+import * as command from "@pulumi/command";
+import { getScriptPath } from "../scripts/index.ts";
+
+export interface NixOutputArgs {
+	/** Flake attribute path (e.g. "packages.x86_64-linux.lens-api-image") */
+	nixAttr: pulumi.Input<string>;
+	/** Absolute path to the repo root containing the flake. */
+	repoRoot: pulumi.Input<string>;
+	/**
+	 * Select a named output from a multi-output nix derivation.
+	 * Nix derivations can produce outputs like `out`, `dev`, `docs`.
+	 * Use this to select a specific output: the attribute becomes
+	 * `nixAttr^subOutput` (e.g. `packages.x86_64-linux.myapp^docs`).
+	 * Only meaningful when the underlying derivation is a multi-output
+	 * derivation. Ignored (no-op) for single-output derivations.
+	 */
+	subOutput?: pulumi.Input<string>;
+	/**
+	 * Select a sub-path within the resolved store path.
+	 * The store path is the root output; this picks a file or directory
+	 * inside it. Example: if `storePath` resolves to
+	 * `/nix/store/...-myapp-docs/`, then `subPath: "assets/style.css"`
+	 * produces `/nix/store/...-myapp-docs/assets/style.css`.
+	 * The path must exist within the output derivation.
+	 */
+	subPath?: pulumi.Input<string>;
+	/** Additional trigger values (added alongside nixAttr). */
+	triggers?: pulumi.Input<string>[];
+	/**
+	 * "resolve" = resolve the output path without building (default).
+	 * Fast — just evaluates the flake to find the store path.
+	 * Fails if the derivation hasn't been built yet and isn't cached
+	 * locally.
+	 *
+	 * "build" = ensure the output exists by building the derivation.
+	 * Runs `nix build` before resolving. Expensive but guarantees the
+	 * output is in the local store.
+	 */
+	mode?: "resolve" | "build";
+	/** Extra environment variables to pass to the command. */
+	env?: Record<string, pulumi.Input<string>>;
+}
+
+export class NixOutput extends pulumi.ComponentResource {
+	/** The /nix/store/... store path of the resolved output */
+	public readonly storePath: pulumi.Output<string>;
+
+	constructor(
+		name: string,
+		args: NixOutputArgs,
+		opts?: pulumi.ComponentResourceOptions,
+	) {
+		// Build resource aliases: add URN alias when parented so the child
+		// resource is adopted correctly under the parent.
+		const aliases: pulumi.Alias[] = [];
+		if (opts?.parent) {
+			aliases.push({ parent: opts.parent });
+		}
+
+		super("sector7:nix:NixOutput", name, args, {
+			...opts,
+			aliases: [...aliases, ...(opts?.aliases ?? [])],
+		});
+
+		const scriptPath = getScriptPath("nix-output-resolve.sh");
+		const commandLogStem = `.pulumi/command-logs/${name}`;
+		const mode = args.mode ?? "resolve";
+
+		const env: Record<string, pulumi.Input<string>> = {
+			NIX_ATTR: args.nixAttr,
+			REPO_ROOT: args.repoRoot,
+			SCRIPT_MODE: mode,
+			COMMAND_LOG_STEM: commandLogStem,
+			...(args.subOutput ? { SUB_OUTPUT: args.subOutput } : {}),
+			...(args.subPath ? { SUB_PATH: args.subPath } : {}),
+			...(args.env ?? {}),
+		};
+
+		const cmd = new command.local.Command(`${name}-resolve`, {
+			create: pulumi.interpolate`bash "${scriptPath}"`,
+			environment: env,
+			triggers: [args.nixAttr, ...(args.triggers ?? [])],
+		}, { parent: this });
+
+		this.storePath = cmd.stdout.apply((stdout: string) => {
+			const match = stdout.match(/STORE_PATH_OUTPUT:(\/nix\/store\/[^\s]+)/);
+			if (!match) {
+				throw new Error(
+					`Could not parse STORE_PATH_OUTPUT from output for ${name}`,
+				);
+			}
+			return match[1];
+		});
+
+		this.registerOutputs({
+			storePath: this.storePath,
+		});
+	}
+}

--- a/packages/sector7/package.json
+++ b/packages/sector7/package.json
@@ -39,6 +39,10 @@
 			"types": "./dist/monitor/index.d.ts",
 			"default": "./dist/monitor/index.js"
 		},
+		"./nix-output": {
+			"types": "./dist/nix-output/index.d.ts",
+			"default": "./dist/nix-output/index.js"
+		},
 		"./scripts": {
 			"types": "./dist/scripts/index.d.ts",
 			"default": "./dist/scripts/index.js"

--- a/packages/sector7/scripts/nix-image-push.sh
+++ b/packages/sector7/scripts/nix-image-push.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+# Push a nix2container image from a store path to a container registry.
+#
+# Modes (controlled by SCRIPT_MODE env var):
+#   "push"    - push the image and output the digest (default)
+#   "resolve" - skip push, just resolve the digest of the already-pushed tag
+#
+# Env vars:
+#   IMAGE_NAME            - image name in registry (e.g. "lens-api")
+#   IMAGE_TAG             - tag (e.g. "dev", "v1.2.3")
+#   ARTIFACT_REGISTRY_URL - registry URL (e.g. "us-east1-docker.pkg.dev/proj/repo")
+#   STORE_PATH            - nix store path of the image (required for push mode)
+#   COMMAND_LOG_STEM      - log directory path (default: .pulumi/command-logs)
+#   AUTH_MODE             - "gcloud" (default) or "ghcr"
+#   SCRIPT_MODE           - "push" (default) or "resolve"
+#
+# For AUTH_MODE=ghcr, also set GITHUB_USER and GITHUB_TOKEN.
+
+set -euo pipefail
+
+SCRIPT_MODE="${SCRIPT_MODE:-push}"
+
+# Validate common required env vars
+for var in IMAGE_NAME IMAGE_TAG ARTIFACT_REGISTRY_URL; do
+  if [ -z "${!var:-}" ]; then
+    echo "ERROR: Required env var $var is not set" >&2
+    exit 1
+  fi
+done
+
+# Push mode requires STORE_PATH
+if [ "${SCRIPT_MODE}" = "push" ]; then
+  if [ -z "${STORE_PATH:-}" ]; then
+    echo "ERROR: Required env var STORE_PATH is not set for push mode" >&2
+    exit 1
+  fi
+fi
+
+COMMAND_LOG_STEM="${COMMAND_LOG_STEM:-.pulumi/command-logs}"
+AUTH_MODE="${AUTH_MODE:-gcloud}"
+
+# Set up logging
+LOG_DIR="${COMMAND_LOG_STEM}"
+mkdir -p "${LOG_DIR}"
+LOG_FILE="${LOG_DIR}/$(date +%Y%m%d-%H%M%S)-${IMAGE_NAME}-${SCRIPT_MODE}.log"
+exec > >(tee -a "${LOG_FILE}") 2>&1
+
+ARTIFACT_REGISTRY_URL="${ARTIFACT_REGISTRY_URL#*://}"
+FULL_TAG="${ARTIFACT_REGISTRY_URL}/${IMAGE_NAME}:${IMAGE_TAG}"
+
+echo "=== ${SCRIPT_MODE} ${IMAGE_NAME}:${IMAGE_TAG} ==="
+echo "AUTH_MODE: ${AUTH_MODE}"
+
+# Temp files for auth and digest
+DIGEST_FILE=$(mktemp)
+AUTH_FILE=$(mktemp)
+trap 'rm -f "${AUTH_FILE}" "${DIGEST_FILE}"' EXIT
+
+# Authenticate by writing authfile directly.
+echo "--- authenticating (${AUTH_MODE}) ---"
+case "${AUTH_MODE}" in
+  gcloud)
+    PASSWORD=$(gcloud auth print-access-token)
+    USERNAME="oauth2accesstoken"
+    ;;
+  ghcr)
+    if [ -z "${GITHUB_TOKEN:-}" ] || [ -z "${GITHUB_USER:-}" ]; then
+      echo "ERROR: GITHUB_TOKEN and GITHUB_USER env vars required for ghcr auth mode" >&2
+      exit 1
+    fi
+    PASSWORD="${GITHUB_TOKEN}"
+    USERNAME="${GITHUB_USER}"
+    ;;
+  *)
+    echo "ERROR: Unknown AUTH_MODE '${AUTH_MODE}' (expected 'gcloud' or 'ghcr')" >&2
+    exit 1
+    ;;
+esac
+
+REGISTRY_HOST="${ARTIFACT_REGISTRY_URL%%/*}"
+AUTH_B64=$(printf '%s:%s' "${USERNAME}" "${PASSWORD}" | base64 | tr -d '\n')
+printf '{"auths":{"%s":{"auth":"%s"}}}' \
+  "${REGISTRY_HOST}" "${AUTH_B64}" > "${AUTH_FILE}"
+chmod 600 "${AUTH_FILE}"
+
+if [ "${SCRIPT_MODE}" = "resolve" ]; then
+  echo "--- resolving digest ---"
+  nix run github:nlewo/nix2container#skopeo-nix2container -- \
+    --insecure-policy inspect --format '{{.Digest}}' \
+    --authfile "${AUTH_FILE}" \
+    docker://"${FULL_TAG}" \
+    | tr -d '\n' \
+    > "${DIGEST_FILE}"
+else
+  IMAGE_PATH="nix:${STORE_PATH}"
+
+  echo "--- skopeo copy ---"
+  nix run github:nlewo/nix2container#skopeo-nix2container -- \
+    --insecure-policy copy --digestfile "${DIGEST_FILE}" \
+    --authfile "${AUTH_FILE}" \
+    "${IMAGE_PATH}" \
+    "docker://${FULL_TAG}"
+fi
+
+DIGEST=$(cat "${DIGEST_FILE}")
+
+echo "=== ${SCRIPT_MODE} complete: ${FULL_TAG} ==="
+echo "=== Digest: ${DIGEST} ==="
+echo "DIGEST_OUTPUT:${DIGEST}"

--- a/packages/sector7/scripts/nix-image-push.sh
+++ b/packages/sector7/scripts/nix-image-push.sh
@@ -42,7 +42,7 @@ AUTH_MODE="${AUTH_MODE:-gcloud}"
 # Set up logging
 LOG_DIR="${COMMAND_LOG_STEM}"
 mkdir -p "${LOG_DIR}"
-LOG_FILE="${LOG_DIR}/$(date +%Y%m%d-%H%M%S)-${IMAGE_NAME}-${SCRIPT_MODE}.log"
+LOG_FILE="${LOG_DIR}/$(date +%Y%m%d-%H%M%S)-${IMAGE_NAME//\//_}-${SCRIPT_MODE}.log"
 exec > >(tee -a "${LOG_FILE}") 2>&1
 
 ARTIFACT_REGISTRY_URL="${ARTIFACT_REGISTRY_URL#*://}"

--- a/packages/sector7/scripts/nix-output-resolve.sh
+++ b/packages/sector7/scripts/nix-output-resolve.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# Resolve or build a nix flake attribute and output its store path.
+#
+# Modes (controlled by SCRIPT_MODE env var):
+#   "resolve" - evaluate the flake to find the store path without building (default)
+#   "build"   - build the derivation, then output the store path
+#
+# Env vars:
+#   NIX_ATTR          - flake attribute path (e.g. "packages.x86_64-linux.lens-api-image")
+#   REPO_ROOT         - absolute path to repo root containing the flake
+#   SUB_OUTPUT        - named output from a multi-output derivation (e.g. "docs", "dev")
+#   SUB_PATH          - sub-path within the resolved store path (e.g. "assets/style.css")
+#   SCRIPT_MODE       - "resolve" (default) or "build"
+#   COMMAND_LOG_STEM  - log directory path (default: .pulumi/command-logs)
+
+set -euo pipefail
+
+SCRIPT_MODE="${SCRIPT_MODE:-resolve}"
+COMMAND_LOG_STEM="${COMMAND_LOG_STEM:-.pulumi/command-logs}"
+
+# Validate required env vars
+for var in NIX_ATTR REPO_ROOT; do
+  if [ -z "${!var:-}" ]; then
+    echo "ERROR: Required env var $var is not set" >&2
+    exit 1
+  fi
+done
+
+# Build the full attribute path with optional sub-output
+FULL_ATTR="${NIX_ATTR}"
+if [ -n "${SUB_OUTPUT:-}" ]; then
+  FULL_ATTR="${NIX_ATTR}^${SUB_OUTPUT}"
+fi
+
+# Set up logging
+LOG_DIR="${COMMAND_LOG_STEM}"
+mkdir -p "${LOG_DIR}"
+LOG_FILE="${LOG_DIR}/$(date +%Y%m%d-%H%M%S)-nix-output-${SCRIPT_MODE}.log"
+exec > >(tee -a "${LOG_FILE}") 2>&1
+
+echo "=== nix-output ${SCRIPT_MODE} ${FULL_ATTR} ==="
+echo "REPO_ROOT: ${REPO_ROOT}"
+
+STORE_PATH=""
+
+if [ "${SCRIPT_MODE}" = "build" ]; then
+  # Build the derivation
+  echo "--- nix build ---"
+  STORE_PATH=$(nix build "${REPO_ROOT}#${FULL_ATTR}" --no-link --print-out-paths -L)
+else
+  # Resolve without building
+  echo "--- nix eval ---"
+  # nix eval --raw gives the store path for a derivation output
+  STORE_PATH=$(nix eval --raw "${REPO_ROOT}#${FULL_ATTR}")
+fi
+
+if [ -z "${STORE_PATH}" ]; then
+  echo "ERROR: Could not resolve store path for ${FULL_ATTR}" >&2
+  exit 1
+fi
+
+# Apply sub-path if specified
+if [ -n "${SUB_PATH:-}" ]; then
+  FULL_PATH="${STORE_PATH}/${SUB_PATH}"
+  if [ ! -e "${FULL_PATH}" ]; then
+    echo "ERROR: Sub-path '${SUB_PATH}' does not exist within ${STORE_PATH}" >&2
+    exit 1
+  fi
+  # Resolve to absolute path (handles symlinks, .., etc.)
+  STORE_PATH=$(cd "$(dirname "${FULL_PATH}")" && pwd)/$(basename "${FULL_PATH}")
+fi
+
+echo "=== Resolved: ${STORE_PATH} ==="
+echo "STORE_PATH_OUTPUT:${STORE_PATH}"

--- a/packages/sector7/tests/nix-image.test.ts
+++ b/packages/sector7/tests/nix-image.test.ts
@@ -185,7 +185,7 @@ describe("NixImage", () => {
 		const pushCmds = byName("test-triggers-default-push");
 		expect(pushCmds).toHaveLength(1);
 		const pushTriggers = pushCmds[0].inputs.triggers as string[];
-		expect(pushTriggers).toEqual(["dev"]);
+		expect(pushTriggers).toEqual(["dev", "/nix/store/abc123-my-image"]);
 	});
 
 	it("uses additive triggers: imageTag plus custom triggers", async () => {
@@ -203,7 +203,7 @@ describe("NixImage", () => {
 		const pushCmds = byName("test-triggers-custom-push");
 		expect(pushCmds).toHaveLength(1);
 		const triggers = pushCmds[0].inputs.triggers as string[];
-		expect(triggers).toEqual(["dev", "custom-trigger-1", "custom-trigger-2"]);
+		expect(triggers).toEqual(["dev", "/nix/store/abc123-my-image", "custom-trigger-1", "custom-trigger-2"]);
 	});
 
 	it("uses resolve mode additive triggers with imageTag first", async () => {

--- a/packages/sector7/tests/nix-image.test.ts
+++ b/packages/sector7/tests/nix-image.test.ts
@@ -16,18 +16,19 @@ beforeAll(() => {
 		newResource: (args) => {
 			const state = args.inputs;
 
-			// For command.local.Command, simulate stdout with DIGEST_OUTPUT marker
+			// For command.local.Command, simulate stdout with appropriate markers
 			if (args.type === "command:local:Command") {
 				const create = state.create as string | undefined;
 
-				if (create?.includes("nix-image-build-push.sh")) {
-					// Build mode: simulate script output
+				if (create?.includes("nix-output-resolve.sh")) {
+					// NixOutput: simulate store path output
+					const storePath = "/nix/store/abc123-my-image";
+					(state as Record<string, unknown>).stdout =
+						`=== Resolved: ${storePath} ===\nSTORE_PATH_OUTPUT:${storePath}\n`;
+				} else if (create?.includes("nix-image-push.sh")) {
+					// Push or resolve: simulate digest output
 					(state as Record<string, unknown>).stdout =
 						"=== Pushed registry/example:dev ===\n=== Digest: sha256:abc123def456 ===\nDIGEST_OUTPUT:sha256:abc123def456\n";
-				} else if (create?.includes("inspect")) {
-					// Resolve mode: simulate skopeo inspect --format output
-					(state as Record<string, unknown>).stdout =
-						"sha256:abc123def456\n";
 				}
 			}
 
@@ -64,7 +65,7 @@ function byName(fragment: string): MockResource[] {
 }
 
 describe("NixImage", () => {
-	it("creates a Command resource for build mode with correct env vars", async () => {
+	it("creates NixOutput child + push command in build mode", async () => {
 		const img = new NixImage("test-build", {
 			nixAttr: "packages.x86_64-linux.my-image",
 			imageName: "my-image",
@@ -75,25 +76,30 @@ describe("NixImage", () => {
 
 		await resolveOutput(img.digest);
 
-		const cmds = byName("test-build-build-push");
-		expect(cmds).toHaveLength(1);
+		// Should create a NixOutput child
+		const nixOutputs = resources.filter(
+			(r) => r.type === "sector7:nix:NixOutput" && r.name === "test-build-build",
+		);
+		expect(nixOutputs).toHaveLength(1);
 
-		const cmd = cmds[0];
-		expect(cmd.type).toBe("command:local:Command");
-		expect(cmd.inputs.environment).toEqual({
-			NIX_ATTR: "packages.x86_64-linux.my-image",
+		// Should create a NixOutput command (build-resolve) and a push command (push)
+		const buildCmds = byName("test-build-build-resolve");
+		const pushCmds = byName("test-build-push");
+		expect(buildCmds).toHaveLength(1);
+		expect(pushCmds).toHaveLength(1);
+
+		const pushCmd = pushCmds[0];
+		expect(pushCmd.type).toBe("command:local:Command");
+		expect(pushCmd.inputs.environment).toMatchObject({
 			IMAGE_NAME: "my-image",
 			IMAGE_TAG: "dev",
 			ARTIFACT_REGISTRY_URL: "us-east1-docker.pkg.dev/my-project/my-repo",
 			AUTH_MODE: "gcloud",
-			SCRIPT_MODE: "build",
-			REPO_ROOT: "/home/user/my-repo",
-			RESULT_LINK: "result-test-build",
-			COMMAND_LOG_STEM: ".pulumi/command-logs/test-build",
+			SCRIPT_MODE: "push",
 		});
 	});
 
-	it("creates a Command resource for resolve mode that inspects the image", async () => {
+	it("creates a resolve command in resolve mode", async () => {
 		const img = new NixImage("test-resolve", {
 			nixAttr: "packages.x86_64-linux.my-image",
 			imageName: "my-image",
@@ -105,6 +111,13 @@ describe("NixImage", () => {
 
 		await resolveOutput(img.digest);
 
+		// Resolve mode should NOT create a NixOutput child
+		const nixOutputs = resources.filter(
+			(r) => r.type === "sector7:nix:NixOutput" && r.name.includes("test-resolve"),
+		);
+		expect(nixOutputs).toHaveLength(0);
+
+		// Should create a single resolve command
 		const cmds = byName("test-resolve-resolve");
 		expect(cmds).toHaveLength(1);
 
@@ -112,7 +125,7 @@ describe("NixImage", () => {
 		expect(cmd.type).toBe("command:local:Command");
 
 		const createCmd = cmd.inputs.create as string;
-		expect(createCmd).toContain("nix-image-build-push.sh");
+		expect(createCmd).toContain("nix-image-push.sh");
 		expect(cmd.inputs.environment).toMatchObject({
 			IMAGE_NAME: "my-image",
 			IMAGE_TAG: "v1.0.0",
@@ -162,11 +175,17 @@ describe("NixImage", () => {
 
 		await resolveOutput(img.digest);
 
-		const cmds = byName("test-triggers-default-build-push");
-		expect(cmds).toHaveLength(1);
+		// NixOutput child triggers: [nixAttr, imageTag]
+		const buildCmds = byName("test-triggers-default-build-resolve");
+		expect(buildCmds).toHaveLength(1);
+		const buildTriggers = buildCmds[0].inputs.triggers as string[];
+		expect(buildTriggers).toEqual(["packages.x86_64-linux.my-image", "dev"]);
 
-		const triggers = cmds[0].inputs.triggers as string[];
-		expect(triggers).toEqual(["dev"]);
+		// Push command should also have imageTag as trigger
+		const pushCmds = byName("test-triggers-default-push");
+		expect(pushCmds).toHaveLength(1);
+		const pushTriggers = pushCmds[0].inputs.triggers as string[];
+		expect(pushTriggers).toEqual(["dev"]);
 	});
 
 	it("uses additive triggers: imageTag plus custom triggers", async () => {
@@ -181,10 +200,9 @@ describe("NixImage", () => {
 
 		await resolveOutput(img.digest);
 
-		const cmds = byName("test-triggers-custom-build-push");
-		expect(cmds).toHaveLength(1);
-
-		const triggers = cmds[0].inputs.triggers as string[];
+		const pushCmds = byName("test-triggers-custom-push");
+		expect(pushCmds).toHaveLength(1);
+		const triggers = pushCmds[0].inputs.triggers as string[];
 		expect(triggers).toEqual(["dev", "custom-trigger-1", "custom-trigger-2"]);
 	});
 
@@ -223,21 +241,6 @@ describe("NixImage", () => {
 		);
 	});
 
-	it("trims trailing newline from resolve stdout", async () => {
-		const img = new NixImage("test-resolve-trim", {
-			nixAttr: "packages.x86_64-linux.my-image",
-			imageName: "my-image",
-			imageTag: "v1.0.0",
-			artifactRegistryUrl: "us-east1-docker.pkg.dev/my-project/my-repo",
-			repoRoot: "/home/user/my-repo",
-			mode: "resolve",
-		});
-
-		const digest = await resolveOutput(img.digest);
-		expect(digest).toBe("sha256:abc123def456");
-		expect(digest).not.toContain("\n");
-	});
-
 	it("registers outputs imageRef and digest", async () => {
 		const img = new NixImage("test-outputs", {
 			nixAttr: "packages.x86_64-linux.my-image",
@@ -270,5 +273,22 @@ describe("NixImage", () => {
 			(r) => r.type === "sector7:nix:NixImage" && r.name === "test-type-token",
 		);
 		expect(component).toBeDefined();
+	});
+
+	it("passes STORE_PATH from NixOutput to push command in build mode", async () => {
+		const img = new NixImage("test-store-path", {
+			nixAttr: "packages.x86_64-linux.my-image",
+			imageName: "my-image",
+			imageTag: "dev",
+			artifactRegistryUrl: "us-east1-docker.pkg.dev/my-project/my-repo",
+			repoRoot: "/home/user/my-repo",
+		});
+
+		await resolveOutput(img.digest);
+
+		const pushCmds = byName("test-store-path-push");
+		expect(pushCmds).toHaveLength(1);
+		const env = pushCmds[0].inputs.environment as Record<string, unknown>;
+		expect(env.STORE_PATH).toBe("/nix/store/abc123-my-image");
 	});
 });

--- a/packages/sector7/tests/nix-output.test.ts
+++ b/packages/sector7/tests/nix-output.test.ts
@@ -1,0 +1,255 @@
+import * as pulumi from "@pulumi/pulumi";
+import * as command from "@pulumi/command";
+import { beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { NixOutput } from "../nix-output/nix-output";
+
+type MockResource = {
+	type: string;
+	name: string;
+	inputs: Record<string, unknown>;
+	parent?: string;
+};
+
+const resources: MockResource[] = [];
+
+beforeAll(() => {
+	pulumi.runtime.setMocks({
+		newResource: (args) => {
+			const state = args.inputs;
+
+			// For command.local.Command, simulate stdout with STORE_PATH_OUTPUT marker
+			if (args.type === "command:local:Command") {
+				const create = state.create as string | undefined;
+
+				if (create?.includes("nix-output-resolve.sh")) {
+					const env = state.environment as Record<string, string> | undefined;
+					const subPath = env?.SUB_PATH;
+					const baseStorePath = "/nix/store/abc123-myapp-1.0.0";
+					const storePath = subPath
+						? `${baseStorePath}/${subPath}`
+						: baseStorePath;
+
+					(state as Record<string, unknown>).stdout =
+						`=== Resolved: ${storePath} ===\nSTORE_PATH_OUTPUT:${storePath}\n`;
+				}
+			}
+
+			resources.push({
+				type: args.type,
+				name: args.name,
+				inputs: state as Record<string, unknown>,
+				parent: args.parent?.urn ?? undefined,
+			});
+
+			return {
+				id: `${args.name}-id`,
+				state,
+			};
+		},
+		call: (args) => args.inputs,
+	});
+});
+
+beforeEach(() => {
+	resources.length = 0;
+});
+
+function resolveOutput<T>(value: pulumi.Input<T>): Promise<T> {
+	return new Promise((resolve) => {
+		pulumi.output(value).apply((resolved) => {
+			resolve(resolved as T);
+			return resolved;
+		});
+	});
+}
+
+function byName(fragment: string): MockResource[] {
+	return resources.filter((resource) => resource.name.includes(fragment));
+}
+
+describe("NixOutput", () => {
+	it("creates a Command resource in resolve mode by default", async () => {
+		const output = new NixOutput("test-default", {
+			nixAttr: "packages.x86_64-linux.myapp",
+			repoRoot: "/home/user/my-repo",
+		});
+
+		await resolveOutput(output.storePath);
+
+		const cmds = byName("test-default-resolve");
+		expect(cmds).toHaveLength(1);
+
+		const cmd = cmds[0];
+		expect(cmd.type).toBe("command:local:Command");
+		expect(cmd.inputs.environment).toEqual({
+			NIX_ATTR: "packages.x86_64-linux.myapp",
+			REPO_ROOT: "/home/user/my-repo",
+			SCRIPT_MODE: "resolve",
+			COMMAND_LOG_STEM: ".pulumi/command-logs/test-default",
+		});
+	});
+
+	it("creates a Command resource in build mode when specified", async () => {
+		const output = new NixOutput("test-build", {
+			nixAttr: "packages.x86_64-linux.myapp",
+			repoRoot: "/home/user/my-repo",
+			mode: "build",
+		});
+
+		await resolveOutput(output.storePath);
+
+		const cmds = byName("test-build-resolve");
+		expect(cmds).toHaveLength(1);
+
+		const cmd = cmds[0];
+		expect(cmd.inputs.environment).toMatchObject({
+			SCRIPT_MODE: "build",
+			NIX_ATTR: "packages.x86_64-linux.myapp",
+			REPO_ROOT: "/home/user/my-repo",
+		});
+	});
+
+	it("parses STORE_PATH_OUTPUT marker from stdout", async () => {
+		const output = new NixOutput("test-storepath", {
+			nixAttr: "packages.x86_64-linux.myapp",
+			repoRoot: "/home/user/my-repo",
+		});
+
+		const storePath = await resolveOutput(output.storePath);
+		expect(storePath).toBe("/nix/store/abc123-myapp-1.0.0");
+	});
+
+	it("passes subOutput as SUB_OUTPUT env var", async () => {
+		const output = new NixOutput("test-suboutput", {
+			nixAttr: "packages.x86_64-linux.myapp",
+			repoRoot: "/home/user/my-repo",
+			subOutput: "docs",
+		});
+
+		await resolveOutput(output.storePath);
+
+		const cmds = byName("test-suboutput-resolve");
+		expect(cmds).toHaveLength(1);
+		expect(cmds[0].inputs.environment).toMatchObject({
+			SUB_OUTPUT: "docs",
+		});
+	});
+
+	it("passes subPath as SUB_PATH env var and resolves full path", async () => {
+		const output = new NixOutput("test-subpath", {
+			nixAttr: "packages.x86_64-linux.myapp",
+			repoRoot: "/home/user/my-repo",
+			subPath: "assets/style.css",
+		});
+
+		const storePath = await resolveOutput(output.storePath);
+		expect(storePath).toBe("/nix/store/abc123-myapp-1.0.0/assets/style.css");
+	});
+
+	it("combines subOutput and subPath", async () => {
+		const output = new NixOutput("test-combined", {
+			nixAttr: "packages.x86_64-linux.myapp",
+			repoRoot: "/home/user/my-repo",
+			subOutput: "docs",
+			subPath: "api/index.html",
+		});
+
+		const storePath = await resolveOutput(output.storePath);
+		expect(storePath).toBe("/nix/store/abc123-myapp-1.0.0/api/index.html");
+
+		const cmds = byName("test-combined-resolve");
+		expect(cmds[0].inputs.environment).toMatchObject({
+			SUB_OUTPUT: "docs",
+			SUB_PATH: "api/index.html",
+		});
+	});
+
+	it("uses nixAttr as default trigger", async () => {
+		const output = new NixOutput("test-trigger-default", {
+			nixAttr: "packages.x86_64-linux.myapp",
+			repoRoot: "/home/user/my-repo",
+		});
+
+		await resolveOutput(output.storePath);
+
+		const cmds = byName("test-trigger-default-resolve");
+		expect(cmds).toHaveLength(1);
+
+		const triggers = cmds[0].inputs.triggers as string[];
+		expect(triggers).toEqual(["packages.x86_64-linux.myapp"]);
+	});
+
+	it("appends custom triggers after nixAttr", async () => {
+		const output = new NixOutput("test-trigger-custom", {
+			nixAttr: "packages.x86_64-linux.myapp",
+			repoRoot: "/home/user/my-repo",
+			triggers: ["commit-sha-abc", "v2.0.0"],
+		});
+
+		await resolveOutput(output.storePath);
+
+		const cmds = byName("test-trigger-custom-resolve");
+		expect(cmds).toHaveLength(1);
+
+		const triggers = cmds[0].inputs.triggers as string[];
+		expect(triggers).toEqual([
+			"packages.x86_64-linux.myapp",
+			"commit-sha-abc",
+			"v2.0.0",
+		]);
+	});
+
+	it("passes extra env vars to the command", async () => {
+		const output = new NixOutput("test-env", {
+			nixAttr: "packages.x86_64-linux.myapp",
+			repoRoot: "/home/user/my-repo",
+			env: { MY_VAR: "my-value" },
+		});
+
+		await resolveOutput(output.storePath);
+
+		const cmds = byName("test-env-resolve");
+		expect(cmds[0].inputs.environment).toMatchObject({
+			MY_VAR: "my-value",
+		});
+	});
+
+	it("registers storePath as output", async () => {
+		const output = new NixOutput("test-outputs", {
+			nixAttr: "packages.x86_64-linux.myapp",
+			repoRoot: "/home/user/my-repo",
+		});
+
+		const storePath = await resolveOutput(output.storePath);
+		expect(storePath).toBeTruthy();
+		expect(storePath).toMatch(/^\/nix\/store\//);
+	});
+
+	it("uses the sector7:nix:NixOutput type token", async () => {
+		const output = new NixOutput("test-type-token", {
+			nixAttr: "packages.x86_64-linux.myapp",
+			repoRoot: "/home/user/my-repo",
+		});
+
+		await resolveOutput(output.storePath);
+
+		const component = resources.find(
+			(r) => r.type === "sector7:nix:NixOutput" && r.name === "test-type-token",
+		);
+		expect(component).toBeDefined();
+	});
+
+	it("does not include SUB_OUTPUT or SUB_PATH when not specified", async () => {
+		const output = new NixOutput("test-no-sub", {
+			nixAttr: "packages.x86_64-linux.myapp",
+			repoRoot: "/home/user/my-repo",
+		});
+
+		await resolveOutput(output.storePath);
+
+		const cmds = byName("test-no-sub-resolve");
+		const env = cmds[0].inputs.environment as Record<string, unknown>;
+		expect(env).not.toHaveProperty("SUB_OUTPUT");
+		expect(env).not.toHaveProperty("SUB_PATH");
+	});
+});


### PR DESCRIPTION
## Summary

Decompose the monolithic `NixImage` into a reusable `NixOutput` primitive + a refactored `NixImage` that composes it.

### New component: `NixOutput` (`sector7:nix:NixOutput`)

A general-purpose Pulumi ComponentResource that declaratively resolves nix flake attribute paths to store paths.

- **resolve mode** (default): fast `nix eval --raw`, read-only, fails if not built yet
- **build mode**: runs `nix build`, expensive but guarantees output exists
- **subOutput**: selects named output from multi-output derivations (e.g. `myapp^docs`)
- **subPath**: selects a path within the resolved store output
- Exported at `@jmmaloney4/sector7/nix-output`

### Refactored `NixImage`

- `mode=build` (default): creates `NixOutput` child (build) + `nix-image-push.sh` (push)
- `mode=resolve`: runs `nix-image-push.sh` in resolve mode only (no NixOutput child)
- Same public interface (`imageRef`, `digest`) — no breaking changes for consumers

### Scripts

- `nix-output-resolve.sh` — resolve or build a nix output, outputs `STORE_PATH_OUTPUT:` marker
- `nix-image-push.sh` — push a store path to a container registry, outputs `DIGEST_OUTPUT:` marker (extracted from the old monolithic `nix-image-build-push.sh`)

### ADR

ADR-018 accepted with all open questions resolved.

## Test plan

- [x] 12 new NixOutput tests: resolve mode, build mode, store path parsing, subOutput, subPath, combined, triggers, env vars, type token, no-sub assertions
- [x] 11 refactored NixImage tests: build mode composition, resolve mode, digest parsing, imageRef, triggers, STORE_PATH passthrough
- [x] Full suite: 97/97 tests pass
- [ ] Manual validation: `nix develop` + `pulumi preview` in a consuming repo

## Risks

- `NixImage` internal resource names changed (e.g. `name-build-push` -> `name-build-resolve` + `name-push`). Existing stacks will see the old resources replaced. This is acceptable for the current deployment scale but should be noted.

## Files changed

- `packages/sector7/nix-output/` — new component (2 files)
- `packages/sector7/scripts/nix-output-resolve.sh` — new script
- `packages/sector7/scripts/nix-image-push.sh` — new script (extracted from old monolith)
- `packages/sector7/nix-image/nix-image.ts` — refactored to compose NixOutput
- `packages/sector7/tests/nix-output.test.ts` — new tests
- `packages/sector7/tests/nix-image.test.ts` — updated for refactored internals
- `packages/sector7/package.json` — new `./nix-output` sub-path export
- `packages/sector7/index.ts` — barrel re-export
- `docs/internal/designs/adr-nix-output-component.md` — ADR-018 (Accepted)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Refactors the `NixImage` deployment path from a single command/script into a composed build (`NixOutput`) + push flow, which will replace existing Pulumi `command.local.Command` resources and may trigger updates/replacements in stacks. Also introduces new shell scripts and trigger wiring that affects when builds/pushes rerun.
> 
> **Overview**
> Introduces **`NixOutput`** (`sector7:nix:NixOutput`) to resolve/build a flake attribute into a Nix store path, with support for `mode` (`resolve`/`build`), `subOutput`, `subPath`, extra `env`, and deterministic trigger semantics.
> 
> Refactors **`NixImage`** to split the prior monolithic build+push command into composition: in `build` mode it creates a `NixOutput` child to obtain `STORE_PATH` and then runs a new `nix-image-push.sh`; in `resolve` mode it skips `NixOutput` and only inspects the remote tag. Digest parsing is hardened by trimming stdout, and trigger wiring now includes both `imageTag` and the resolved store path for pushes.
> 
> Adds the new scripts `nix-output-resolve.sh` (emits `STORE_PATH_OUTPUT`) and `nix-image-push.sh` (push/resolve, emits `DIGEST_OUTPUT`), exports `./nix-output` from the package and barrel index, updates/extends tests for both components, and documents the design in ADR-018.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 66bda505b40a33d746c6318621bd3b85fe874bd5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->