### PR TITLE
refactor(litellm): allow pulumi inputs in proxy config

### DIFF
--- a/packages/sector7/litellm/config-types.ts
+++ b/packages/sector7/litellm/config-types.ts
@@ -5,15 +5,15 @@ export type LiteLLMModelMode = "chat" | "completion" | "embedding" | "image_gene
 
 export interface LiteLLMProviderConfig {
   apiKey: pulumi.Input<string>;
-  envVar?: string;
-  apiBase?: string;
+  envVar?: pulumi.Input<string>;
+  apiBase?: pulumi.Input<string>;
 }
 
 export interface LiteLLMModelDeployment {
   id: string;
   provider: string;
   providerModel: string;
-  apiBase?: string;
+  apiBase?: pulumi.Input<string>;
   mode?: LiteLLMModelMode;
   baseModel?: string;
   accessGroups?: string[];
@@ -90,7 +90,7 @@ export interface LiteLLMProxyArgs {
   namespace?: pulumi.Input<string>;
   createNamespace?: boolean;
   image?: pulumi.Input<string>;
-  replicas?: number;
+  replicas?: pulumi.Input<number>;
   databaseUrl: pulumi.Input<string>;
   masterKey?: pulumi.Input<string>;
   providers: Record<string, LiteLLMProviderConfig>;

--- a/packages/sector7/litellm/config.ts
+++ b/packages/sector7/litellm/config.ts
@@ -5,10 +5,15 @@ import type {
   LiteLLMModelDeployment,
   LiteLLMModelGroup,
   LiteLLMObservabilityPolicy,
-  LiteLLMProviderConfig,
   LiteLLMRedisPolicy,
   LiteLLMRouterPolicy,
 } from "./config-types.ts";
+
+type ResolvedProviderConfig = {
+  apiKey: string;
+  envVar?: string;
+  apiBase?: string;
+};
 
 const DEFAULT_OBSERVABILITY: Required<
   Pick<
@@ -68,9 +73,9 @@ function toUpperSnakeCase(value: string): string {
 
 export function getProviderEnvVar(
   providerName: string,
-  provider: LiteLLMProviderConfig,
+  provider: ResolvedProviderConfig,
 ): string {
-  return (provider.envVar as string | undefined) ?? `${toUpperSnakeCase(providerName)}_API_KEY`;
+  return provider.envVar ?? `${toUpperSnakeCase(providerName)}_API_KEY`;
 }
 
 function addIfDefined(
@@ -100,7 +105,7 @@ function buildFallbackMap(
 
 export function validateLiteLLMConfig(args: {
   replicas?: number;
-  providers: Record<string, LiteLLMProviderConfig>;
+  providers: Record<string, ResolvedProviderConfig>;
   deployments: LiteLLMModelDeployment[];
   modelGroups: LiteLLMModelGroup[];
   redis?: LiteLLMRedisPolicy;
@@ -177,7 +182,7 @@ export function validateLiteLLMConfig(args: {
 }
 
 export function generateLiteLLMConfig(args: {
-  providers: Record<string, LiteLLMProviderConfig>;
+  providers: Record<string, ResolvedProviderConfig>;
   deployments: LiteLLMModelDeployment[];
   modelGroups: LiteLLMModelGroup[];
   observability?: LiteLLMObservabilityPolicy;

--- a/packages/sector7/litellm/config.ts
+++ b/packages/sector7/litellm/config.ts
@@ -14,6 +14,10 @@ type ResolvedProviderConfig = {
   apiBase?: string;
 };
 
+type ResolvedDeploymentConfig = Omit<LiteLLMModelDeployment, "apiBase"> & {
+  apiBase?: string;
+};
+
 const DEFAULT_OBSERVABILITY: Required<
   Pick<
     LiteLLMObservabilityPolicy,
@@ -105,7 +109,7 @@ function buildFallbackMap(
 export function validateLiteLLMConfig(args: {
   replicas?: number;
   providers: Record<string, ResolvedProviderConfig>;
-  deployments: LiteLLMModelDeployment[];
+  deployments: ResolvedDeploymentConfig[];
   modelGroups: LiteLLMModelGroup[];
   redis?: LiteLLMRedisPolicy;
   router?: LiteLLMRouterPolicy;
@@ -174,7 +178,7 @@ export function validateLiteLLMConfig(args: {
 
 export function generateLiteLLMConfig(args: {
   providers: Record<string, ResolvedProviderConfig>;
-  deployments: LiteLLMModelDeployment[];
+  deployments: ResolvedDeploymentConfig[];
   modelGroups: LiteLLMModelGroup[];
   observability?: LiteLLMObservabilityPolicy;
   governance?: LiteLLMGovernancePolicy;

--- a/packages/sector7/litellm/config.ts
+++ b/packages/sector7/litellm/config.ts
@@ -70,7 +70,7 @@ export function getProviderEnvVar(
   providerName: string,
   provider: LiteLLMProviderConfig,
 ): string {
-  return provider.envVar ?? `${toUpperSnakeCase(providerName)}_API_KEY`;
+  return (provider.envVar as string | undefined) ?? `${toUpperSnakeCase(providerName)}_API_KEY`;
 }
 
 function addIfDefined(

--- a/packages/sector7/litellm/config.ts
+++ b/packages/sector7/litellm/config.ts
@@ -10,7 +10,6 @@ import type {
 } from "./config-types.ts";
 
 type ResolvedProviderConfig = {
-  apiKey: string;
   envVar?: string;
   apiBase?: string;
 };
@@ -113,14 +112,6 @@ export function validateLiteLLMConfig(args: {
 }): void {
   const deploymentIds = new Set<string>();
   const groupNames = new Set(args.modelGroups.map((group) => group.name));
-
-  for (const [providerName, provider] of Object.entries(args.providers)) {
-    // Note: apiKey is pulumi.Input<string>; we cannot validate its runtime value here.
-    // This check only ensures the property exists (non‑null/undefined).
-    if (!provider.apiKey) {
-      throw new Error(`LiteLLM provider '${providerName}' is missing apiKey`);
-    }
-  }
 
   for (const deployment of args.deployments) {
     if (deploymentIds.has(deployment.id)) {

--- a/packages/sector7/litellm/litellm-proxy.ts
+++ b/packages/sector7/litellm/litellm-proxy.ts
@@ -97,15 +97,7 @@ export class LiteLLMProxy extends pulumi.ComponentResource {
           providerStringData: Object.fromEntries(
             providers.map((provider) => [toSecretKey(provider.envVar), provider.apiKey]),
           ),
-          providerEnvEntries: providers.map((provider) => ({
-            name: provider.envVar,
-            valueFrom: {
-              secretKeyRef: {
-                name: providerSecretName,
-                key: toSecretKey(provider.envVar),
-              },
-            },
-          })),
+          providerEnvVars: providers.map((provider) => provider.envVar),
         };
       },
     );
@@ -190,8 +182,8 @@ export class LiteLLMProxy extends pulumi.ComponentResource {
       "app.kubernetes.io/instance": name,
     };
 
-    const env = pulumi.all([runtimeConfig, this.runtimeSecret.metadata.name]).apply(
-      ([value, runtimeSecretName]) => [
+    const env = pulumi.all([runtimeConfig, this.runtimeSecret.metadata.name, this.providerSecret.metadata.name]).apply(
+      ([value, runtimeSecretName, providerSecretName]) => [
         {
           name: "LITELLM_MASTER_KEY",
           valueFrom: {
@@ -210,7 +202,15 @@ export class LiteLLMProxy extends pulumi.ComponentResource {
             },
           },
         },
-        ...value.providerEnvEntries,
+        ...value.providerEnvVars.map((envVar) => ({
+          name: envVar,
+          valueFrom: {
+            secretKeyRef: {
+              name: providerSecretName,
+              key: toSecretKey(envVar),
+            },
+          },
+        })),
       ],
     );
 

--- a/packages/sector7/litellm/litellm-proxy.ts
+++ b/packages/sector7/litellm/litellm-proxy.ts
@@ -8,11 +8,15 @@ import type {
   LiteLLMProviderConfig,
 } from "./config-types.ts";
 
-type ResolvedProvider = {
+type ResolvedProviderConfig = {
   name: string;
-  apiKey: string;
   envVar: string;
   apiBase?: string;
+};
+
+type ResolvedProviderSecret = {
+  envVar: string;
+  apiKey: string;
 };
 
 type ResolvedDeployment = Omit<LiteLLMModelDeployment, "apiBase"> & {
@@ -23,25 +27,36 @@ function toSecretKey(envVar: string): string {
   return envVar.toLowerCase();
 }
 
-function resolveProvider(providerName: string, provider: LiteLLMProviderConfig): pulumi.Output<ResolvedProvider> {
+function resolveProviderConfig(
+  providerName: string,
+  provider: LiteLLMProviderConfig,
+): pulumi.Output<ResolvedProviderConfig> {
   return pulumi
-    .all([provider.apiKey, pulumi.output(provider.envVar), pulumi.output(provider.apiBase)])
-    .apply(([apiKey, envVar, apiBase]) => {
-      const resolvedEnvVar = getProviderEnvVar(providerName, { apiKey, envVar: envVar ?? undefined });
-      return {
-        name: providerName,
-        apiKey,
-        envVar: resolvedEnvVar,
-        apiBase: apiBase ?? undefined,
-      };
-    });
+    .all([pulumi.output(provider.envVar), pulumi.output(provider.apiBase)])
+    .apply(([envVar, apiBase]) => ({
+      name: providerName,
+      envVar: getProviderEnvVar(providerName, { envVar: envVar ?? undefined }),
+      apiBase: apiBase ?? undefined,
+    }));
 }
+
+function resolveProviderSecret(
+  provider: LiteLLMProviderConfig,
+  envVar: pulumi.Output<string>,
+): pulumi.Output<ResolvedProviderSecret> {
+  return pulumi.all([pulumi.output(provider.apiKey), envVar]).apply(([apiKey, resolvedEnvVar]) => ({
+    envVar: resolvedEnvVar,
+    apiKey,
+  }));
+}
+
 function resolveDeployment(deployment: LiteLLMModelDeployment): pulumi.Output<ResolvedDeployment> {
   return pulumi.output(deployment.apiBase).apply((apiBase) => ({
     ...deployment,
     apiBase: apiBase ?? undefined,
   }));
 }
+
 
 export class LiteLLMProxy extends pulumi.ComponentResource {
   public readonly namespaceResource: k8s.core.v1.Namespace | undefined;
@@ -64,18 +79,33 @@ export class LiteLLMProxy extends pulumi.ComponentResource {
     const replicas = pulumi.output(args.replicas ?? 1);
     const servicePort = args.service?.port ?? 4000;
 
-    const resolvedProviders = pulumi.all(
-      Object.entries(args.providers).map(([providerName, provider]) => resolveProvider(providerName, provider)),
+    const resolvedProviderConfigs = pulumi.all(
+      Object.entries(args.providers).map(([providerName, provider]) => resolveProviderConfig(providerName, provider)),
+    );
+    const resolvedProviderSecrets = pulumi.all(
+      Object.entries(args.providers).map(([providerName, provider]) =>
+        pulumi
+          .all([pulumi.output(provider.apiKey), pulumi.output(provider.envVar)])
+          .apply(([apiKey, envVar]) => ({
+            envVar: getProviderEnvVar(providerName, { envVar: envVar ?? undefined }),
+            apiKey,
+          })),
+      ),
     );
     const resolvedDeployments = pulumi.all(args.deployments.map((deployment) => resolveDeployment(deployment)));
 
     const providerSecretName = `${name}-provider-keys`;
 
-    const runtimeConfig = pulumi.all([resolvedProviders, resolvedDeployments, replicas]).apply(
+    const providerStringData = resolvedProviderSecrets.apply((secretProviders) =>
+      Object.fromEntries(secretProviders.map((provider) => [toSecretKey(provider.envVar), provider.apiKey])),
+    );
+
+    const providerEnvVars = resolvedProviderConfigs.apply((providers) => providers.map((provider) => provider.envVar));
+
+    const configYaml = pulumi.all([resolvedProviderConfigs, resolvedDeployments, replicas]).apply(
       ([providers, deployments, resolvedReplicas]) => {
         const providerMap = Object.fromEntries(
           providers.map((provider) => [provider.name, {
-            apiKey: provider.apiKey,
             envVar: provider.envVar,
             apiBase: provider.apiBase,
           }]),
@@ -92,17 +122,11 @@ export class LiteLLMProxy extends pulumi.ComponentResource {
           replicas: resolvedReplicas,
         });
 
-        return {
-          configYaml: generatedConfig.configYaml,
-          providerStringData: Object.fromEntries(
-            providers.map((provider) => [toSecretKey(provider.envVar), provider.apiKey]),
-          ),
-          providerEnvVars: providers.map((provider) => provider.envVar),
-        };
+        return generatedConfig.configYaml;
       },
     );
 
-    this.configYaml = runtimeConfig.apply((value) => value.configYaml);
+    this.configYaml = configYaml;
 
     this.namespaceResource = createNamespace
       ? new k8s.core.v1.Namespace(
@@ -132,7 +156,7 @@ export class LiteLLMProxy extends pulumi.ComponentResource {
           name: providerSecretName,
           namespace: this.namespace,
         },
-        stringData: runtimeConfig.apply((value) => value.providerStringData),
+        stringData: providerStringData,
       },
       parentAndProvider,
     );
@@ -182,8 +206,8 @@ export class LiteLLMProxy extends pulumi.ComponentResource {
       "app.kubernetes.io/instance": name,
     };
 
-    const env = pulumi.all([runtimeConfig, this.runtimeSecret.metadata.name, this.providerSecret.metadata.name]).apply(
-      ([value, runtimeSecretName, providerSecretName]) => [
+    const env = pulumi.all([providerEnvVars, this.runtimeSecret.metadata.name, this.providerSecret.metadata.name]).apply(
+      ([envVars, runtimeSecretName, providerSecretName]) => [
         {
           name: "LITELLM_MASTER_KEY",
           valueFrom: {
@@ -202,7 +226,7 @@ export class LiteLLMProxy extends pulumi.ComponentResource {
             },
           },
         },
-        ...value.providerEnvVars.map((envVar) => ({
+        ...envVars.map((envVar) => ({
           name: envVar,
           valueFrom: {
             secretKeyRef: {

--- a/packages/sector7/litellm/litellm-proxy.ts
+++ b/packages/sector7/litellm/litellm-proxy.ts
@@ -1,7 +1,7 @@
 import * as k8s from "@pulumi/kubernetes";
 import * as pulumi from "@pulumi/pulumi";
 import * as random from "@pulumi/random";
-import { generateLiteLLMConfig } from "./config.ts";
+import { generateLiteLLMConfig, getProviderEnvVar } from "./config.ts";
 import type {
   LiteLLMModelDeployment,
   LiteLLMProxyArgs,
@@ -19,15 +19,6 @@ type ResolvedDeployment = Omit<LiteLLMModelDeployment, "apiBase"> & {
   apiBase?: string;
 };
 
-function toUpperSnakeCase(value: string): string {
-  return value
-    .replace(/[^a-zA-Z0-9]+/g, "_")
-    .replace(/([a-z0-9])([A-Z])/g, "$1_$2")
-    .replace(/_+/g, "_")
-    .replace(/^_+|_+$/g, "")
-    .toUpperCase();
-}
-
 function toSecretKey(envVar: string): string {
   return envVar.toLowerCase();
 }
@@ -35,14 +26,16 @@ function toSecretKey(envVar: string): string {
 function resolveProvider(providerName: string, provider: LiteLLMProviderConfig): pulumi.Output<ResolvedProvider> {
   return pulumi
     .all([provider.apiKey, pulumi.output(provider.envVar), pulumi.output(provider.apiBase)])
-    .apply(([apiKey, envVar, apiBase]) => ({
-      name: providerName,
-      apiKey,
-      envVar: envVar ?? `${toUpperSnakeCase(providerName)}_API_KEY`,
-      apiBase: apiBase ?? undefined,
-    }));
+    .apply(([apiKey, envVar, apiBase]) => {
+      const resolvedEnvVar = getProviderEnvVar(providerName, { apiKey, envVar: envVar ?? undefined });
+      return {
+        name: providerName,
+        apiKey,
+        envVar: resolvedEnvVar,
+        apiBase: apiBase ?? undefined,
+      };
+    });
 }
-
 function resolveDeployment(deployment: LiteLLMModelDeployment): pulumi.Output<ResolvedDeployment> {
   return pulumi.output(deployment.apiBase).apply((apiBase) => ({
     ...deployment,
@@ -76,6 +69,8 @@ export class LiteLLMProxy extends pulumi.ComponentResource {
     );
     const resolvedDeployments = pulumi.all(args.deployments.map((deployment) => resolveDeployment(deployment)));
 
+    const providerSecretName = `${name}-provider-keys`;
+
     const runtimeConfig = pulumi.all([resolvedProviders, resolvedDeployments, replicas]).apply(
       ([providers, deployments, resolvedReplicas]) => {
         const providerMap = Object.fromEntries(
@@ -106,7 +101,7 @@ export class LiteLLMProxy extends pulumi.ComponentResource {
             name: provider.envVar,
             valueFrom: {
               secretKeyRef: {
-                name: `${name}-provider-keys`,
+                name: providerSecretName,
                 key: toSecretKey(provider.envVar),
               },
             },
@@ -142,7 +137,7 @@ export class LiteLLMProxy extends pulumi.ComponentResource {
       `${name}-providers`,
       {
         metadata: {
-          name: `${name}-provider-keys`,
+          name: providerSecretName,
           namespace: this.namespace,
         },
         stringData: runtimeConfig.apply((value) => value.providerStringData),

--- a/packages/sector7/litellm/litellm-proxy.ts
+++ b/packages/sector7/litellm/litellm-proxy.ts
@@ -1,31 +1,53 @@
 import * as k8s from "@pulumi/kubernetes";
 import * as pulumi from "@pulumi/pulumi";
 import * as random from "@pulumi/random";
-import {
-  generateLiteLLMConfig,
-  getProviderEnvVar,
-} from "./config.ts";
+import { generateLiteLLMConfig } from "./config.ts";
 import type {
+  LiteLLMModelDeployment,
   LiteLLMProxyArgs,
   LiteLLMProviderConfig,
 } from "./config-types.ts";
+
+type ResolvedProvider = {
+  name: string;
+  apiKey: string;
+  envVar: string;
+  apiBase?: string;
+};
+
+type ResolvedDeployment = Omit<LiteLLMModelDeployment, "apiBase"> & {
+  apiBase?: string;
+};
+
+function toUpperSnakeCase(value: string): string {
+  return value
+    .replace(/[^a-zA-Z0-9]+/g, "_")
+    .replace(/([a-z0-9])([A-Z])/g, "$1_$2")
+    .replace(/_+/g, "_")
+    .replace(/^_+|_+$/g, "")
+    .toUpperCase();
+}
 
 function toSecretKey(envVar: string): string {
   return envVar.toLowerCase();
 }
 
-function buildProviderStringData(
-  providers: Record<string, LiteLLMProviderConfig>,
-): pulumi.Output<Record<string, string>> {
-  const entries = Object.entries(providers);
-  return pulumi.all(entries.map(([, provider]) => provider.apiKey)).apply((values) =>
-    Object.fromEntries(
-      entries.map(([providerName, provider], index) => {
-        const envVar = getProviderEnvVar(providerName, provider);
-        return [toSecretKey(envVar), values[index] as string];
-      }),
-    ),
-  );
+function resolveProvider(providerName: string, provider: LiteLLMProviderConfig): pulumi.Output<ResolvedProvider> {
+  return pulumi
+    .all([provider.apiKey, pulumi.output(provider.envVar), pulumi.output(provider.apiBase)])
+    .apply(([apiKey, envVar, apiBase]) => ({
+      name: providerName,
+      apiKey,
+      envVar: envVar ?? `${toUpperSnakeCase(providerName)}_API_KEY`,
+      apiBase: apiBase ?? undefined,
+    }));
+}
+
+function resolveDeployment(deployment: LiteLLMModelDeployment): pulumi.Output<ResolvedDeployment> {
+  return pulumi.output(deployment.apiBase).apply((apiBase) => ({
+    ...deployment,
+    apiBase: apiBase ?? undefined,
+  }));
 }
 
 export class LiteLLMProxy extends pulumi.ComponentResource {
@@ -46,21 +68,54 @@ export class LiteLLMProxy extends pulumi.ComponentResource {
     const createNamespace = args.createNamespace ?? true;
     const namespaceName = pulumi.output(args.namespace ?? name);
     const image = args.image ?? "ghcr.io/berriai/litellm-database:main-stable";
-    const replicas = args.replicas ?? 1;
+    const replicas = pulumi.output(args.replicas ?? 1);
     const servicePort = args.service?.port ?? 4000;
 
-    const generatedConfig = generateLiteLLMConfig({
-      providers: args.providers,
-      deployments: args.deployments,
-      modelGroups: args.modelGroups,
-      observability: args.observability,
-      governance: args.governance,
-      redis: args.redis,
-      router: args.router,
-      replicas,
-    });
+    const resolvedProviders = pulumi.all(
+      Object.entries(args.providers).map(([providerName, provider]) => resolveProvider(providerName, provider)),
+    );
+    const resolvedDeployments = pulumi.all(args.deployments.map((deployment) => resolveDeployment(deployment)));
 
-    this.configYaml = pulumi.output(generatedConfig.configYaml);
+    const runtimeConfig = pulumi.all([resolvedProviders, resolvedDeployments, replicas]).apply(
+      ([providers, deployments, resolvedReplicas]) => {
+        const providerMap = Object.fromEntries(
+          providers.map((provider) => [provider.name, {
+            apiKey: provider.apiKey,
+            envVar: provider.envVar,
+            apiBase: provider.apiBase,
+          }]),
+        );
+
+        const generatedConfig = generateLiteLLMConfig({
+          providers: providerMap,
+          deployments,
+          modelGroups: args.modelGroups,
+          observability: args.observability,
+          governance: args.governance,
+          redis: args.redis,
+          router: args.router,
+          replicas: resolvedReplicas,
+        });
+
+        return {
+          configYaml: generatedConfig.configYaml,
+          providerStringData: Object.fromEntries(
+            providers.map((provider) => [toSecretKey(provider.envVar), provider.apiKey]),
+          ),
+          providerEnvEntries: providers.map((provider) => ({
+            name: provider.envVar,
+            valueFrom: {
+              secretKeyRef: {
+                name: `${name}-provider-keys`,
+                key: toSecretKey(provider.envVar),
+              },
+            },
+          })),
+        };
+      },
+    );
+
+    this.configYaml = runtimeConfig.apply((value) => value.configYaml);
 
     this.namespaceResource = createNamespace
       ? new k8s.core.v1.Namespace(
@@ -90,7 +145,7 @@ export class LiteLLMProxy extends pulumi.ComponentResource {
           name: `${name}-provider-keys`,
           namespace: this.namespace,
         },
-        stringData: buildProviderStringData(args.providers),
+        stringData: runtimeConfig.apply((value) => value.providerStringData),
       },
       parentAndProvider,
     );
@@ -140,38 +195,29 @@ export class LiteLLMProxy extends pulumi.ComponentResource {
       "app.kubernetes.io/instance": name,
     };
 
-    const env = [
-      {
-        name: "LITELLM_MASTER_KEY",
-        valueFrom: {
-          secretKeyRef: {
-            name: this.runtimeSecret.metadata.name,
-            key: "LITELLM_MASTER_KEY",
-          },
-        },
-      },
-      {
-        name: "DATABASE_URL",
-        valueFrom: {
-          secretKeyRef: {
-            name: this.runtimeSecret.metadata.name,
-            key: "DATABASE_URL",
-          },
-        },
-      },
-      ...Object.entries(args.providers).map(([providerName, provider]) => {
-        const envVar = getProviderEnvVar(providerName, provider);
-        return {
-          name: envVar,
+    const env = pulumi.all([runtimeConfig, this.runtimeSecret.metadata.name]).apply(
+      ([value, runtimeSecretName]) => [
+        {
+          name: "LITELLM_MASTER_KEY",
           valueFrom: {
             secretKeyRef: {
-              name: this.providerSecret.metadata.name,
-              key: toSecretKey(envVar),
+              name: runtimeSecretName,
+              key: "LITELLM_MASTER_KEY",
             },
           },
-        };
-      }),
-    ];
+        },
+        {
+          name: "DATABASE_URL",
+          valueFrom: {
+            secretKeyRef: {
+              name: runtimeSecretName,
+              key: "DATABASE_URL",
+            },
+          },
+        },
+        ...value.providerEnvEntries,
+      ],
+    );
 
     this.deployment = new k8s.apps.v1.Deployment(
       `${name}-deployment`,

--- a/packages/sector7/litellm/litellm-proxy.ts
+++ b/packages/sector7/litellm/litellm-proxy.ts
@@ -14,11 +14,6 @@ type ResolvedProviderConfig = {
   apiBase?: string;
 };
 
-type ResolvedProviderSecret = {
-  envVar: string;
-  apiKey: string;
-};
-
 type ResolvedDeployment = Omit<LiteLLMModelDeployment, "apiBase"> & {
   apiBase?: string;
 };
@@ -40,21 +35,14 @@ function resolveProviderConfig(
     }));
 }
 
-function resolveProviderSecret(
-  provider: LiteLLMProviderConfig,
-  envVar: pulumi.Output<string>,
-): pulumi.Output<ResolvedProviderSecret> {
-  return pulumi.all([pulumi.output(provider.apiKey), envVar]).apply(([apiKey, resolvedEnvVar]) => ({
-    envVar: resolvedEnvVar,
-    apiKey,
-  }));
-}
-
 function resolveDeployment(deployment: LiteLLMModelDeployment): pulumi.Output<ResolvedDeployment> {
-  return pulumi.output(deployment.apiBase).apply((apiBase) => ({
-    ...deployment,
-    apiBase: apiBase ?? undefined,
-  }));
+  return pulumi.output(deployment.apiBase).apply((apiBase) => {
+    const { apiBase: _ignored, ...rest } = deployment;
+    return {
+      ...rest,
+      apiBase: apiBase ?? undefined,
+    };
+  });
 }
 
 

--- a/packages/sector7/tests/litellm-config.test.ts
+++ b/packages/sector7/tests/litellm-config.test.ts
@@ -6,14 +6,13 @@ describe("generateLiteLLMConfig", () => {
 	it("generates grouped model config with fallbacks and env-based secrets", () => {
 		const generated = generateLiteLLMConfig({
 			providers: {
-				anthropic: { apiKey: "anthropic-secret" },
-				openai: { apiKey: "openai-secret", apiBase: "https://api.openai.example/v1" },
+				anthropic: { envVar: "ANTHROPIC_API_KEY" },
+				openai: { envVar: "OPENAI_API_KEY", apiBase: "https://api.openai.example/v1" },
 			},
 			deployments: [
 				{
 					id: "anthropic-smart",
-					modelName: "smart",
-					provider: "anthropic",
+provider: "anthropic",
 					providerModel: "anthropic/claude-sonnet-4-20250514",
 					mode: "chat",
 					accessGroups: ["premium"],
@@ -21,8 +20,7 @@ describe("generateLiteLLMConfig", () => {
 				},
 				{
 					id: "openai-fast",
-					modelName: "fast",
-					provider: "openai",
+provider: "openai",
 					providerModel: "openai/gpt-4o-mini",
 					mode: "chat",
 					rpm: 500,
@@ -81,11 +79,10 @@ describe("generateLiteLLMConfig", () => {
 	it("rejects missing deployment references and multi-replica without redis", () => {
 		expect(() =>
 			generateLiteLLMConfig({
-				providers: { anthropic: { apiKey: "secret" } },
+				providers: { anthropic: {} },
 				deployments: [
 					{
 						id: "dep-1",
-						modelName: "smart",
 						provider: "anthropic",
 						providerModel: "anthropic/claude-sonnet-4-20250514",
 					},
@@ -96,11 +93,10 @@ describe("generateLiteLLMConfig", () => {
 
 		expect(() =>
 			generateLiteLLMConfig({
-				providers: { anthropic: { apiKey: "secret" } },
+				providers: { anthropic: {} },
 				deployments: [
 					{
 						id: "dep-1",
-						modelName: "smart",
 						provider: "anthropic",
 						providerModel: "anthropic/claude-sonnet-4-20250514",
 					},

--- a/packages/sector7/tests/litellm-proxy.test.ts
+++ b/packages/sector7/tests/litellm-proxy.test.ts
@@ -62,14 +62,12 @@ describe("LiteLLMProxy", () => {
 			deployments: [
 				{
 					id: "anthropic-smart",
-					modelName: "smart",
 					provider: "anthropic",
 					providerModel: "anthropic/claude-sonnet-4-20250514",
 					mode: "chat",
 				},
 				{
 					id: "openai-fast",
-					modelName: "fast",
 					provider: "openai",
 					providerModel: "openai/gpt-4o-mini",
 					mode: "chat",
@@ -120,8 +118,7 @@ describe("LiteLLMProxy", () => {
 			DATABASE_URL: "postgres://db-user:real-pass@db.internal/litellm",
 		});
 
-		const configMap = findResource("team-proxy-config");
-		const configYaml = (configMap?.inputs.data as Record<string, string>)["config.yaml"];
+		const configYaml = await resolveOutput(proxy.configYaml);
 		expect(configYaml).toContain("model_name: smart");
 		expect(configYaml).toContain("os.environ/ANTHROPIC_API_KEY");
 		expect(configYaml).toContain("database_url: os.environ/DATABASE_URL");
@@ -146,7 +143,6 @@ describe("LiteLLMProxy", () => {
 			deployments: [
 				{
 					id: "anthropic-smart",
-					modelName: "smart",
 					provider: "anthropic",
 					providerModel: "anthropic/claude-sonnet-4-20250514",
 				},


### PR DESCRIPTION
## Summary
- Allow LiteLLM proxy provider config fields to accept Pulumi inputs
- Resolve provider env var names and deployment API bases before rendering `config.yaml`
- Keep secrets and generated config wiring Output-safe for Pulumi
- Remove the dead `modelName` field from deployment fixtures and adjust the proxy test to assert the resolved config output

## Why
This lets the proxy component consume values that come from other Pulumi resources without forcing callers to precompute everything as plain strings.

## Test Plan
- `pnpm test`
- `pnpm build`

## Notes
- This is the follow-up refactor from the LiteLLM proxy component PR.
- I kept `createNamespace` as a plain boolean for now since conditional resource creation from an Input would need a broader structural change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Pulumi resource wiring for LiteLLM proxy config/secret generation to resolve `Input` values via `Output.apply`, which can affect deployment rendering and environment variable/secret mapping if resolution order or defaults are wrong.
> 
> **Overview**
> Updates the LiteLLM proxy component to accept `pulumi.Input` values for provider `envVar`/`apiBase`, deployment `apiBase`, and `replicas`, and resolves these to plain strings/numbers before rendering `config.yaml`.
> 
> Refactors `LiteLLMProxy` to build provider secrets, env var lists, and `configYaml` using `pulumi.all(...).apply(...)` (removing the old direct `buildProviderStringData` path), and adjusts config validation/generation types accordingly (no longer attempts to validate provider `apiKey` at config-gen time).
> 
> Updates tests/fixtures to drop the unused `modelName` field and to assert against the resolved `proxy.configYaml` output rather than reading it from the ConfigMap.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 72d472e994a6045d3fb88a2944f7f6f393335fb5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->