### PR TITLE
feat(litellm): implement LiteLLM proxy component (ADR-022)

### DIFF
--- a/docs/internal/designs/022-litellm-proxy-component.md
+++ b/docs/internal/designs/022-litellm-proxy-component.md
@@ -1,0 +1,401 @@
+---
+id: ADR-022
+title: LiteLLM Proxy ComponentResource
+status: Proposed
+date: 2026-05-14
+deciders: [jmmaloney4]
+consulted: []
+tags: [design, adr, pulumi, kubernetes, litellm]
+supersedes: []
+superseded_by: []
+links: []
+---
+
+# Context
+
+We need a repeatable way to deploy and configure a LiteLLM proxy for small but growing teams of AI users. The immediate garden deployment already has the right basic shape:
+
+- a Kubernetes Deployment running `ghcr.io/berriai/litellm-database:main-stable`
+- a ConfigMap-mounted `config.yaml`
+- provider API keys supplied through Kubernetes Secrets and environment variables
+- Cloud SQL PostgreSQL for LiteLLM virtual keys, spend tracking, teams, and users
+- an auto-generated master key
+- optional Langfuse OTEL callbacks
+- consumer virtual keys created through the LiteLLM API
+
+The current garden stack is too project-specific to reuse cleanly. It embeds model YAML construction, Cloud SQL wiring, provider env vars, and key-generation behavior directly in one Pulumi program. That is fine for a bootstrap deployment, but it will get brittle as additional providers, semantic model groups, keys, budgets, and Redis coordination are added.
+
+Sector7 is the right home for the reusable deployment abstraction because this is not garden-specific infrastructure. It is a general Pulumi component that can be used by garden, yard, or any future cluster that wants an OpenAI-compatible team gateway with managed routing, fallback, cost tracking, and virtual keys.
+
+# Decision
+
+Create a Sector7 `LiteLLMProxy` Pulumi `ComponentResource` behind a dedicated subpath export, not the main package barrel.
+
+The component SHOULD own the LiteLLM proxy Kubernetes objects and config generation:
+
+- Namespace, when requested
+- provider-credential Secret
+- runtime Secret for master key and database URL references
+- ConfigMap containing generated `config.yaml`
+- Deployment
+- Service
+- optional consumer virtual keys created through the LiteLLM API after the Deployment is ready
+
+The component MUST NOT own garden-specific Cloud SQL creation. Database creation, private networking, and database password generation belong to the consuming stack or to a separate database component. `LiteLLMProxy` accepts `databaseUrl` as a secret input.
+
+The component MUST keep provider API keys out of the generated ConfigMap. Provider deployments reference environment variables with LiteLLM's `os.environ/<ENV_VAR>` syntax. Pulumi passes the actual values through Kubernetes Secret-backed env vars.
+
+The component SHOULD expose a typed domain model and generate LiteLLM `config.yaml` from it. It SHOULD NOT require consumers to hand-write YAML strings.
+
+## Type token
+
+`sector7:kubernetes:LiteLLMProxy`
+
+## Package surface
+
+Use a subpath export:
+
+```ts
+import { LiteLLMProxy } from "@jmmaloney4/sector7/litellm";
+```
+
+Do not export this through the root barrel. This component adds Kubernetes, random, command, and YAML serialization concerns that should not become transitive requirements for Cloudflare-only consumers.
+
+Package wiring:
+
+```json
+{
+  "exports": {
+    "./litellm": {
+      "types": "./dist/litellm/index.d.ts",
+      "default": "./dist/litellm/index.js"
+    }
+  }
+}
+```
+
+## Interface sketch
+
+```ts
+export interface LiteLLMProxyArgs {
+  namespace?: pulumi.Input<string>;
+  createNamespace?: pulumi.Input<boolean>;
+  image?: pulumi.Input<string>;
+  replicas?: pulumi.Input<number>;
+
+  databaseUrl: pulumi.Input<string>;
+  masterKey?: pulumi.Input<string>;
+
+  providers: Record<string, LiteLLMProviderConfig>;
+  deployments: LiteLLMModelDeployment[];
+  modelGroups: LiteLLMModelGroup[];
+
+  router?: LiteLLMRouterPolicy;
+  governance?: LiteLLMGovernancePolicy;
+  observability?: LiteLLMObservabilityPolicy;
+  redis?: LiteLLMRedisPolicy;
+
+  keys?: Record<string, LiteLLMVirtualKeySpec>;
+
+  service?: LiteLLMServiceSpec;
+  resources?: k8s.types.input.core.v1.ResourceRequirements;
+}
+
+export interface LiteLLMProviderConfig {
+  apiKey: pulumi.Input<string>;
+  envVar?: pulumi.Input<string>;
+  apiBase?: pulumi.Input<string>;
+}
+
+export interface LiteLLMModelDeployment {
+  id: string;
+  modelName: string;
+  provider: string;
+  providerModel: string;
+  apiBase?: pulumi.Input<string>;
+  mode?: "chat" | "completion" | "embedding";
+  baseModel?: string;
+  accessGroups?: string[];
+  rpm?: number;
+  tpm?: number;
+  weight?: number;
+  order?: number;
+  maxInputTokens?: number;
+  inputCostPerToken?: number;
+  outputCostPerToken?: number;
+}
+
+export interface LiteLLMModelGroup {
+  name: string;
+  deploymentIds: string[];
+  fallbacks?: string[];
+  contextWindowFallbacks?: string[];
+  accessGroups?: string[];
+}
+
+export interface LiteLLMVirtualKeySpec {
+  keyAlias: pulumi.Input<string>;
+  key?: pulumi.Input<string>;
+  models?: pulumi.Input<pulumi.Input<string>[]>;
+  teamId?: pulumi.Input<string>;
+  userId?: pulumi.Input<string>;
+  maxBudget?: pulumi.Input<number>;
+  budgetDuration?: pulumi.Input<string>;
+  rpmLimit?: pulumi.Input<number>;
+  tpmLimit?: pulumi.Input<number>;
+  metadata?: pulumi.Input<Record<string, string>>;
+  duration?: pulumi.Input<string>;
+}
+```
+
+Concrete names can change during implementation. The important design point is the separation between:
+
+- provider credentials
+- provider model deployments
+- client-facing model groups
+- router policy
+- governance policy
+- generated virtual keys
+
+## Generated LiteLLM configuration
+
+The component should generate one ConfigMap entry, `config.yaml`, from a structured object.
+
+The generated config should include:
+
+```yaml
+model_list:
+  - model_name: smart
+    litellm_params:
+      model: anthropic/claude-sonnet-4-20250514
+      api_key: os.environ/ANTHROPIC_API_KEY
+      rpm: 500
+      tpm: 200000
+    model_info:
+      id: anthropic-sonnet-smart
+      base_model: anthropic/claude-sonnet-4-20250514
+      access_groups: [core, premium]
+      mode: chat
+      max_input_tokens: 200000
+
+litellm_settings:
+  drop_params: true
+  turn_off_message_logging: true
+  redact_user_api_key_info: true
+  request_timeout: 120
+  success_callback: [prometheus]
+  failure_callback: [prometheus]
+
+general_settings:
+  master_key: os.environ/LITELLM_MASTER_KEY
+  database_url: os.environ/DATABASE_URL
+  enforce_user_param: true
+  token_rate_limit_type: total
+  database_connection_pool_limit: 10
+  allow_requests_on_db_unavailable: false
+
+router_settings:
+  routing_strategy: cost-based-routing
+  enable_pre_call_checks: true
+  allowed_fails: 3
+  cooldown_time: 30
+  num_retries: 2
+  retry_policy:
+    RateLimitErrorRetries: 3
+    InternalServerErrorRetries: 2
+    TimeoutErrorRetries: 1
+    AuthenticationErrorRetries: 0
+  fallbacks:
+    - smart: [coding, fast]
+  context_window_fallbacks:
+    - smart: [long-context]
+  default_fallbacks: [smart]
+```
+
+The component should use a YAML serializer rather than hand-concatenating strings. Add a small runtime dependency such as `yaml` to the package if needed.
+
+## Default model taxonomy
+
+The component should make semantic model groups easy, but it should not bake in Jack-specific providers or model names.
+
+Recommended consumer-facing groups:
+
+- `smart`: best general reasoning
+- `coding`: code-heavy work
+- `fast`: low-latency agent loops and everyday chat
+- `cheap`: summarization, extraction, classification, and test traffic
+- `long-context`: large context windows
+- `embedding`: embedding models
+
+Consumers can define any names. The component should only validate references and generate the LiteLLM shape.
+
+## Routing policy
+
+Default policy should optimize for cost with explicit reliability behavior:
+
+- `routing_strategy: cost-based-routing`
+- `enable_pre_call_checks: true`
+- `allowed_fails: 3`
+- `cooldown_time: 30`
+- `num_retries: 2`
+- retry rate limits and 5xx errors
+- do not retry authentication errors
+- model-group fallbacks
+- context-window fallbacks
+- optional `default_fallbacks`
+
+Rationale:
+
+- LiteLLM's `simple-shuffle` is the low-latency production recommendation, but this component is aimed at teams that explicitly want fallback and cost optimization across providers.
+- Cost-sensitive groups should prefer `cost-based-routing`.
+- Latency-sensitive groups can be modeled as separate model groups such as `fast`; if LiteLLM version support for `routing_groups` is confirmed, the component can expose per-group strategies later.
+- Authentication errors should fail loudly. Retrying bad credentials hides a deployment problem.
+
+## Redis behavior
+
+The component should support Redis but not require it for a single-replica deployment.
+
+Rules:
+
+- If `replicas > 1`, Redis SHOULD be required unless `allowMultiReplicaWithoutRedis` is explicitly set.
+- Redis-backed `cache_params` should be used for multi-instance cooldown and rate-limit coordination.
+- `cache_params.supported_call_types: []` should be the default so Redis coordinates proxy state without enabling response caching by accident.
+- `general_settings.use_redis_transaction_buffer: true` should be opt-in. LiteLLM documents it as mandatory for very high RPS or many instances; it is not needed for an initial 1-3 replica deployment unless deadlocks are observed.
+
+## Virtual keys
+
+The component may manage virtual keys, but the key-management implementation should be isolated.
+
+Initial implementation can use the existing pattern from garden:
+
+1. Generate a key in Pulumi when `key` is not provided.
+2. Register it with LiteLLM via `/key/generate` after the Deployment is ready.
+3. Store the generated key as a Pulumi secret output.
+4. Delete the key by token hash on destroy/replacement.
+
+The helper must build JSON with a real JSON encoder, not shell `printf`. Key aliases and metadata can contain quotes. A small Python helper script or a TypeScript command wrapper is acceptable.
+
+Virtual key creation is operationally useful but it increases the component's side effects. If implementation gets too large, split it into two resources:
+
+- `LiteLLMProxy`: Deployment and config
+- `LiteLLMVirtualKey`: key registration against an existing proxy
+
+# Consequences
+
+## Positive
+
+- Garden's LiteLLM stack becomes mostly configuration instead of bespoke deployment code.
+- Other repos can reuse the same gateway pattern without copying a Pulumi stack.
+- Semantic model groups and fallback policy become typed and reviewable.
+- Provider secrets stay out of ConfigMaps and Pulumi previews.
+- The component can enforce hard-won validation before `pulumi up` reaches Kubernetes.
+- Sector7 gains a useful Kubernetes deployment component, not just Cloudflare/Nix utilities.
+
+## Negative
+
+- Sector7 gains Kubernetes dependencies in a new subpath export.
+- The component spans several concerns: Deployment, config generation, secrets, and optional API-side key registration.
+- LiteLLM config settings move fast. The component must avoid over-modeling every upstream knob or it will become stale.
+- Generated virtual keys require imperative API calls after deploy. That is less clean than Kubernetes-only resources, but LiteLLM exposes keys through its database-backed API, not Kubernetes objects.
+
+# Alternatives
+
+## Keep LiteLLM deployment only in garden
+
+Simpler today, but repeats the same mistakes as the bootstrap stack: handwritten YAML, project-specific provider handling, and no reusable validation. This is acceptable for a spike, not for the stable pattern.
+
+## Put only the YAML generator in Sector7
+
+This avoids Kubernetes dependencies, but it leaves every consumer to wire ConfigMaps, Secrets, Deployment args, probes, and Service objects by hand. The deployment mechanics are part of the value. A partial helper would invite inconsistent production setups.
+
+## Helm chart wrapper
+
+LiteLLM has deployment examples and charts, but a Helm wrapper does not solve the main problem: typed model groups, provider-secret mapping, key generation, and Pulumi-native outputs. It also makes validation harder because values are passed into a chart boundary.
+
+## Dynamic provider for the whole proxy
+
+Wrong abstraction. Kubernetes resources should stay Kubernetes resources. Only the LiteLLM API-side key registration needs imperative behavior.
+
+# Security / Privacy / Compliance
+
+- Provider API keys MUST be Kubernetes Secret values and MUST NOT appear in generated `config.yaml`.
+- `databaseUrl` and `masterKey` MUST be treated as Pulumi secrets and mounted through env vars.
+- The default generated config SHOULD set `turn_off_message_logging: true` and `redact_user_api_key_info: true`.
+- Langfuse or other callbacks that store prompts/responses MUST be explicit opt-in.
+- `allow_requests_on_db_unavailable` should default to false. Allowing requests when the DB is unavailable weakens key verification and should only be used in tightly controlled private networks.
+- Consumer virtual keys should support budgets, RPM/TPM limits, model access groups, and expirations.
+
+# Operational Notes
+
+- Liveness probe: `GET /health/liveliness`.
+- Readiness probe: `GET /health/readiness`.
+- Service port: 4000.
+- Use the `litellm-database` image variant when `DATABASE_URL` is set; it includes Prisma and migration tooling.
+- Start with resource limits around the known garden shape: requests `250m` CPU / `512Mi` memory, limits `1` CPU / `2Gi` memory. The 2Gi limit avoids early OOMKilled startup failures while Prisma and LiteLLM initialize.
+- Emit useful outputs:
+  - `proxyUrl`
+  - `namespace`
+  - `serviceName`
+  - `masterKey`
+  - virtual key outputs
+  - generated model names
+- Provide a generated smoke-test command or script in docs:
+  - health check
+  - `/v1/models`
+  - one cheap request
+  - one smart request
+  - forced fallback request using LiteLLM's `mock_testing_fallbacks`
+
+# Status Transitions
+
+- 2026-05-14: Proposed after extracting the garden LiteLLM config design into Sector7.
+
+# Implementation Notes
+
+Proposed file layout:
+
+```text
+packages/sector7/litellm/
+  config.ts
+  config-types.ts
+  index.ts
+  litellm-proxy.ts
+  litellm-virtual-key.ts
+packages/sector7/scripts/
+  litellm-key.sh
+packages/sector7/tests/
+  litellm-config.test.ts
+  litellm-proxy.test.ts
+  litellm-virtual-key.test.ts
+```
+
+Validation should reject:
+
+- duplicate deployment IDs
+- model groups that reference missing deployment IDs
+- fallbacks that reference missing model groups
+- deployments that reference missing providers
+- provider env var name collisions
+- `replicas > 1` without Redis, unless explicitly overridden
+- `databaseUrl` or provider API keys appearing in generated config text
+
+Implementation sequence:
+
+1. Add the ADR and keep the garden note out of garden.
+2. Add config types and pure config generator tests.
+3. Add `LiteLLMProxy` with Namespace, Secret, ConfigMap, Deployment, and Service tests using Pulumi mocks.
+4. Add `LiteLLMVirtualKey` or key support after the Deployment path is stable.
+5. Migrate garden's `deploy/services/litellm` stack to use the Sector7 component.
+6. Fix garden's current `DATABASE_URL` construction during migration. The bootstrap stack has used a literal `***` placeholder in the connection string; the migrated code must use the real password value in the secret.
+
+# References
+
+- LiteLLM routing docs: https://docs.litellm.ai/docs/routing
+- LiteLLM proxy docs: https://docs.litellm.ai/docs/simple_proxy
+- LiteLLM config management: https://docs.litellm.ai/docs/proxy/config_management
+- LiteLLM config settings: https://docs.litellm.ai/docs/proxy/config_settings
+- LiteLLM DB deadlocks / HA setup: https://docs.litellm.ai/docs/proxy/db_deadlocks
+- LiteLLM router architecture: https://docs.litellm.ai/docs/router_architecture
+- LiteLLM user hierarchy: https://docs.litellm.ai/docs/proxy/user_management_heirarchy
+- LiteLLM virtual keys: https://docs.litellm.ai/docs/proxy/virtual_keys
+- LiteLLM users, budgets, and rate limits: https://docs.litellm.ai/docs/proxy/users

--- a/docs/internal/designs/022-litellm-proxy-component.md
+++ b/docs/internal/designs/022-litellm-proxy-component.md
@@ -94,6 +94,7 @@ export interface LiteLLMProxyArgs {
   governance?: LiteLLMGovernancePolicy;
   observability?: LiteLLMObservabilityPolicy;
   redis?: LiteLLMRedisPolicy;
+  allowMultiReplicaWithoutRedis?: pulumi.Input<boolean>;
 
   keys?: Record<string, LiteLLMVirtualKeySpec>;
 
@@ -109,15 +110,16 @@ export interface LiteLLMProviderConfig {
 
 export interface LiteLLMModelDeployment {
   id: string;
-  modelName: string;
   provider: string;
   providerModel: string;
   apiBase?: pulumi.Input<string>;
-  mode?: "chat" | "completion" | "embedding";
+  mode?: "chat" | "completion" | "embedding" | "image_generation" | "audio_transcription" | "audio_speech" | "rerank";
   baseModel?: string;
   accessGroups?: string[];
   rpm?: number;
   tpm?: number;
+  rpd?: number;
+  tpd?: number;
   weight?: number;
   order?: number;
   maxInputTokens?: number;
@@ -134,7 +136,6 @@ export interface LiteLLMModelGroup {
 }
 
 export interface LiteLLMVirtualKeySpec {
-  keyAlias: pulumi.Input<string>;
   key?: pulumi.Input<string>;
   models?: pulumi.Input<pulumi.Input<string>[]>;
   teamId?: pulumi.Input<string>;
@@ -273,7 +274,7 @@ Initial implementation can use the existing pattern from garden:
 3. Store the generated key as a Pulumi secret output.
 4. Delete the key by token hash on destroy/replacement.
 
-The helper must build JSON with a real JSON encoder, not shell `printf`. Key aliases and metadata can contain quotes. A small Python helper script or a TypeScript command wrapper is acceptable.
+The helper must build JSON with a real JSON encoder, not shell `printf`. Key aliases and metadata can contain quotes. A TypeScript command wrapper (using `@pulumi/command`) is preferred to avoid requiring Python in the runtime environment.
 
 Virtual key creation is operationally useful but it increases the component's side effects. If implementation gets too large, split it into two resources:
 

--- a/packages/sector7/barrel-guard.ts
+++ b/packages/sector7/barrel-guard.ts
@@ -1,0 +1,4 @@
+// @ts-expect-error LiteLLM lives on the ./litellm subpath, not the root barrel
+import { litellm } from "./index.ts";
+
+void litellm;

--- a/packages/sector7/litellm/config-types.ts
+++ b/packages/sector7/litellm/config-types.ts
@@ -1,0 +1,109 @@
+import type * as k8s from "@pulumi/kubernetes";
+import type * as pulumi from "@pulumi/pulumi";
+
+export type LiteLLMModelMode = "chat" | "completion" | "embedding";
+
+export interface LiteLLMProviderConfig {
+  apiKey: pulumi.Input<string>;
+  envVar?: string;
+  apiBase?: string;
+}
+
+export interface LiteLLMModelDeployment {
+  id: string;
+  modelName: string;
+  provider: string;
+  providerModel: string;
+  apiBase?: string;
+  mode?: LiteLLMModelMode;
+  baseModel?: string;
+  accessGroups?: string[];
+  rpm?: number;
+  tpm?: number;
+  weight?: number;
+  order?: number;
+  maxInputTokens?: number;
+  inputCostPerToken?: number;
+  outputCostPerToken?: number;
+}
+
+export interface LiteLLMModelGroup {
+  name: string;
+  deploymentIds: string[];
+  fallbacks?: string[];
+  contextWindowFallbacks?: string[];
+  accessGroups?: string[];
+}
+
+export interface LiteLLMObservabilityPolicy {
+  dropParams?: boolean;
+  requestTimeout?: number;
+  turnOffMessageLogging?: boolean;
+  redactUserApiKeyInfo?: boolean;
+  successCallbacks?: string[];
+  failureCallbacks?: string[];
+  serviceCallbacks?: string[];
+}
+
+export interface LiteLLMGovernancePolicy {
+  enforceUserParam?: boolean;
+  tokenRateLimitType?: "input" | "output" | "total";
+  databaseConnectionPoolLimit?: number;
+  allowRequestsOnDbUnavailable?: boolean;
+  globalMaxParallelRequests?: number;
+  maxBudget?: number;
+  budgetDuration?: string;
+  upperboundKeyGenerateParams?: Record<string, number | string | boolean>;
+  defaultKeyGenerateParams?: Record<string, string | number | boolean | string[]>;
+}
+
+export interface LiteLLMRedisPolicy {
+  host: string;
+  port?: number;
+  maxConnections?: number;
+  supportedCallTypes?: string[];
+  useRedisTransactionBuffer?: boolean;
+}
+
+export interface LiteLLMRouterPolicy {
+  routingStrategy?:
+    | "simple-shuffle"
+    | "least-busy"
+    | "latency-based-routing"
+    | "usage-based-routing-v2"
+    | "cost-based-routing";
+  enablePreCallChecks?: boolean;
+  allowedFails?: number;
+  cooldownTime?: number;
+  numRetries?: number;
+  retryPolicy?: Record<string, number>;
+  defaultFallbacks?: string[];
+}
+
+export interface LiteLLMServiceSpec {
+  type?: "ClusterIP" | "NodePort" | "LoadBalancer";
+  port?: number;
+}
+
+export interface LiteLLMProxyArgs {
+  namespace?: pulumi.Input<string>;
+  createNamespace?: boolean;
+  image?: pulumi.Input<string>;
+  replicas?: number;
+  databaseUrl: pulumi.Input<string>;
+  masterKey?: pulumi.Input<string>;
+  providers: Record<string, LiteLLMProviderConfig>;
+  deployments: LiteLLMModelDeployment[];
+  modelGroups: LiteLLMModelGroup[];
+  router?: LiteLLMRouterPolicy;
+  governance?: LiteLLMGovernancePolicy;
+  observability?: LiteLLMObservabilityPolicy;
+  redis?: LiteLLMRedisPolicy;
+  service?: LiteLLMServiceSpec;
+  resources?: k8s.types.input.core.v1.ResourceRequirements;
+}
+
+export interface LiteLLMGeneratedConfig {
+  configYaml: string;
+  providerEnvVars: string[];
+}

--- a/packages/sector7/litellm/config-types.ts
+++ b/packages/sector7/litellm/config-types.ts
@@ -1,7 +1,7 @@
 import type * as k8s from "@pulumi/kubernetes";
 import type * as pulumi from "@pulumi/pulumi";
 
-export type LiteLLMModelMode = "chat" | "completion" | "embedding";
+export type LiteLLMModelMode = "chat" | "completion" | "embedding" | "image_generation" | "audio_transcription" | "audio_speech" | "rerank";
 
 export interface LiteLLMProviderConfig {
   apiKey: pulumi.Input<string>;
@@ -11,7 +11,6 @@ export interface LiteLLMProviderConfig {
 
 export interface LiteLLMModelDeployment {
   id: string;
-  modelName: string;
   provider: string;
   providerModel: string;
   apiBase?: string;
@@ -20,6 +19,8 @@ export interface LiteLLMModelDeployment {
   accessGroups?: string[];
   rpm?: number;
   tpm?: number;
+  rpd?: number;
+  tpd?: number;
   weight?: number;
   order?: number;
   maxInputTokens?: number;

--- a/packages/sector7/litellm/config.ts
+++ b/packages/sector7/litellm/config.ts
@@ -1,0 +1,334 @@
+import { stringify } from "yaml";
+import type {
+  LiteLLMGeneratedConfig,
+  LiteLLMGovernancePolicy,
+  LiteLLMModelDeployment,
+  LiteLLMModelGroup,
+  LiteLLMObservabilityPolicy,
+  LiteLLMProviderConfig,
+  LiteLLMRedisPolicy,
+  LiteLLMRouterPolicy,
+} from "./config-types.ts";
+
+const DEFAULT_OBSERVABILITY: Required<
+  Pick<
+    LiteLLMObservabilityPolicy,
+    | "dropParams"
+    | "requestTimeout"
+    | "turnOffMessageLogging"
+    | "redactUserApiKeyInfo"
+  >
+> = {
+  dropParams: true,
+  requestTimeout: 120,
+  turnOffMessageLogging: true,
+  redactUserApiKeyInfo: true,
+};
+
+const DEFAULT_ROUTER: Required<
+  Pick<
+    LiteLLMRouterPolicy,
+    | "routingStrategy"
+    | "enablePreCallChecks"
+    | "allowedFails"
+    | "cooldownTime"
+    | "numRetries"
+  >
+> = {
+  routingStrategy: "cost-based-routing",
+  enablePreCallChecks: true,
+  allowedFails: 3,
+  cooldownTime: 30,
+  numRetries: 2,
+};
+
+const DEFAULT_GOVERNANCE: Required<
+  Pick<
+    LiteLLMGovernancePolicy,
+    | "enforceUserParam"
+    | "tokenRateLimitType"
+    | "databaseConnectionPoolLimit"
+    | "allowRequestsOnDbUnavailable"
+  >
+> = {
+  enforceUserParam: true,
+  tokenRateLimitType: "total",
+  databaseConnectionPoolLimit: 10,
+  allowRequestsOnDbUnavailable: false,
+};
+
+function toUpperSnakeCase(value: string): string {
+  return value
+    .replace(/[^a-zA-Z0-9]+/g, "_")
+    .replace(/([a-z0-9])([A-Z])/g, "$1_$2")
+    .replace(/_+/g, "_")
+    .replace(/^_+|_+$/g, "")
+    .toUpperCase();
+}
+
+export function getProviderEnvVar(
+  providerName: string,
+  provider: LiteLLMProviderConfig,
+): string {
+  return provider.envVar ?? `${toUpperSnakeCase(providerName)}_API_KEY`;
+}
+
+function addIfDefined(
+  target: Record<string, unknown>,
+  key: string,
+  value: unknown,
+): void {
+  if (value !== undefined) {
+    target[key] = value;
+  }
+}
+
+function buildFallbackMap(
+  groups: LiteLLMModelGroup[],
+  key: "fallbacks" | "contextWindowFallbacks",
+): Array<Record<string, string[]>> {
+  return groups.flatMap((group) => {
+    const targets = key === "fallbacks"
+      ? group.fallbacks
+      : group.contextWindowFallbacks;
+    if (!targets || targets.length === 0) {
+      return [];
+    }
+    return [{ [group.name]: targets }];
+  });
+}
+
+export function validateLiteLLMConfig(args: {
+  replicas?: number;
+  providers: Record<string, LiteLLMProviderConfig>;
+  deployments: LiteLLMModelDeployment[];
+  modelGroups: LiteLLMModelGroup[];
+  redis?: LiteLLMRedisPolicy;
+  router?: LiteLLMRouterPolicy;
+}): void {
+  const deploymentIds = new Set<string>();
+  const groupNames = new Set(args.modelGroups.map((group) => group.name));
+
+  for (const [providerName, provider] of Object.entries(args.providers)) {
+    if (!provider.apiKey) {
+      throw new Error(`LiteLLM provider '${providerName}' is missing apiKey`);
+    }
+  }
+
+  for (const deployment of args.deployments) {
+    if (deploymentIds.has(deployment.id)) {
+      throw new Error(`Duplicate LiteLLM deployment id: ${deployment.id}`);
+    }
+    deploymentIds.add(deployment.id);
+
+    if (!args.providers[deployment.provider]) {
+      throw new Error(
+        `LiteLLM deployment '${deployment.id}' references unknown provider '${deployment.provider}'`,
+      );
+    }
+  }
+
+  for (const group of args.modelGroups) {
+    if (group.deploymentIds.length === 0) {
+      throw new Error(`LiteLLM model group '${group.name}' must reference at least one deployment`);
+    }
+
+    for (const deploymentId of group.deploymentIds) {
+      if (!deploymentIds.has(deploymentId)) {
+        throw new Error(
+          `LiteLLM model group '${group.name}' references missing deployment '${deploymentId}'`,
+        );
+      }
+    }
+
+    for (const fallback of group.fallbacks ?? []) {
+      if (!groupNames.has(fallback)) {
+        throw new Error(
+          `LiteLLM model group '${group.name}' fallback references missing group '${fallback}'`,
+        );
+      }
+    }
+
+    for (const fallback of group.contextWindowFallbacks ?? []) {
+      if (!groupNames.has(fallback)) {
+        throw new Error(
+          `LiteLLM model group '${group.name}' context window fallback references missing group '${fallback}'`,
+        );
+      }
+    }
+  }
+
+  const envVars = new Set<string>();
+  for (const [providerName, provider] of Object.entries(args.providers)) {
+    const envVar = getProviderEnvVar(providerName, provider);
+    if (envVars.has(envVar)) {
+      throw new Error(`Duplicate LiteLLM provider env var: ${envVar}`);
+    }
+    envVars.add(envVar);
+  }
+
+  if ((args.replicas ?? 1) > 1 && !args.redis) {
+    throw new Error(
+      "LiteLLM replicas > 1 require redis configuration for shared cooldown and rate-limit state",
+    );
+  }
+}
+
+export function generateLiteLLMConfig(args: {
+  providers: Record<string, LiteLLMProviderConfig>;
+  deployments: LiteLLMModelDeployment[];
+  modelGroups: LiteLLMModelGroup[];
+  observability?: LiteLLMObservabilityPolicy;
+  governance?: LiteLLMGovernancePolicy;
+  redis?: LiteLLMRedisPolicy;
+  router?: LiteLLMRouterPolicy;
+  replicas?: number;
+}): LiteLLMGeneratedConfig {
+  validateLiteLLMConfig(args);
+
+  const providerEnvVars = Object.entries(args.providers).map(([providerName, provider]) =>
+    getProviderEnvVar(providerName, provider),
+  );
+  const deploymentsById = new Map(
+    args.deployments.map((deployment) => [deployment.id, deployment] as const),
+  );
+
+  const modelList = args.modelGroups.flatMap((group) =>
+    group.deploymentIds.map((deploymentId) => {
+      const deployment = deploymentsById.get(deploymentId);
+      if (!deployment) {
+        throw new Error(`Missing deployment '${deploymentId}' after validation`);
+      }
+
+      const provider = args.providers[deployment.provider];
+      const envVar = getProviderEnvVar(deployment.provider, provider);
+      const litellmParams: Record<string, unknown> = {
+        model: deployment.providerModel,
+        api_key: `os.environ/${envVar}`,
+      };
+      addIfDefined(litellmParams, "api_base", deployment.apiBase ?? provider.apiBase);
+      addIfDefined(litellmParams, "rpm", deployment.rpm);
+      addIfDefined(litellmParams, "tpm", deployment.tpm);
+      addIfDefined(litellmParams, "weight", deployment.weight);
+      addIfDefined(litellmParams, "order", deployment.order);
+
+      const accessGroups = new Set<string>([
+        ...(deployment.accessGroups ?? []),
+        ...(group.accessGroups ?? []),
+      ]);
+
+      const modelInfo: Record<string, unknown> = {
+        id: deployment.id,
+      };
+      addIfDefined(modelInfo, "base_model", deployment.baseModel ?? deployment.providerModel);
+      addIfDefined(modelInfo, "access_groups", accessGroups.size > 0 ? [...accessGroups] : undefined);
+      addIfDefined(modelInfo, "mode", deployment.mode);
+      addIfDefined(modelInfo, "max_input_tokens", deployment.maxInputTokens);
+      addIfDefined(modelInfo, "input_cost_per_token", deployment.inputCostPerToken);
+      addIfDefined(modelInfo, "output_cost_per_token", deployment.outputCostPerToken);
+
+      return {
+        model_name: group.name,
+        litellm_params: litellmParams,
+        model_info: modelInfo,
+      };
+    }),
+  );
+
+  const observability = {
+    ...DEFAULT_OBSERVABILITY,
+    ...args.observability,
+  };
+
+  const litellmSettings: Record<string, unknown> = {
+    drop_params: observability.dropParams,
+    turn_off_message_logging: observability.turnOffMessageLogging,
+    redact_user_api_key_info: observability.redactUserApiKeyInfo,
+    request_timeout: observability.requestTimeout,
+  };
+  addIfDefined(litellmSettings, "success_callback", args.observability?.successCallbacks);
+  addIfDefined(litellmSettings, "failure_callback", args.observability?.failureCallbacks);
+  addIfDefined(litellmSettings, "service_callbacks", args.observability?.serviceCallbacks);
+
+  if (args.redis) {
+    litellmSettings.cache = true;
+    litellmSettings.cache_params = {
+      type: "redis",
+      host: args.redis.host,
+      port: args.redis.port ?? 6379,
+      supported_call_types: args.redis.supportedCallTypes ?? [],
+      ...(args.redis.maxConnections !== undefined
+        ? { max_connections: args.redis.maxConnections }
+        : {}),
+    };
+  }
+
+  const governance = {
+    ...DEFAULT_GOVERNANCE,
+    ...args.governance,
+  };
+  addIfDefined(litellmSettings, "max_budget", args.governance?.maxBudget);
+  addIfDefined(litellmSettings, "budget_duration", args.governance?.budgetDuration);
+  addIfDefined(
+    litellmSettings,
+    "upperbound_key_generate_params",
+    args.governance?.upperboundKeyGenerateParams,
+  );
+  addIfDefined(
+    litellmSettings,
+    "default_key_generate_params",
+    args.governance?.defaultKeyGenerateParams,
+  );
+
+  const generalSettings: Record<string, unknown> = {
+    master_key: "os.environ/LITELLM_MASTER_KEY",
+    database_url: "os.environ/DATABASE_URL",
+    enforce_user_param: governance.enforceUserParam,
+    token_rate_limit_type: governance.tokenRateLimitType,
+    database_connection_pool_limit: governance.databaseConnectionPoolLimit,
+    allow_requests_on_db_unavailable: governance.allowRequestsOnDbUnavailable,
+  };
+  addIfDefined(generalSettings, "global_max_parallel_requests", args.governance?.globalMaxParallelRequests);
+  addIfDefined(generalSettings, "use_redis_transaction_buffer", args.redis?.useRedisTransactionBuffer);
+
+  const router = {
+    ...DEFAULT_ROUTER,
+    ...args.router,
+  };
+  const routerSettings: Record<string, unknown> = {
+    routing_strategy: router.routingStrategy,
+    enable_pre_call_checks: router.enablePreCallChecks,
+    allowed_fails: router.allowedFails,
+    cooldown_time: router.cooldownTime,
+    num_retries: router.numRetries,
+  };
+  addIfDefined(routerSettings, "retry_policy", args.router?.retryPolicy);
+  addIfDefined(routerSettings, "default_fallbacks", args.router?.defaultFallbacks);
+
+  const fallbacks = buildFallbackMap(args.modelGroups, "fallbacks");
+  if (fallbacks.length > 0) {
+    routerSettings.fallbacks = fallbacks;
+  }
+  const contextWindowFallbacks = buildFallbackMap(args.modelGroups, "contextWindowFallbacks");
+  if (contextWindowFallbacks.length > 0) {
+    routerSettings.context_window_fallbacks = contextWindowFallbacks;
+  }
+
+  const configYaml = stringify(
+    {
+      model_list: modelList,
+      litellm_settings: litellmSettings,
+      general_settings: generalSettings,
+      router_settings: routerSettings,
+    },
+    {
+      aliasDuplicateObjects: false,
+      lineWidth: 0,
+    },
+  );
+
+  return {
+    configYaml,
+    providerEnvVars,
+  };
+}

--- a/packages/sector7/litellm/config.ts
+++ b/packages/sector7/litellm/config.ts
@@ -110,6 +110,8 @@ export function validateLiteLLMConfig(args: {
   const groupNames = new Set(args.modelGroups.map((group) => group.name));
 
   for (const [providerName, provider] of Object.entries(args.providers)) {
+    // Note: apiKey is pulumi.Input<string>; we cannot validate its runtime value here.
+    // This check only ensures the property exists (non‑null/undefined).
     if (!provider.apiKey) {
       throw new Error(`LiteLLM provider '${providerName}' is missing apiKey`);
     }

--- a/packages/sector7/litellm/index.ts
+++ b/packages/sector7/litellm/index.ts
@@ -1,0 +1,14 @@
+export { LiteLLMProxy } from "./litellm-proxy.ts";
+export type {
+	LiteLLMGeneratedConfig,
+	LiteLLMGovernancePolicy,
+	LiteLLMModelDeployment,
+	LiteLLMModelGroup,
+	LiteLLMObservabilityPolicy,
+	LiteLLMProviderConfig,
+	LiteLLMProxyArgs,
+	LiteLLMRedisPolicy,
+	LiteLLMRouterPolicy,
+	LiteLLMServiceSpec,
+} from "./config-types.ts";
+export { generateLiteLLMConfig } from "./config.ts";

--- a/packages/sector7/litellm/litellm-proxy.ts
+++ b/packages/sector7/litellm/litellm-proxy.ts
@@ -1,0 +1,278 @@
+import * as k8s from "@pulumi/kubernetes";
+import * as pulumi from "@pulumi/pulumi";
+import * as random from "@pulumi/random";
+import {
+  generateLiteLLMConfig,
+  getProviderEnvVar,
+} from "./config.ts";
+import type {
+  LiteLLMProxyArgs,
+  LiteLLMProviderConfig,
+} from "./config-types.ts";
+
+function toSecretKey(envVar: string): string {
+  return envVar.toLowerCase();
+}
+
+function buildProviderStringData(
+  providers: Record<string, LiteLLMProviderConfig>,
+): pulumi.Output<Record<string, string>> {
+  const entries = Object.entries(providers);
+  return pulumi.all(entries.map(([, provider]) => provider.apiKey)).apply((values) =>
+    Object.fromEntries(
+      entries.map(([providerName, provider], index) => {
+        const envVar = getProviderEnvVar(providerName, provider);
+        return [toSecretKey(envVar), values[index] as string];
+      }),
+    ),
+  );
+}
+
+export class LiteLLMProxy extends pulumi.ComponentResource {
+  public readonly namespaceResource: k8s.core.v1.Namespace | undefined;
+  public readonly providerSecret: k8s.core.v1.Secret;
+  public readonly runtimeSecret: k8s.core.v1.Secret;
+  public readonly configMap: k8s.core.v1.ConfigMap;
+  public readonly deployment: k8s.apps.v1.Deployment;
+  public readonly service: k8s.core.v1.Service;
+  public readonly namespace: pulumi.Output<string>;
+  public readonly proxyUrl: pulumi.Output<string>;
+  public readonly masterKey: pulumi.Output<string>;
+  public readonly configYaml: pulumi.Output<string>;
+
+  constructor(name: string, args: LiteLLMProxyArgs, opts?: pulumi.ComponentResourceOptions) {
+    super("sector7:kubernetes:LiteLLMProxy", name, args, opts);
+
+    const createNamespace = args.createNamespace ?? true;
+    const namespaceName = pulumi.output(args.namespace ?? name);
+    const image = args.image ?? "ghcr.io/berriai/litellm-database:main-stable";
+    const replicas = args.replicas ?? 1;
+    const servicePort = args.service?.port ?? 4000;
+
+    const generatedConfig = generateLiteLLMConfig({
+      providers: args.providers,
+      deployments: args.deployments,
+      modelGroups: args.modelGroups,
+      observability: args.observability,
+      governance: args.governance,
+      redis: args.redis,
+      router: args.router,
+      replicas,
+    });
+
+    this.configYaml = pulumi.output(generatedConfig.configYaml);
+
+    this.namespaceResource = createNamespace
+      ? new k8s.core.v1.Namespace(
+          `${name}-ns`,
+          {
+            metadata: {
+              name: namespaceName,
+              labels: {
+                "app.kubernetes.io/name": "litellm",
+                "app.kubernetes.io/component": "proxy",
+                "app.kubernetes.io/managed-by": "pulumi",
+              },
+            },
+          },
+          { ...opts, parent: this },
+        )
+      : undefined;
+
+    this.namespace = this.namespaceResource?.metadata.name ?? namespaceName;
+
+    const parentAndProvider = { ...opts, parent: this };
+
+    this.providerSecret = new k8s.core.v1.Secret(
+      `${name}-providers`,
+      {
+        metadata: {
+          name: `${name}-provider-keys`,
+          namespace: this.namespace,
+        },
+        stringData: buildProviderStringData(args.providers),
+      },
+      parentAndProvider,
+    );
+
+    const generatedMasterKey = new random.RandomPassword(
+      `${name}-master-key`,
+      {
+        length: 32,
+        special: false,
+      },
+      { parent: this },
+    ).result;
+    this.masterKey = pulumi.output(args.masterKey ?? generatedMasterKey);
+
+    this.runtimeSecret = new k8s.core.v1.Secret(
+      `${name}-runtime`,
+      {
+        metadata: {
+          name: `${name}-runtime`,
+          namespace: this.namespace,
+        },
+        stringData: pulumi.all([this.masterKey, args.databaseUrl]).apply(([masterKey, databaseUrl]) => ({
+          LITELLM_MASTER_KEY: masterKey,
+          DATABASE_URL: databaseUrl,
+        })),
+      },
+      parentAndProvider,
+    );
+
+    this.configMap = new k8s.core.v1.ConfigMap(
+      `${name}-config`,
+      {
+        metadata: {
+          name: `${name}-config`,
+          namespace: this.namespace,
+        },
+        data: {
+          "config.yaml": this.configYaml,
+        },
+      },
+      parentAndProvider,
+    );
+
+    const appLabels = {
+      "app.kubernetes.io/name": "litellm",
+      "app.kubernetes.io/component": "proxy",
+      "app.kubernetes.io/instance": name,
+    };
+
+    const env = [
+      {
+        name: "LITELLM_MASTER_KEY",
+        valueFrom: {
+          secretKeyRef: {
+            name: this.runtimeSecret.metadata.name,
+            key: "LITELLM_MASTER_KEY",
+          },
+        },
+      },
+      {
+        name: "DATABASE_URL",
+        valueFrom: {
+          secretKeyRef: {
+            name: this.runtimeSecret.metadata.name,
+            key: "DATABASE_URL",
+          },
+        },
+      },
+      ...Object.entries(args.providers).map(([providerName, provider]) => {
+        const envVar = getProviderEnvVar(providerName, provider);
+        return {
+          name: envVar,
+          valueFrom: {
+            secretKeyRef: {
+              name: this.providerSecret.metadata.name,
+              key: toSecretKey(envVar),
+            },
+          },
+        };
+      }),
+    ];
+
+    this.deployment = new k8s.apps.v1.Deployment(
+      `${name}-deployment`,
+      {
+        metadata: {
+          name,
+          namespace: this.namespace,
+          labels: appLabels,
+        },
+        spec: {
+          replicas,
+          selector: {
+            matchLabels: appLabels,
+          },
+          template: {
+            metadata: {
+              labels: appLabels,
+            },
+            spec: {
+              containers: [
+                {
+                  name: "litellm",
+                  image,
+                  args: ["--config", "/app/config.yaml"],
+                  ports: [{ containerPort: servicePort }],
+                  env,
+                  volumeMounts: [
+                    {
+                      name: "config-volume",
+                      mountPath: "/app/config.yaml",
+                      subPath: "config.yaml",
+                      readOnly: true,
+                    },
+                  ],
+                  livenessProbe: {
+                    httpGet: { path: "/health/liveliness", port: servicePort },
+                    initialDelaySeconds: 120,
+                    periodSeconds: 15,
+                    timeoutSeconds: 10,
+                    failureThreshold: 3,
+                  },
+                  readinessProbe: {
+                    httpGet: { path: "/health/readiness", port: servicePort },
+                    initialDelaySeconds: 30,
+                    periodSeconds: 15,
+                    timeoutSeconds: 10,
+                    failureThreshold: 3,
+                  },
+                  resources: args.resources ?? {
+                    requests: { cpu: "250m", memory: "512Mi" },
+                    limits: { cpu: "1", memory: "2Gi" },
+                  },
+                },
+              ],
+              volumes: [
+                {
+                  name: "config-volume",
+                  configMap: {
+                    name: this.configMap.metadata.name,
+                  },
+                },
+              ],
+            },
+          },
+        },
+      },
+      parentAndProvider,
+    );
+
+    this.service = new k8s.core.v1.Service(
+      `${name}-service`,
+      {
+        metadata: {
+          name,
+          namespace: this.namespace,
+          labels: appLabels,
+        },
+        spec: {
+          type: args.service?.type ?? "ClusterIP",
+          selector: appLabels,
+          ports: [
+            {
+              name: "http",
+              port: servicePort,
+              targetPort: servicePort,
+              protocol: "TCP",
+            },
+          ],
+        },
+      },
+      parentAndProvider,
+    );
+
+    this.proxyUrl = pulumi.interpolate`http://${this.service.metadata.name}.${this.namespace}.svc.cluster.local:${servicePort}`;
+
+    this.registerOutputs({
+      namespace: this.namespace,
+      proxyUrl: this.proxyUrl,
+      masterKey: this.masterKey,
+      configYaml: this.configYaml,
+      serviceName: this.service.metadata.name,
+    });
+  }
+}

--- a/packages/sector7/litellm/litellm-proxy.ts
+++ b/packages/sector7/litellm/litellm-proxy.ts
@@ -103,7 +103,7 @@ export class LiteLLMProxy extends pulumi.ComponentResource {
       },
       { parent: this },
     ).result;
-    this.masterKey = pulumi.output(args.masterKey ?? generatedMasterKey);
+    this.masterKey = pulumi.secret(pulumi.output(args.masterKey ?? generatedMasterKey));
 
     this.runtimeSecret = new k8s.core.v1.Secret(
       `${name}-runtime`,
@@ -208,7 +208,7 @@ export class LiteLLMProxy extends pulumi.ComponentResource {
                   ],
                   livenessProbe: {
                     httpGet: { path: "/health/liveliness", port: servicePort },
-                    initialDelaySeconds: 120,
+                    initialDelaySeconds: 180,
                     periodSeconds: 15,
                     timeoutSeconds: 10,
                     failureThreshold: 3,

--- a/packages/sector7/package.json
+++ b/packages/sector7/package.json
@@ -50,6 +50,10 @@
     "./d1": {
       "types": "./dist/d1/index.d.ts",
       "default": "./dist/d1/index.js"
+    },
+    "./litellm": {
+      "types": "./dist/litellm/index.d.ts",
+      "default": "./dist/litellm/index.js"
     }
   },
   "files": [
@@ -67,13 +71,20 @@
     "@pulumi/pulumi": "^3.0.0",
     "@pulumi/cloudflare": "^6.0.0",
     "@pulumi/gcp": "^9.0.0",
-    "@pulumi/command": "^1.0.0"
+    "@pulumi/command": "^1.0.0",
+    "@pulumi/kubernetes": "^4.0.0",
+    "@pulumi/random": "^4.0.0"
+  },
+  "dependencies": {
+    "yaml": "^2.8.1"
   },
   "devDependencies": {
     "@pulumi/pulumi": "3.234.0",
     "@pulumi/cloudflare": "6.15.0",
     "@pulumi/gcp": "9.22.0",
     "@pulumi/command": "1.2.1",
+    "@pulumi/kubernetes": "4.24.0",
+    "@pulumi/random": "4.18.3",
     "rimraf": "6.1.3",
     "typescript": "5.9.3",
     "vitest": "4.1.2"

--- a/packages/sector7/tests/litellm-config.test.ts
+++ b/packages/sector7/tests/litellm-config.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from "vitest";
+import { parse } from "yaml";
+import { generateLiteLLMConfig } from "../litellm/config.ts";
+
+describe("generateLiteLLMConfig", () => {
+	it("generates grouped model config with fallbacks and env-based secrets", () => {
+		const generated = generateLiteLLMConfig({
+			providers: {
+				anthropic: { apiKey: "anthropic-secret" },
+				openai: { apiKey: "openai-secret", apiBase: "https://api.openai.example/v1" },
+			},
+			deployments: [
+				{
+					id: "anthropic-smart",
+					modelName: "smart",
+					provider: "anthropic",
+					providerModel: "anthropic/claude-sonnet-4-20250514",
+					mode: "chat",
+					accessGroups: ["premium"],
+					maxInputTokens: 200000,
+				},
+				{
+					id: "openai-fast",
+					modelName: "fast",
+					provider: "openai",
+					providerModel: "openai/gpt-4o-mini",
+					mode: "chat",
+					rpm: 500,
+					tpm: 200000,
+				},
+			],
+			modelGroups: [
+				{
+					name: "smart",
+					deploymentIds: ["anthropic-smart"],
+					fallbacks: ["fast"],
+					contextWindowFallbacks: ["long-context"],
+					accessGroups: ["core"],
+				},
+				{
+					name: "fast",
+					deploymentIds: ["openai-fast"],
+				},
+				{
+					name: "long-context",
+					deploymentIds: ["anthropic-smart"],
+				},
+			],
+			router: {
+				defaultFallbacks: ["smart"],
+				retryPolicy: { RateLimitErrorRetries: 3 },
+			},
+			governance: {
+				maxBudget: 500,
+				budgetDuration: "30d",
+			},
+		});
+
+		expect(generated.providerEnvVars).toEqual(["ANTHROPIC_API_KEY", "OPENAI_API_KEY"]);
+		expect(generated.configYaml).not.toContain("anthropic-secret");
+		expect(generated.configYaml).not.toContain("openai-secret");
+
+		const parsed = parse(generated.configYaml) as Record<string, unknown>;
+		const modelList = parsed.model_list as Array<Record<string, unknown>>;
+		expect(modelList).toHaveLength(3);
+		expect(modelList[0].model_name).toBe("smart");
+		expect((modelList[0].litellm_params as Record<string, unknown>).api_key).toBe("os.environ/ANTHROPIC_API_KEY");
+		expect((modelList[0].model_info as Record<string, unknown>).access_groups).toEqual(["premium", "core"]);
+
+		const routerSettings = parsed.router_settings as Record<string, unknown>;
+		expect(routerSettings.routing_strategy).toBe("cost-based-routing");
+		expect(routerSettings.fallbacks).toEqual([{ smart: ["fast"] }]);
+		expect(routerSettings.context_window_fallbacks).toEqual([{ smart: ["long-context"] }]);
+		expect(routerSettings.default_fallbacks).toEqual(["smart"]);
+
+		const generalSettings = parsed.general_settings as Record<string, unknown>;
+		expect(generalSettings.database_url).toBe("os.environ/DATABASE_URL");
+		expect(generalSettings.master_key).toBe("os.environ/LITELLM_MASTER_KEY");
+	});
+
+	it("rejects missing deployment references and multi-replica without redis", () => {
+		expect(() =>
+			generateLiteLLMConfig({
+				providers: { anthropic: { apiKey: "secret" } },
+				deployments: [
+					{
+						id: "dep-1",
+						modelName: "smart",
+						provider: "anthropic",
+						providerModel: "anthropic/claude-sonnet-4-20250514",
+					},
+				],
+				modelGroups: [{ name: "smart", deploymentIds: ["missing-deployment"] }],
+			}),
+		).toThrow(/missing deployment/i);
+
+		expect(() =>
+			generateLiteLLMConfig({
+				providers: { anthropic: { apiKey: "secret" } },
+				deployments: [
+					{
+						id: "dep-1",
+						modelName: "smart",
+						provider: "anthropic",
+						providerModel: "anthropic/claude-sonnet-4-20250514",
+					},
+				],
+				modelGroups: [{ name: "smart", deploymentIds: ["dep-1"] }],
+				replicas: 2,
+			}),
+		).toThrow(/replicas > 1 require redis/i);
+	});
+});

--- a/packages/sector7/tests/litellm-proxy.test.ts
+++ b/packages/sector7/tests/litellm-proxy.test.ts
@@ -1,0 +1,163 @@
+import * as pulumi from "@pulumi/pulumi";
+import { beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { LiteLLMProxy } from "../litellm/litellm-proxy.ts";
+
+type MockResource = {
+	type: string;
+	name: string;
+	inputs: Record<string, unknown>;
+};
+
+const resources: MockResource[] = [];
+
+beforeAll(() => {
+	pulumi.runtime.setMocks({
+		newResource: (args) => {
+			const state = { ...(args.inputs as Record<string, unknown>) };
+			if (args.type === "random:index/randomPassword:RandomPassword") {
+				state.result = "generated-master-key";
+			}
+			resources.push({
+				type: args.type,
+				name: args.name,
+				inputs: state,
+			});
+			return {
+				id: `${args.name}-id`,
+				state,
+			};
+		},
+		call: (args) => args.inputs,
+	});
+});
+
+beforeEach(() => {
+	resources.length = 0;
+});
+
+function resolveOutput<T>(value: pulumi.Input<T>): Promise<T> {
+	return new Promise((resolve) => {
+		pulumi.output(value).apply((resolved) => {
+			resolve(resolved as T);
+			return resolved;
+		});
+	});
+}
+
+function findResource(name: string): MockResource | undefined {
+	return resources.find((resource) => resource.name === name);
+}
+
+describe("LiteLLMProxy", () => {
+	it("creates namespace, secrets, configmap, deployment, and service", async () => {
+		const proxy = new LiteLLMProxy("team-proxy", {
+			namespace: "litellm-prod",
+			providers: {
+				anthropic: { apiKey: pulumi.secret("anthropic-secret") },
+				openai: {
+					apiKey: pulumi.secret("openai-secret"),
+					apiBase: "https://api.openai.example/v1",
+				},
+			},
+			deployments: [
+				{
+					id: "anthropic-smart",
+					modelName: "smart",
+					provider: "anthropic",
+					providerModel: "anthropic/claude-sonnet-4-20250514",
+					mode: "chat",
+				},
+				{
+					id: "openai-fast",
+					modelName: "fast",
+					provider: "openai",
+					providerModel: "openai/gpt-4o-mini",
+					mode: "chat",
+				},
+			],
+			modelGroups: [
+				{ name: "smart", deploymentIds: ["anthropic-smart"], fallbacks: ["fast"] },
+				{ name: "fast", deploymentIds: ["openai-fast"] },
+			],
+			databaseUrl: pulumi.secret("postgres://db-user:real-pass@db.internal/litellm"),
+		});
+
+		await Promise.all([
+			resolveOutput(proxy.proxyUrl),
+			resolveOutput(proxy.masterKey),
+			resolveOutput(proxy.configYaml),
+			resolveOutput(proxy.providerSecret.id),
+			resolveOutput(proxy.runtimeSecret.id),
+			resolveOutput(proxy.configMap.id),
+			resolveOutput(proxy.deployment.id),
+			resolveOutput(proxy.service.id),
+		]);
+
+		expect(await resolveOutput(proxy.proxyUrl)).toBe(
+			"http://team-proxy.litellm-prod.svc.cluster.local:4000",
+		);
+		expect(await resolveOutput(proxy.masterKey)).toBe("generated-master-key");
+
+		const namespace = findResource("team-proxy-ns");
+		expect(namespace?.type).toBe("kubernetes:core/v1:Namespace");
+
+		const providerSecret = findResource("team-proxy-providers");
+		expect(providerSecret?.type).toBe("kubernetes:core/v1:Secret");
+		const providerSecretData = providerSecret?.inputs.stringData as {
+			value: Record<string, string>;
+		};
+		expect(providerSecretData.value).toEqual({
+			anthropic_api_key: "anthropic-secret",
+			openai_api_key: "openai-secret",
+		});
+
+		const runtimeSecret = findResource("team-proxy-runtime");
+		const runtimeSecretData = runtimeSecret?.inputs.stringData as {
+			value: Record<string, string>;
+		};
+		expect(runtimeSecretData.value).toEqual({
+			LITELLM_MASTER_KEY: "generated-master-key",
+			DATABASE_URL: "postgres://db-user:real-pass@db.internal/litellm",
+		});
+
+		const configMap = findResource("team-proxy-config");
+		const configYaml = (configMap?.inputs.data as Record<string, string>)["config.yaml"];
+		expect(configYaml).toContain("model_name: smart");
+		expect(configYaml).toContain("os.environ/ANTHROPIC_API_KEY");
+		expect(configYaml).toContain("database_url: os.environ/DATABASE_URL");
+		expect(configYaml).not.toContain("real-pass");
+
+		const deployment = findResource("team-proxy-deployment");
+		expect(deployment?.type).toBe("kubernetes:apps/v1:Deployment");
+		expect(deployment?.inputs.metadata).toMatchObject({
+			name: "team-proxy",
+			namespace: "litellm-prod",
+		});
+
+		const service = findResource("team-proxy-service");
+		expect(service?.type).toBe("kubernetes:core/v1:Service");
+	});
+
+	it("can skip namespace creation", async () => {
+		const proxy = new LiteLLMProxy("shared-proxy", {
+			createNamespace: false,
+			namespace: "shared-services",
+			providers: { anthropic: { apiKey: pulumi.secret("anthropic-secret") } },
+			deployments: [
+				{
+					id: "anthropic-smart",
+					modelName: "smart",
+					provider: "anthropic",
+					providerModel: "anthropic/claude-sonnet-4-20250514",
+				},
+			],
+			modelGroups: [{ name: "smart", deploymentIds: ["anthropic-smart"] }],
+			databaseUrl: pulumi.secret("postgres://db-user:real-pass@db.internal/litellm"),
+		});
+
+		await resolveOutput(proxy.proxyUrl);
+
+		expect(findResource("shared-proxy-ns")).toBeUndefined();
+		expect(await resolveOutput(proxy.namespace)).toBe("shared-services");
+	});
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,9 +19,13 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 4.1.2
-        version: 4.1.2(@opentelemetry/api@1.9.0)(@types/node@24.12.3)(vite@7.3.1(@types/node@24.12.3))
+        version: 4.1.2(@opentelemetry/api@1.9.0)(@types/node@24.12.3)(vite@7.3.1(@types/node@24.12.3)(yaml@2.9.0))
 
   packages/sector7:
+    dependencies:
+      yaml:
+        specifier: ^2.8.1
+        version: 2.9.0
     devDependencies:
       '@pulumi/cloudflare':
         specifier: 6.15.0
@@ -32,9 +36,15 @@ importers:
       '@pulumi/gcp':
         specifier: 9.22.0
         version: 9.22.0(typescript@5.9.3)
+      '@pulumi/kubernetes':
+        specifier: 4.24.0
+        version: 4.24.0(typescript@5.9.3)
       '@pulumi/pulumi':
         specifier: 3.234.0
         version: 3.234.0(typescript@5.9.3)
+      '@pulumi/random':
+        specifier: 4.18.3
+        version: 4.18.3(typescript@5.9.3)
       rimraf:
         specifier: 6.1.3
         version: 6.1.3
@@ -43,7 +53,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 4.1.2
-        version: 4.1.2(@opentelemetry/api@1.9.0)(@types/node@24.12.3)(vite@7.3.1(@types/node@24.12.3))
+        version: 4.1.2(@opentelemetry/api@1.9.0)(@types/node@24.12.3)(vite@7.3.1(@types/node@24.12.3)(yaml@2.9.0))
 
 packages:
 
@@ -458,6 +468,9 @@ packages:
   '@pulumi/gcp@9.22.0':
     resolution: {integrity: sha512-uiQlH0MkT8LwLOiVfPOXGI3I0GIen/j8aL/FIhc379+RUVDd+5153xkd6hgQEwZikRrWKMUn1K0uyM4iTlPCqw==}
 
+  '@pulumi/kubernetes@4.24.0':
+    resolution: {integrity: sha512-6aWo91xWpCMQe7kv9DGiVGXN0doYu/h98joEHPDc9gTpckSNkctGeRCZ0KKpBU0RLk9Ig+MVdx48WbY467GD8A==}
+
   '@pulumi/pulumi@3.234.0':
     resolution: {integrity: sha512-g9tXFsk0gGkZUV1fjy45b+yRRr2ydSzyt0ZcnUjOzG8K4A0d/gzP82Og6IAcifU5Lv6InyDdONw4nRrJrTj+5Q==}
     engines: {node: '>=20'}
@@ -469,6 +482,9 @@ packages:
         optional: true
       typescript:
         optional: true
+
+  '@pulumi/random@4.18.3':
+    resolution: {integrity: sha512-2OKJPNTZu0YyxOMvxnHiUzh3qGm5EowIffAx9dKNUQRQLHOqm3TM2HQ0jYMQUrydrRbXopaiRavFFPD0QKyJEg==}
 
   '@rollup/rollup-android-arm-eabi@4.59.0':
     resolution: {integrity: sha512-upnNBkA6ZH2VKGcBj9Fyl9IGNPULcjXRlg0LLeaioQWueH30p6IXtJEbKAgvyv+mJaMxSm1l6xwDXYjpEMiLMg==}
@@ -1333,6 +1349,10 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
+  shell-quote@1.8.3:
+    resolution: {integrity: sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==}
+    engines: {node: '>= 0.4'}
+
   shimmer@1.2.1:
     resolution: {integrity: sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw==}
 
@@ -1603,6 +1623,11 @@ packages:
   yallist@5.0.0:
     resolution: {integrity: sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==}
     engines: {node: '>=18'}
+
+  yaml@2.9.0:
+    resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
+    engines: {node: '>= 14.6'}
+    hasBin: true
 
   yargs-parser@21.1.1:
     resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
@@ -2051,6 +2076,16 @@ snapshots:
       - ts-node
       - typescript
 
+  '@pulumi/kubernetes@4.24.0(typescript@5.9.3)':
+    dependencies:
+      '@pulumi/pulumi': 3.234.0(typescript@5.9.3)
+      glob: 10.5.0
+      shell-quote: 1.8.3
+    transitivePeerDependencies:
+      - supports-color
+      - ts-node
+      - typescript
+
   '@pulumi/pulumi@3.234.0(typescript@5.9.3)':
     dependencies:
       '@grpc/grpc-js': 1.14.3
@@ -2084,6 +2119,14 @@ snapshots:
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
+
+  '@pulumi/random@4.18.3(typescript@5.9.3)':
+    dependencies:
+      '@pulumi/pulumi': 3.234.0(typescript@5.9.3)
+    transitivePeerDependencies:
+      - supports-color
+      - ts-node
+      - typescript
 
   '@rollup/rollup-android-arm-eabi@4.59.0':
     optional: true
@@ -2281,13 +2324,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.2(vite@7.3.1(@types/node@24.12.3))':
+  '@vitest/mocker@4.1.2(vite@7.3.1(@types/node@24.12.3)(yaml@2.9.0))':
     dependencies:
       '@vitest/spy': 4.1.2
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.1(@types/node@24.12.3)
+      vite: 7.3.1(@types/node@24.12.3)(yaml@2.9.0)
 
   '@vitest/pretty-format@4.1.2':
     dependencies:
@@ -2955,6 +2998,8 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
+  shell-quote@1.8.3: {}
+
   shimmer@1.2.1: {}
 
   siginfo@2.0.0: {}
@@ -3099,7 +3144,7 @@ snapshots:
 
   validate-npm-package-name@7.0.2: {}
 
-  vite@7.3.1(@types/node@24.12.3):
+  vite@7.3.1(@types/node@24.12.3)(yaml@2.9.0):
     dependencies:
       esbuild: 0.27.4
       fdir: 6.5.0(picomatch@4.0.3)
@@ -3110,11 +3155,12 @@ snapshots:
     optionalDependencies:
       '@types/node': 24.12.3
       fsevents: 2.3.3
+      yaml: 2.9.0
 
-  vitest@4.1.2(@opentelemetry/api@1.9.0)(@types/node@24.12.3)(vite@7.3.1(@types/node@24.12.3)):
+  vitest@4.1.2(@opentelemetry/api@1.9.0)(@types/node@24.12.3)(vite@7.3.1(@types/node@24.12.3)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.2
-      '@vitest/mocker': 4.1.2(vite@7.3.1(@types/node@24.12.3))
+      '@vitest/mocker': 4.1.2(vite@7.3.1(@types/node@24.12.3)(yaml@2.9.0))
       '@vitest/pretty-format': 4.1.2
       '@vitest/runner': 4.1.2
       '@vitest/snapshot': 4.1.2
@@ -3131,7 +3177,7 @@ snapshots:
       tinyexec: 1.1.1
       tinyglobby: 0.2.15
       tinyrainbow: 3.1.0
-      vite: 7.3.1(@types/node@24.12.3)
+      vite: 7.3.1(@types/node@24.12.3)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@opentelemetry/api': 1.9.0
@@ -3179,6 +3225,8 @@ snapshots:
   yallist@4.0.0: {}
 
   yallist@5.0.0: {}
+
+  yaml@2.9.0: {}
 
   yargs-parser@21.1.1: {}
 


### PR DESCRIPTION
## Summary

- implements `@jmmaloney4/sector7/litellm` as a new LiteLLM proxy subpath export
- adds a typed config generator that emits `config.yaml` for grouped models, fallbacks, routing, budgets, and observability defaults
- adds a `LiteLLMProxy` Kubernetes component that creates the namespace, config map, provider secrets, runtime secret, deployment, service, and generated master key
- adds focused tests for config generation and the Pulumi component wiring

## Test plan

- [x] `cd packages/sector7 && pnpm test`
- [x] `cd packages/sector7 && pnpm build`

## Risks

- this is intentionally phase 1 of the LiteLLM component boundary. It does not yet manage virtual key lifecycle through the LiteLLM API.
- multi-replica deployments require Redis and the config generator now enforces that invariant. Consumers that want HA need to wire Redis explicitly.
- database provisioning still belongs in the consumer stack. This component expects a working `DATABASE_URL`.

## Follow-up

- add a small `LiteLLMVirtualKey` resource once we decide how much of user/team/key lifecycle belongs in Sector7 versus the consumer stack
- migrate garden `deploy/services/litellm` to consume this component and replace its current handwritten config generation
- decide whether the root package barrel should ever expose `litellm`, or whether keeping it subpath-only remains the right dependency boundary

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new Kubernetes-facing Pulumi component plus config generation/validation and new runtime dependencies (`@pulumi/kubernetes`, `@pulumi/random`, `yaml`), which could affect consumers and deployment behavior if misconfigured.
> 
> **Overview**
> Adds a new `@jmmaloney4/sector7/litellm` subpath export that provides a typed LiteLLM `config.yaml` generator (with defaults for routing/governance/observability, fallbacks, optional Redis wiring, and validation that enforces provider/group/deployment consistency and requires Redis for `replicas > 1`).
> 
> Introduces `LiteLLMProxy` (`sector7:kubernetes:LiteLLMProxy`) to deploy the proxy to Kubernetes by creating an optional Namespace, Secrets for provider keys and runtime values (`DATABASE_URL`, generated/override master key), a ConfigMap with generated config, plus a Deployment and Service, and exposes outputs like `proxyUrl`.
> 
> Adds an ADR documenting the design boundary (subpath-only, secrets not in ConfigMaps), updates `package.json`/lockfile for new deps, and includes Vitest coverage for config generation and Pulumi resource wiring.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6ae8ae1189dfc1f33d5d2cf9c42e8518db1f8916. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->