### PR TITLE
fix(nix): decouple image push from flake checks

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -73,6 +73,9 @@ jobs:
       max-parallel: 1
       matrix:
         include: ${{ fromJson(needs.detect.outputs.matrix_include) }}
+        exclude:
+          # Exclude images from this job - they're built and pushed separately
+          - is_image: true
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -90,9 +93,9 @@ jobs:
           echo "Building via nix-fast-build: $attr"
           # Build only missing (uncached) derivations, with CI-friendly logs and no out-link
           nix-fast-build --skip-cached --no-nom --no-link -j 2 --flake "$attr"
-  push-images:
-    name: "🐳 push ${{ matrix.package-name }}"
-    needs: [detect, build]
+  build-and-push-images:
+    name: "🐳 build+push ${{ matrix.package-name }}"
+    needs: [detect]
     # Only run if there are actually images to push
     if: ${{ needs.detect.outputs.images_to_push != '[]' }}
     strategy:

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -36,9 +36,8 @@ jobs:
     name: '☃️ detect flake outputs'
     runs-on: ${{ startsWith(inputs.runs-on, '[') && fromJson(inputs.runs-on) || inputs.runs-on }}
     outputs:
-      matrix_include: ${{ steps.compute.outputs.matrix_include }}
-      has_work: ${{ steps.compute.outputs.has_work }}
-      images_to_push: ${{ steps.images.outputs.image_matrix }}
+      build_matrix_include: ${{ steps.split.outputs.build_matrix_include }}
+      images_to_push: ${{ steps.split.outputs.image_matrix }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -53,29 +52,27 @@ jobs:
         uses: jmmaloney4/sector7/.github/actions/compute-flake-build-matrix@61fa58a027d96afc7c5c9a2953ab54dd3bb42ad4 # main
         with:
           probe-timeout-seconds: '180'
-      - name: compute images to push
-        id: images
+      - name: split build and image matrices
+        id: split
         shell: 'nix shell nixpkgs#jq -c bash {0}'
         run: |
-          # Use jq to filter the matrix for entries where is_image is true,
-          # then extract just the package name (the 'name' field)
-          # into a list for the downstream matrix.
-          image_names=$(echo '${{ steps.compute.outputs.matrix_include }}' | jq -c '[ .[] | select(.is_image == true) | .name ]')
+          matrix='${{ steps.compute.outputs.matrix_include }}'
+          build_matrix=$(echo "$matrix" | jq -c '[ .[] | select(.is_image != true) ]')
+          image_names=$(echo "$matrix" | jq -c '[ .[] | select(.is_image == true) | .name ]')
+          echo "Found build entries: $build_matrix"
           echo "Found images: $image_names"
+          echo "build_matrix_include=$build_matrix" >> "$GITHUB_OUTPUT"
           echo "image_matrix=$image_names" >> "$GITHUB_OUTPUT"
   build:
     name: "👷‍♂️ ${{ matrix.category }}.${{ matrix.system }}.${{ matrix.name }}"
     needs: [detect]
     runs-on: ${{ startsWith(inputs.runs-on, '[') && fromJson(inputs.runs-on) || inputs.runs-on }}
-    if: ${{ needs.detect.outputs.has_work == 'true' }}
+    if: ${{ needs.detect.outputs.build_matrix_include != '[]' }}
     strategy:
       fail-fast: false
       max-parallel: 1
       matrix:
-        include: ${{ fromJson(needs.detect.outputs.matrix_include) }}
-        exclude:
-          # Exclude images from this job - they're built and pushed separately
-          - is_image: true
+        include: ${{ fromJson(needs.detect.outputs.build_matrix_include) }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -37,6 +37,7 @@ jobs:
     runs-on: ${{ startsWith(inputs.runs-on, '[') && fromJson(inputs.runs-on) || inputs.runs-on }}
     outputs:
       build_matrix_include: ${{ steps.split.outputs.build_matrix_include }}
+      build_has_work: ${{ steps.split.outputs.build_has_work }}
       images_to_push: ${{ steps.split.outputs.image_matrix }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -56,18 +57,21 @@ jobs:
         id: split
         shell: 'nix shell nixpkgs#jq -c bash {0}'
         run: |
+          set -euo pipefail
           matrix='${{ steps.compute.outputs.matrix_include }}'
           build_matrix=$(echo "$matrix" | jq -c '[ .[] | select(.is_image != true) ]')
           image_names=$(echo "$matrix" | jq -c '[ .[] | select(.is_image == true) | .name ]')
+          build_has_work=$(if [ "$build_matrix" = '[]' ]; then echo false; else echo true; fi)
           echo "Found build entries: $build_matrix"
           echo "Found images: $image_names"
           echo "build_matrix_include=$build_matrix" >> "$GITHUB_OUTPUT"
+          echo "build_has_work=$build_has_work" >> "$GITHUB_OUTPUT"
           echo "image_matrix=$image_names" >> "$GITHUB_OUTPUT"
   build:
     name: "👷‍♂️ ${{ matrix.category }}.${{ matrix.system }}.${{ matrix.name }}"
     needs: [detect]
     runs-on: ${{ startsWith(inputs.runs-on, '[') && fromJson(inputs.runs-on) || inputs.runs-on }}
-    if: ${{ needs.detect.outputs.build_matrix_include != '[]' }}
+    if: ${{ needs.detect.outputs.build_has_work == 'true' }}
     strategy:
       fail-fast: false
       max-parallel: 1


### PR DESCRIPTION
## Summary
- Exclude image packages from the general `nix` build matrix
- Run image build/push in a separate job that only depends on detection
- Keep this PR scoped to the workflow fix; the broader ADR writeup is intentionally left out

## Why
- Prevent unrelated build or check failures from silently blocking registry pushes
- Preserve the current SHA-tagging behavior for image publication

## Test Plan
- `nix fmt -L`
- `nix flake check -L` *(fails in `node-modules` with `ERR_PNPM_NO_OFFLINE_TARBALL`, which appears to be pre-existing repository debt unrelated to this change)*

## Notes
- This is the narrow workflow-only slice of PR #77
- If accepted, PR #77 should be closed as superseded

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes CI job dependencies and matrix computation; mis-splitting the matrix or output wiring could skip builds or prevent images from being published.
> 
> **Overview**
> Separates image outputs from the general Nix build matrix in `.github/workflows/nix.yml` by splitting the computed flake matrix into **build** entries and **image** package names.
> 
> The `build` job now runs only for non-image entries (`build_matrix_include` / `build_has_work`), while a new `build-and-push-images` reusable-workflow job publishes images directly from detection output without depending on the build job, reducing the chance that unrelated flake check/build failures block registry pushes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f531d59068197ca094e2f9fc85b6c37d434d1691. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->