### PR TITLE
feat(d1): D1Query dynamic provider for schema initialization

### DIFF
--- a/packages/sector7/d1/d1-query.ts
+++ b/packages/sector7/d1/d1-query.ts
@@ -1,0 +1,332 @@
+import * as pulumi from "@pulumi/pulumi";
+import {
+	type CustomResourceOptions,
+	dynamic,
+	type Input,
+	type Output,
+} from "@pulumi/pulumi";
+
+/**
+ * Resource options accepted by sector7 dynamic resources.
+ *
+ * Pulumi dynamic resources are executed by the Node.js dynamic provider runtime,
+ * not by a cloud provider plugin. Passing `provider` or `providers` makes Pulumi
+ * route the resource through the wrong provider bridge, which fails with a
+ * misleading `pulumi-nodejs:dynamic:Resource` unknown-token error.
+ */
+export type DynamicResourceOptions = Omit<
+	CustomResourceOptions,
+	"provider" | "providers"
+>;
+
+// ---------------------------------------------------------------------------
+// Inputs
+// ---------------------------------------------------------------------------
+
+/**
+ * Arguments for creating a D1Query resource.
+ *
+ * All `Input<T>` values are resolved by Pulumi before reaching the dynamic
+ * provider, so secrets (which are `Output<string>`) are valid inputs.
+ */
+export interface D1QueryArgs {
+	/**
+	 * Cloudflare account ID.
+	 */
+	accountId: Input<string>;
+
+	/**
+	 * D1 database ID to execute the query against.
+	 */
+	databaseId: Input<string>;
+
+	/**
+	 * SQL to execute. Supports multi-statement SQL (semicolon-separated).
+	 *
+	 * Use `CREATE TABLE IF NOT EXISTS` for idempotent schema initialization.
+	 * The query is re-executed only when this value changes.
+	 */
+	sql: Input<string>;
+
+	/**
+	 * Cloudflare API token with D1 write permissions.
+	 * Store as a Pulumi secret: `pulumi.secret("...")` or config
+	 * `pulumi.config.requireSecret("cloudflare:apiToken")`.
+	 */
+	apiToken: Input<string>;
+}
+
+/**
+ * Resolved inputs as seen inside the dynamic provider callbacks.
+ * All values are plain strings -- Pulumi resolves Input<T> before invoking the provider.
+ */
+interface D1QueryInputs {
+	accountId: string;
+	databaseId: string;
+	sql: string;
+	apiToken: string;
+}
+
+/**
+ * State persisted in Pulumi state for each D1Query resource.
+ */
+interface D1QueryState extends D1QueryInputs {
+	/**
+	 * SHA-256 hex digest of the SQL that was last executed.
+	 * Used to detect changes between runs.
+	 */
+	sqlHash: string;
+}
+
+// ---------------------------------------------------------------------------
+// Cloudflare D1 REST API
+// ---------------------------------------------------------------------------
+
+const CLOUDFLARE_API_BASE = "https://api.cloudflare.com/client/v4";
+
+/**
+ * Execute a SQL query against a D1 database via the Cloudflare REST API.
+ *
+ * @see https://developers.cloudflare.com/api/operations/cloudflare-d1-query-database
+ */
+const executeD1Query = async (
+	accountId: string,
+	databaseId: string,
+	sql: string,
+	apiToken: string,
+): Promise<void> => {
+	const url = `${CLOUDFLARE_API_BASE}/accounts/${accountId}/d1/database/${databaseId}/query`;
+
+	const response = await fetch(url, {
+		method: "POST",
+		headers: {
+			"Content-Type": "application/json",
+			Authorization: `Bearer ${apiToken}`,
+		},
+		body: JSON.stringify({ sql }),
+	});
+
+	if (!response.ok) {
+		const text = await response.text();
+		throw new Error(
+			`D1 query failed: ${response.status} ${response.statusText}\n${text}`,
+		);
+	}
+
+	const body = (await response.json()) as {
+		success: boolean;
+		errors?: Array<{ message: string }>;
+	};
+
+	if (!body.success) {
+		const messages =
+			body.errors?.map((e) => e.message).join("; ") ?? "unknown error";
+		throw new Error(`D1 query failed: ${messages}`);
+	}
+};
+
+// ---------------------------------------------------------------------------
+// Pulumi dynamic provider
+// ---------------------------------------------------------------------------
+
+/**
+ * Pulumi dynamic resource provider that executes SQL against a Cloudflare D1
+ * database via the REST API.
+ *
+ * Notes
+ * -----
+ * This provider uses the global `fetch()` available in Node.js 18+.
+ * No external HTTP dependencies are required.
+ *
+ * Node built-in imports (crypto) are inlined as dynamic import() calls
+ * inside provider callbacks rather than imported at module top level. Pulumi
+ * serializes the provider object via V8 source capture; top-level ES module
+ * imports of Node built-ins capture native-code functions that cannot be
+ * serialized. Dynamic import() calls are emitted verbatim and evaluated at
+ * runtime after deserialization.
+ *
+ * Lifecycle
+ * ---------
+ * - check  : validate inputs (non-empty SQL, required fields)
+ * - diff   : compare sqlHash; trigger replacement when SQL changes
+ * - create : execute SQL; store sqlHash
+ * - update : re-execute SQL; update sqlHash
+ * - delete : no-op (schema data persists after resource removal)
+ */
+const d1QueryProvider: dynamic.ResourceProvider = {
+	async check(
+		_olds: D1QueryState,
+		news: D1QueryInputs,
+	): Promise<dynamic.CheckResult> {
+		const failures: dynamic.CheckFailure[] = [];
+
+		if (!news.sql || news.sql.trim().length === 0) {
+			failures.push({
+				property: "sql",
+				reason: "SQL must be a non-empty string",
+			});
+		}
+
+		if (!news.accountId) {
+			failures.push({
+				property: "accountId",
+				reason: "accountId is required",
+			});
+		}
+
+		if (!news.databaseId) {
+			failures.push({
+				property: "databaseId",
+				reason: "databaseId is required",
+			});
+		}
+
+		if (!news.apiToken) {
+			failures.push({
+				property: "apiToken",
+				reason: "apiToken is required",
+			});
+		}
+
+		return { inputs: news, failures };
+	},
+
+	async diff(
+		_id: string,
+		olds: D1QueryState,
+		news: D1QueryInputs,
+	): Promise<dynamic.DiffResult> {
+		const replaces: string[] = [];
+		if (olds.accountId !== news.accountId) replaces.push("accountId");
+		if (olds.databaseId !== news.databaseId) replaces.push("databaseId");
+		// SQL change triggers replacement (re-run the query)
+		if (olds.sql !== news.sql) replaces.push("sql");
+
+		const changes = replaces.length > 0;
+
+		return { changes, replaces, deleteBeforeReplace: changes };
+	},
+
+	async create(inputs: D1QueryInputs): Promise<dynamic.CreateResult> {
+		const nodeCrypto = (await import(
+			"node:crypto"
+		)) as typeof import("node:crypto");
+
+		await executeD1Query(
+			inputs.accountId,
+			inputs.databaseId,
+			inputs.sql,
+			inputs.apiToken,
+		);
+
+		const sqlHash = nodeCrypto
+			.createHash("sha256")
+			.update(inputs.sql)
+			.digest("hex");
+
+		return {
+			id: `d1query:${inputs.databaseId}:${sqlHash.slice(0, 12)}`,
+			outs: { ...inputs, sqlHash },
+		};
+	},
+
+	async update(
+		_id: string,
+		_olds: D1QueryState,
+		news: D1QueryInputs,
+	): Promise<dynamic.UpdateResult> {
+		const nodeCrypto = (await import(
+			"node:crypto"
+		)) as typeof import("node:crypto");
+
+		await executeD1Query(
+			news.accountId,
+			news.databaseId,
+			news.sql,
+			news.apiToken,
+		);
+
+		const sqlHash = nodeCrypto
+			.createHash("sha256")
+			.update(news.sql)
+			.digest("hex");
+
+		return { outs: { ...news, sqlHash } };
+	},
+
+	async delete(
+		_id: string,
+		_props: D1QueryState,
+	): Promise<void> {
+		// No-op: schema data persists after resource removal.
+		// D1 databases outlive individual Pulumi stacks.
+	},
+};
+
+// ---------------------------------------------------------------------------
+// Guard
+// ---------------------------------------------------------------------------
+
+const rejectCloudProviderOptions = (
+	resourceName: string,
+	opts?: CustomResourceOptions,
+): void => {
+	if (!opts) return;
+
+	const hasProvider =
+		Object.prototype.hasOwnProperty.call(opts, "provider") &&
+		opts.provider !== undefined;
+	const hasProviders =
+		Object.prototype.hasOwnProperty.call(opts, "providers") &&
+		(opts as Record<string, unknown>).providers !== undefined;
+	if (!hasProvider && !hasProviders) return;
+
+	throw new Error(
+		`${resourceName} is a Pulumi dynamic resource; do not pass provider/providers. ` +
+			"Pass provider options only to cloud provider resources, and use parent/dependsOn for dynamic resource ordering.",
+	);
+};
+
+// ---------------------------------------------------------------------------
+// Public resource
+// ---------------------------------------------------------------------------
+
+/**
+ * A Pulumi dynamic resource that executes SQL against a Cloudflare D1 database.
+ *
+ * @remarks
+ * Uses the Cloudflare REST API to run SQL statements during `pulumi up`.
+ * Designed for schema initialization (e.g., `CREATE TABLE IF NOT EXISTS`)
+ * but can execute any SQL.
+ *
+ * The resource tracks SQL content via SHA-256 hashing. When the SQL changes,
+ * the query is re-executed. Deletion is a no-op (schema persists).
+ *
+ * Authentication requires a Cloudflare API token with D1 permissions.
+ * Pass it as a Pulumi secret to avoid leaking it in state:
+ *
+ * @example
+ * ```typescript
+ * new D1Query("init-schema", {
+ *   accountId: "abc123",
+ *   databaseId: d1.id,
+ *   sql: "CREATE TABLE IF NOT EXISTS foo (id INTEGER PRIMARY KEY);",
+ *   apiToken: pulumi.secret(process.env.CF_API_TOKEN!),
+ * });
+ * ```
+ */
+export class D1Query extends dynamic.Resource {
+	/**
+	 * SHA-256 hex digest of the last-executed SQL.
+	 */
+	public readonly sqlHash!: Output<string>;
+
+	constructor(
+		name: string,
+		args: D1QueryArgs,
+		opts?: DynamicResourceOptions,
+	) {
+		rejectCloudProviderOptions("D1Query", opts);
+		super(d1QueryProvider, name, { sqlHash: undefined, ...args }, opts);
+	}
+}

--- a/packages/sector7/d1/d1-query.ts
+++ b/packages/sector7/d1/d1-query.ts
@@ -202,9 +202,12 @@ const d1QueryProvider: dynamic.ResourceProvider = {
 		// SQL change triggers replacement (re-run the query)
 		if (olds.sql !== news.sql) replaces.push("sql");
 
-		const changes = replaces.length > 0;
+		// apiToken change triggers update (re-execute with new credentials)
+		const hasTokenChange = olds.apiToken !== news.apiToken;
 
-		return { changes, replaces, deleteBeforeReplace: changes };
+		const changes = replaces.length > 0 || hasTokenChange;
+
+		return { changes, replaces, deleteBeforeReplace: replaces.length > 0 };
 	},
 
 	async create(inputs: D1QueryInputs): Promise<dynamic.CreateResult> {

--- a/packages/sector7/d1/index.ts
+++ b/packages/sector7/d1/index.ts
@@ -1,0 +1,1 @@
+export { D1Query, type D1QueryArgs, type DynamicResourceOptions } from "./d1-query.ts";

--- a/packages/sector7/index.ts
+++ b/packages/sector7/index.ts
@@ -4,3 +4,4 @@ export * as workersite from "./workersite/index.ts";
 export * as nixImage from "./nix-image/index.ts";
 export * as monitor from "./monitor/index.ts";
 export * as nixOutput from "./nix-output/index.ts";
+export * as d1 from "./d1/index.ts";

--- a/packages/sector7/monitor/uptime-monitor.ts
+++ b/packages/sector7/monitor/uptime-monitor.ts
@@ -334,7 +334,7 @@ export class UptimeMonitor extends pulumi.ComponentResource {
 				mainModule: "worker.js",
 				bindings: baseBindings,
 			},
-			resourceOpts,
+			{ parent: this, dependsOn: this.d1Query ? [this.d1Query] : [] },
 		);
 
 		// 5. Create cron trigger for scheduled execution

--- a/packages/sector7/monitor/uptime-monitor.ts
+++ b/packages/sector7/monitor/uptime-monitor.ts
@@ -1,5 +1,6 @@
 import * as cloudflare from "@pulumi/cloudflare";
 import * as pulumi from "@pulumi/pulumi";
+import { D1Query, type D1QueryArgs } from "../d1/d1-query.ts";
 import {
 	type MonitorTarget,
 	generateMonitorScript,
@@ -103,12 +104,19 @@ export interface UptimeMonitorArgs {
 	 * default schema.
 	 * @default built-in schema with ts, monitor_id, url, ok, status, latency_ms, error, region_hint
 	 *
-	 * NOTE: The Cloudflare Pulumi provider does not support D1 schema migration.
-	 * You must apply the schema manually (e.g., `wrangler d1 execute <db> --file=schema.sql`)
-	 * before the first cron run. The Worker will fail with a missing-table error if the
-	 * `probe_results` table does not exist.
+	 * Applied automatically during `pulumi up` via the D1 REST API.
+	 * Re-applied when the SQL content changes.
 	 */
 	d1Schema?: pulumi.Input<string>;
+
+	/**
+	 * Cloudflare API token with D1 write permissions.
+	 * Required to apply the D1 schema during `pulumi up`.
+	 *
+	 * Store as a Pulumi secret to avoid leaking it in state:
+	 * `pulumi.secret("...")` or `pulumi.config.requireSecret("cloudflare:apiToken")`.
+	 */
+	apiToken: pulumi.Input<string>;
 }
 
 const DEFAULT_D1_SCHEMA = [
@@ -160,6 +168,12 @@ const DEFAULT_D1_SCHEMA = [
  * ```
  */
 export class UptimeMonitor extends pulumi.ComponentResource {
+	/**
+	 * The D1 schema initialization query resource.
+	 * Present when a D1 database is created or referenced.
+	 */
+	public readonly d1Query: D1Query | undefined;
+
 	/**
 	 * The D1 database storing probe results.
 	 * Present when `createD1Database` is true.
@@ -252,6 +266,18 @@ export class UptimeMonitor extends pulumi.ComponentResource {
 			}
 		}
 
+		// 1b. Apply D1 schema via dynamic provider
+		this.d1Query = new D1Query(
+			`${name}-schema`,
+			{
+				accountId: args.accountId,
+				databaseId: this.d1DatabaseId,
+				sql: args.d1Schema ?? DEFAULT_D1_SCHEMA,
+				apiToken: args.apiToken,
+			},
+			{ parent: this, dependsOn: this.d1Database ? [this.d1Database] : [] },
+		);
+
 		// 2. Create or reference KV namespace
 		if (args.kvNamespaceId) {
 			this.kvNamespaceId = pulumi.output(args.kvNamespaceId);
@@ -328,6 +354,7 @@ export class UptimeMonitor extends pulumi.ComponentResource {
 		this.registerOutputs({
 			d1Database: this.d1Database,
 			d1DatabaseId: this.d1DatabaseId,
+			d1Query: this.d1Query,
 			kvNamespace: this.kvNamespace,
 			kvNamespaceId: this.kvNamespaceId,
 			worker: this.worker,

--- a/packages/sector7/package.json
+++ b/packages/sector7/package.json
@@ -46,6 +46,10 @@
     "./scripts": {
       "types": "./dist/scripts/index.d.ts",
       "default": "./dist/scripts/index.js"
+    },
+    "./d1": {
+      "types": "./dist/d1/index.d.ts",
+      "default": "./dist/d1/index.js"
     }
   },
   "files": [

--- a/packages/sector7/tests/d1-query.test.ts
+++ b/packages/sector7/tests/d1-query.test.ts
@@ -1,0 +1,123 @@
+import { createHash } from "node:crypto";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+type D1Provider = {
+	check: (
+		olds: unknown,
+		news: Record<string, string>,
+	) => Promise<{ failures: Array<{ property: string; reason: string }> }>;
+	diff: (
+		id: string,
+		olds: Record<string, string>,
+		news: Record<string, string>,
+	) => Promise<{
+		changes: boolean;
+		replaces?: string[];
+		deleteBeforeReplace?: boolean;
+	}>;
+};
+
+type DynamicResourceCall = {
+	name: string;
+	args: Record<string, unknown>;
+	opts: Record<string, unknown> | undefined;
+	provider: D1Provider;
+};
+
+let provider: D1Provider | undefined;
+const dynamicResourceCalls: DynamicResourceCall[] = [];
+
+vi.mock("@pulumi/pulumi", () => {
+	const output = <T>(value: T) => ({
+		apply: <U>(fn: (value: T) => U) => fn(value),
+	});
+
+	return {
+		all: <T>(value: T) => output(value),
+		output,
+		mergeOptions: (
+			left: Record<string, unknown>,
+			right: Record<string, unknown>,
+		) => ({ ...left, ...right }),
+		dynamic: {
+			Resource: class {
+				constructor(
+					resourceProvider: D1Provider,
+					name: string,
+					args: Record<string, unknown>,
+					opts?: Record<string, unknown>,
+				) {
+					provider = resourceProvider;
+					dynamicResourceCalls.push({ name, args, opts, provider: resourceProvider });
+				}
+			},
+		},
+	};
+});
+
+import { D1Query } from "../d1/d1-query.ts";
+
+const createArgs = (sql = "CREATE TABLE t (id INTEGER);") => ({
+	accountId: "account-123",
+	databaseId: "db-456",
+	sql,
+	apiToken: "test-token",
+});
+
+const cloudProviderOpt = { provider: { urn: "cloudflare-provider" } };
+
+describe("D1Query provider", () => {
+	beforeEach(() => {
+		provider = undefined;
+		dynamicResourceCalls.length = 0;
+		new D1Query("test", createArgs());
+	});
+
+	it("registers a dynamic resource with correct args", () => {
+		expect(dynamicResourceCalls).toHaveLength(1);
+		expect(dynamicResourceCalls[0].name).toBe("test");
+		expect(dynamicResourceCalls[0].args.accountId).toBe("account-123");
+		expect(dynamicResourceCalls[0].args.databaseId).toBe("db-456");
+		expect(dynamicResourceCalls[0].args.sql).toBe("CREATE TABLE t (id INTEGER);");
+		expect(dynamicResourceCalls[0].args.apiToken).toBe("test-token");
+	});
+
+	it("reports no check failures for valid inputs", async () => {
+		const result = await provider!.check({}, createArgs());
+		expect(result.failures).toHaveLength(0);
+	});
+
+	it("reports check failures when required fields are missing", async () => {
+		const result = await provider!.check({}, {} as Record<string, string>);
+		expect(result.failures.length).toBeGreaterThanOrEqual(1);
+	});
+
+	it("detects no changes when SQL is unchanged", async () => {
+		const olds = { ...createArgs(), sqlHash: createHash("sha256").update(createArgs().sql).digest("hex") };
+		const result = await provider!.diff("test-id", olds, createArgs());
+		expect(result.changes).toBe(false);
+	});
+
+	it("detects changes when SQL is modified", async () => {
+		const oldSql = "CREATE TABLE t (id INTEGER);";
+		const newSql = "CREATE TABLE t (id INTEGER, name TEXT);";
+		const olds = { ...createArgs(oldSql), sqlHash: createHash("sha256").update(oldSql).digest("hex") };
+		const result = await provider!.diff("test-id", olds, { ...createArgs(), sql: newSql });
+		expect(result.changes).toBe(true);
+		expect(result.replaces).toContain("sql");
+	});
+
+	it("triggers delete-before-replace when SQL changes", async () => {
+		const oldSql = "CREATE TABLE t (id INTEGER);";
+		const newSql = "CREATE TABLE t (id INTEGER, name TEXT);";
+		const olds = { ...createArgs(oldSql), sqlHash: createHash("sha256").update(oldSql).digest("hex") };
+		const result = await provider!.diff("test-id", olds, { ...createArgs(), sql: newSql });
+		expect(result.deleteBeforeReplace).toBe(true);
+	});
+
+	it("rejects cloud provider options", () => {
+		expect(
+			() => new D1Query("bad-opts", createArgs(), cloudProviderOpt as any),
+		).toThrow(/D1Query is a Pulumi dynamic resource/);
+	});
+});

--- a/packages/sector7/tests/d1-query.test.ts
+++ b/packages/sector7/tests/d1-query.test.ts
@@ -115,6 +115,19 @@ describe("D1Query provider", () => {
 		expect(result.deleteBeforeReplace).toBe(true);
 	});
 
+	it("detects changes when apiToken is rotated", async () => {
+		const sql = "CREATE TABLE t (id INTEGER);";
+		const olds = { ...createArgs(sql), sqlHash: createHash("sha256").update(sql).digest("hex") };
+		const result = await provider!.diff("test-id", olds, {
+			...createArgs(),
+			apiToken: "new-token",
+		});
+		expect(result.changes).toBe(true);
+		// Token change does not trigger replacement, just update
+		expect(result.replaces).toHaveLength(0);
+		expect(result.deleteBeforeReplace).toBe(false);
+	});
+
 	it("rejects cloud provider options", () => {
 		expect(
 			() => new D1Query("bad-opts", createArgs(), cloudProviderOpt as any),

--- a/packages/sector7/tests/uptime-monitor.test.ts
+++ b/packages/sector7/tests/uptime-monitor.test.ts
@@ -5,13 +5,15 @@ import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 // functions during pulumi.runtime.setMocks testing.
 vi.mock("../d1/d1-query.ts", () => {
 	return {
-		D1Query: class {
+		D1Query: class extends pulumi.ComponentResource {
 			public readonly sqlHash: pulumi.Output<string>;
 			constructor(
-				_provider: unknown,
+				_name: string,
 				args: Record<string, unknown>,
 			) {
+				super("sector7:test:D1Query", _name, {}, {});
 				this.sqlHash = pulumi.output("mock-hash");
+				this.registerOutputs({ sqlHash: this.sqlHash });
 			}
 		},
 	};

--- a/packages/sector7/tests/uptime-monitor.test.ts
+++ b/packages/sector7/tests/uptime-monitor.test.ts
@@ -1,5 +1,22 @@
 import * as pulumi from "@pulumi/pulumi";
-import { beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mock D1Query to avoid V8 closure serialization of the dynamic provider
+// functions during pulumi.runtime.setMocks testing.
+vi.mock("../d1/d1-query.ts", () => {
+	return {
+		D1Query: class {
+			public readonly sqlHash: pulumi.Output<string>;
+			constructor(
+				_provider: unknown,
+				args: Record<string, unknown>,
+			) {
+				this.sqlHash = pulumi.output("mock-hash");
+			}
+		},
+	};
+});
+
 import { UptimeMonitor } from "../monitor/uptime-monitor.ts";
 
 type MockResource = {
@@ -47,10 +64,15 @@ function findResource(name: string): MockResource | undefined {
 	return resources.find((r) => r.name === name);
 }
 
+const DEFAULT_ARGS = {
+	accountId: "account-123",
+	apiToken: "test-api-token",
+} as const;
+
 describe("UptimeMonitor", () => {
-	it("creates D1, KV, Worker, and cron trigger for a basic monitor", async () => {
+	it("creates D1, KV, Worker, cron trigger, and D1Query for a basic monitor", async () => {
 		const monitor = new UptimeMonitor("basic", {
-			accountId: "account-123",
+			...DEFAULT_ARGS,
 			name: "basic-uptime",
 			monitors: [
 				{ id: "grafana", url: "https://grafana.example.com/healthz" },
@@ -64,6 +86,7 @@ describe("UptimeMonitor", () => {
 		expect(findResource("basic-kv")).toBeDefined();
 		expect(findResource("basic-worker")).toBeDefined();
 		expect(findResource("basic-cron")).toBeDefined();
+		expect(monitor.d1Query).toBeDefined();
 
 		const worker = findResource("basic-worker");
 		const bindings = worker?.inputs.bindings as Array<Record<string, unknown>>;
@@ -80,7 +103,7 @@ describe("UptimeMonitor", () => {
 
 	it("adds a webhook secret binding when webhookUrl is provided", async () => {
 		const monitor = new UptimeMonitor("webhook", {
-			accountId: "account-123",
+			...DEFAULT_ARGS,
 			name: "webhook-uptime",
 			monitors: [
 				{ id: "api", url: "https://api.example.com/healthz" },
@@ -93,7 +116,6 @@ describe("UptimeMonitor", () => {
 		const worker = findResource("webhook-worker");
 		expect(worker).toBeDefined();
 
-		// Bindings may be a Pulumi Output in mocks; resolve if needed
 		const rawBindings = worker!.inputs.bindings;
 		const bindings = await resolveOutput(
 			rawBindings as pulumi.Input<Array<Record<string, unknown>>>,
@@ -108,7 +130,7 @@ describe("UptimeMonitor", () => {
 
 	it("creates a cron trigger with the specified schedule", async () => {
 		const monitor = new UptimeMonitor("scheduled", {
-			accountId: "account-123",
+			...DEFAULT_ARGS,
 			name: "scheduled-uptime",
 			monitors: [
 				{ id: "site", url: "https://example.com/" },
@@ -127,7 +149,7 @@ describe("UptimeMonitor", () => {
 
 	it("defaults to every-minute cron schedule", async () => {
 		const monitor = new UptimeMonitor("defcron", {
-			accountId: "account-123",
+			...DEFAULT_ARGS,
 			name: "defcron-uptime",
 			monitors: [
 				{ id: "site", url: "https://example.com/" },
@@ -145,7 +167,7 @@ describe("UptimeMonitor", () => {
 
 	it("uses existing D1 database when d1DatabaseId is provided", async () => {
 		const monitor = new UptimeMonitor("exd1", {
-			accountId: "account-123",
+			...DEFAULT_ARGS,
 			name: "exd1-uptime",
 			monitors: [
 				{ id: "site", url: "https://example.com/" },
@@ -155,12 +177,11 @@ describe("UptimeMonitor", () => {
 
 		await resolveOutput(monitor.worker.id);
 
-		// Should NOT create a D1 database resource
 		expect(findResource("exd1-d1")).toBeUndefined();
 		expect(monitor.d1Database).toBeUndefined();
 		expect(await resolveOutput(monitor.d1DatabaseId)).toBe("existing-db-id");
+		expect(monitor.d1Query).toBeDefined();
 
-		// Worker should still have the DB binding pointing to the existing database
 		const worker = findResource("exd1-worker");
 		const d1Binding = (worker?.inputs.bindings as Array<Record<string, unknown>>)
 			.find((b) => b.name === "DB");
@@ -169,7 +190,7 @@ describe("UptimeMonitor", () => {
 
 	it("uses existing KV namespace when kvNamespaceId is provided", async () => {
 		const monitor = new UptimeMonitor("exkv", {
-			accountId: "account-123",
+			...DEFAULT_ARGS,
 			name: "exkv-uptime",
 			monitors: [
 				{ id: "site", url: "https://example.com/" },
@@ -179,7 +200,6 @@ describe("UptimeMonitor", () => {
 
 		await resolveOutput(monitor.worker.id);
 
-		// Should NOT create a KV namespace resource
 		expect(findResource("exkv-kv")).toBeUndefined();
 		expect(monitor.kvNamespace).toBeUndefined();
 		expect(await resolveOutput(monitor.kvNamespaceId)).toBe("existing-kv-id");
@@ -189,7 +209,7 @@ describe("UptimeMonitor", () => {
 		expect(
 			() =>
 				new UptimeMonitor("no-monitors", {
-					accountId: "account-123",
+					...DEFAULT_ARGS,
 					name: "no-monitors-uptime",
 					monitors: [],
 				} as unknown as ConstructorParameters<typeof UptimeMonitor>[1]),
@@ -200,7 +220,7 @@ describe("UptimeMonitor", () => {
 		expect(
 			() =>
 				new UptimeMonitor("dup-ids", {
-					accountId: "account-123",
+					...DEFAULT_ARGS,
 					name: "dup-ids-uptime",
 					monitors: [
 						{ id: "site", url: "https://example.com/" },
@@ -212,7 +232,7 @@ describe("UptimeMonitor", () => {
 
 	it("generates Worker script with embedded monitor configuration", async () => {
 		const monitor = new UptimeMonitor("scriptchk", {
-			accountId: "account-123",
+			...DEFAULT_ARGS,
 			name: "scriptchk-uptime",
 			monitors: [
 				{
@@ -235,7 +255,7 @@ describe("UptimeMonitor", () => {
 
 	it("supports multiple monitors", async () => {
 		const monitor = new UptimeMonitor("multi", {
-			accountId: "account-123",
+			...DEFAULT_ARGS,
 			name: "multi-uptime",
 			monitors: [
 				{ id: "grafana", url: "https://grafana.example.com/healthz" },


### PR DESCRIPTION
...[truncated]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new dynamic provider that executes arbitrary SQL against Cloudflare D1 during `pulumi up`, which can affect production data/schema if misconfigured and requires handling an API token as an input/state value.
> 
> **Overview**
> Adds a new `D1Query` Pulumi dynamic resource (exported via `sector7/d1`) that runs SQL against a Cloudflare D1 database using the Cloudflare REST API, tracking changes via a SHA-256 `sqlHash` and re-executing on SQL/token changes.
> 
> Updates `UptimeMonitor` to require an `apiToken` and to automatically apply the default/overridden D1 schema during deployments by creating a `D1Query` and making the Worker depend on it, removing the prior manual schema-migration expectation. Includes new unit tests for the dynamic provider behavior and adjusts monitor tests to mock `D1Query` and assert it is created; package exports are updated to expose the new module.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 47f7de46a57c48ba1326491927695f8514d39c61. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->