### PR TITLE
feat(litellm): add team-scoped capability routing

### DIFF
--- a/docs/internal/designs/024-litellm-team-scoped-capability-routing.md
+++ b/docs/internal/designs/024-litellm-team-scoped-capability-routing.md
@@ -1,0 +1,224 @@
+---
+id: ADR-024
+title: Team-scoped capability aliases for LiteLLM
+status: Proposed
+date: 2026-05-17
+deciders: [jmmaloney4]
+consulted: []
+tags: [design, adr, pulumi, kubernetes, litellm]
+supersedes: []
+superseded_by: []
+links:
+  - '[ADR-022](./022-litellm-proxy-component.md)'
+  - https://github.com/jmmaloney4/sector7/issues/197
+---
+
+# Context
+
+ADR-022 established Sector7's `LiteLLMProxy` component and the low-level split between provider credentials, deployments, model groups, router policy, and governance policy.
+
+That is a good base, but the next consumer use case exposes a gap in the public API.
+
+We now need LiteLLM to front multiple backend pools for multiple billing accounts while preserving stable capability aliases for callers. The concrete example is a shared AI gateway where both a `personal` team and a `cavinsresearch` team should be able to request `coding`, but the gateway should route those requests to different backend pools and attribute spend to different billing contexts.
+
+The current Sector7 surface pushes consumers toward the wrong abstraction:
+
+- billing boundaries get encoded into model names
+- internal OpenAI-compatible upstreams such as `codex-proxy` still look like second-class cases
+- virtual key and team lifecycle helpers live outside Sector7
+- there is no documented high-level builder for multi-team capability routing
+
+That leads to names like `personal-zai-coding` and `cavinsresearch-zai-coding`, which are operationally workable but architecturally wrong. The caller should ask for a capability. The billing context should come from the key or team.
+
+In scope:
+
+- Sector7's LiteLLM type surface
+- a documented architecture for team-scoped capability aliases
+- high-level builders that compile to the existing low-level model-group shape
+- upstream LiteLLM team and API-key resources
+- internal OpenAI-compatible upstreams that may not need provider-level API keys
+
+Out of scope:
+
+- redesigning LiteLLM itself
+- replacing the low-level deployment/model-group API
+- building a full LiteLLM UI or admin workflow
+- solving every future budget / spend / org policy feature in one pass
+
+# Decision
+
+Sector7's LiteLLM package MUST separate the caller-facing alias layer from the billing/team layer.
+
+Concretely:
+
+1. The public API SHOULD model stable capability aliases such as `smart`, `coding`, and `cheap`.
+2. Billing boundaries such as `personal` and `cavinsresearch` MUST be represented as teams or team-like routing scopes, not baked into caller-visible alias names.
+3. Sector7 MUST provide a high-level builder that compiles team-scoped capability definitions into the existing low-level `LiteLLMModelGroup[]` shape.
+4. Sector7 MUST widen the low-level config surface so internal OpenAI-compatible upstreams can omit provider API keys when appropriate.
+5. Sector7 SHOULD upstream operational resources for LiteLLM team and key management so consumers do not need to re-implement them.
+
+## High-level routing model
+
+The architecture is a four-layer stack:
+
+1. team / billing boundary
+2. capability alias
+3. backend pool
+4. key / budget / spend attribution
+
+Desired behavior:
+
+- team `personal` requests `coding` -> personal coding pool
+- team `cavinsresearch` requests `coding` -> research coding pool
+- both callers use the same public alias
+- spend attribution follows the key/team used for the request
+
+## Internal vs public model names
+
+Sector7 SHOULD treat LiteLLM model-group names as internal routing identifiers.
+
+For team-scoped shared aliases, the generated model groups SHOULD:
+
+- keep a unique internal `name`, for example `personal::coding`
+- expose the caller-facing alias via `teamPublicModelName: "coding"`
+- attach `teamId: "personal"`
+
+This keeps fallback wiring and config validation unambiguous while letting the public alias remain stable per team.
+
+## Low-level type widening
+
+The low-level config types MUST support:
+
+- provider configs without `apiKey`
+- optional per-model metadata for team routing and tags
+- passthrough settings for LiteLLM config sections where Sector7 does not yet model every upstream field
+
+Recommended additions:
+
+- `LiteLLMProviderConfig.apiKey?: pulumi.Input<string>`
+- `LiteLLMModelDeployment.teamId?`
+- `LiteLLMModelDeployment.teamPublicModelName?`
+- `LiteLLMModelDeployment.tags?`
+- `LiteLLMModelDeployment.extraLiteLLMParams?`
+- `LiteLLMModelDeployment.extraModelInfo?`
+- `LiteLLMModelGroup.teamId?`
+- `LiteLLMModelGroup.teamPublicModelName?`
+- `LiteLLMModelGroup.tags?`
+- `LiteLLMModelGroup.extraModelInfo?`
+- `LiteLLMProxyArgs.extraLiteLLMSettings?`
+- `LiteLLMProxyArgs.extraGeneralSettings?`
+- `LiteLLMProxyArgs.extraRouterSettings?`
+
+## High-level builder
+
+Sector7 SHOULD provide a builder that accepts team definitions and capability definitions, then emits low-level model groups.
+
+The builder MUST:
+
+- generate unique internal model-group names per team/capability
+- preserve shared public aliases per team
+- rewrite fallback references within the same team scope
+- fail loudly on duplicate team/capability combinations
+
+## Operational resources
+
+Sector7 SHOULD ship team and key resources in the LiteLLM package:
+
+- `LiteLLMTeam`
+- `LiteLLMApiKey`
+
+These resources SHOULD use the existing Pulumi command-provider pattern already used elsewhere in Sector7, and they SHOULD support team-aware payloads such as `teamId`, `budgetId`, aliases, metadata, and tags.
+
+# Consequences
+
+## Positive
+
+- Consumers can expose stable aliases without leaking billing-account names into their public API.
+- Internal upstreams such as `codex-proxy` become first-class citizens.
+- Team and key lifecycle logic moves into the reusable library instead of being reimplemented in each consumer stack.
+- The high-level builder gives consumers a clean entry point while preserving the existing low-level escape hatch.
+
+## Negative
+
+- The LiteLLM package grows a second abstraction layer, which adds API surface area.
+- Team-scoped aliases depend on LiteLLM semantics that Sector7 must keep validating against upstream behavior.
+- There is some risk of overfitting to the current multi-team gateway use case if we do not keep the low-level surface available.
+
+## Neutral
+
+- Existing consumers can keep using the low-level deployment/model-group API.
+- The builder is additive, not a breaking replacement.
+
+# Alternatives
+
+## Alternative A: keep billing names in model aliases
+
+Example: `personal-coding`, `research-coding`.
+
+Pros:
+- no library refactor required
+- easy to understand in one small deployment
+
+Cons:
+- caller-visible API leaks internal billing structure
+- aliases become unstable when account structure changes
+- every consumer repeats the same awkward naming policy
+
+Decision: rejected.
+
+## Alternative B: build the high-level builder only in a consumer repo
+
+Pros:
+- fast for one consumer
+- fewer immediate upstream changes
+
+Cons:
+- duplicates logic outside Sector7
+- keeps team/key lifecycle split across repos
+- locks the reusable library at the wrong abstraction level
+
+Decision: rejected.
+
+## Alternative C: replace the low-level API entirely with a high-level one
+
+Pros:
+- one clean opinionated surface
+
+Cons:
+- throws away useful escape hatches
+- too risky while LiteLLM integration is still evolving
+- makes advanced or unusual topologies harder to express
+
+Decision: rejected.
+
+# Security / Privacy / Compliance
+
+- Provider API keys MUST stay out of generated ConfigMaps.
+- Internal upstreams without provider API keys SHOULD not force dummy secrets into Kubernetes.
+- Team and key management helpers SHOULD treat generated keys as secret outputs.
+- This decision introduces more admin-surface automation, so request/response payloads SHOULD avoid logging raw credentials.
+
+# Operational Notes
+
+- Shared aliases improve operator ergonomics because keys and teams can change routing without changing clients.
+- The high-level builder SHOULD generate deterministic internal names so fallbacks and diffs are reviewable.
+- Internal OpenAI-compatible upstreams should prefer explicit `apiBase` configuration and no fake provider secret when authentication is handled elsewhere.
+- Release validation for the LiteLLM subpath remains important because previous packaging drift broke the published artifact shape.
+
+# Status Transitions
+
+- This ADR amends ADR-022 in practice by defining the next abstraction layer above the original low-level proxy component.
+- ADR-022 remains the foundational deployment ADR. This ADR narrows how the public LiteLLM API should evolve.
+
+# Implementation Notes
+
+- Add the team-scoped builder first, but keep it compiled to `LiteLLMModelGroup[]`.
+- Make provider API keys optional before wiring internal upstream examples.
+- Upstream the existing consumer-side key helper into Sector7 and add a parallel team helper.
+- Add tests for shared alias generation, internal upstreams, and admin resource payloads.
+- Update public Pulumi docs to describe both the low-level and high-level entry points.
+
+# References
+
+- [ADR-022: LiteLLM Proxy ComponentResource](./022-litellm-proxy-component.md)
+- Sector7 issue tracking the refactor: https://github.com/jmmaloney4/sector7/issues/197

--- a/docs/public/pulumi.md
+++ b/docs/public/pulumi.md
@@ -119,6 +119,99 @@ config:
     limitToRef: refs/heads/main
 ```
 
+## LiteLLM
+
+Sector7 ships a low-level `LiteLLMProxy` component plus higher-level helpers for team-scoped capability routing.
+
+Use the low-level API when you want to wire providers, deployments, and model groups by hand.
+Use the team-scoped builder when callers should see stable aliases like `coding` or `cheap` while LiteLLM routes to different backend pools based on team / billing context.
+
+```typescript
+import * as pulumi from "@pulumi/pulumi";
+import {
+  LiteLLMApiKey,
+  LiteLLMProxy,
+  LiteLLMTeam,
+  buildLiteLLMTeamScopedModelGroups,
+} from "@jmmaloney4/sector7/litellm";
+
+const modelGroups = buildLiteLLMTeamScopedModelGroups({
+  teams: [
+    {
+      id: "personal",
+      alias: "Personal",
+      capabilities: [
+        {
+          name: "coding",
+          deploymentIds: ["codex-main", "codex-fallback"],
+          fallbacks: ["cheap"],
+        },
+        {
+          name: "cheap",
+          deploymentIds: ["cheap-main"],
+        },
+      ],
+    },
+  ],
+});
+
+const proxy = new LiteLLMProxy("litellm", {
+  namespace: "litellm",
+  databaseUrl: pulumi.secret("postgres://..."),
+  providers: {
+    codex: {
+      apiBase: "http://codex-proxy.codex.svc.cluster.local:9879",
+    },
+    openai: {
+      apiKey: pulumi.secret("[REDACTED]"),
+    },
+  },
+  deployments: [
+    {
+      id: "codex-main",
+      provider: "codex",
+      providerModel: "openai/gpt-5-codex",
+    },
+    {
+      id: "codex-fallback",
+      provider: "codex",
+      providerModel: "openai/gpt-5-codex",
+    },
+    {
+      id: "cheap-main",
+      provider: "openai",
+      providerModel: "openai/gpt-4o-mini",
+    },
+  ],
+  modelGroups,
+  router: {
+    routingStrategy: "least-busy",
+  },
+});
+
+const personalTeam = new LiteLLMTeam("personal-team", {
+  proxyNamespace: proxy.namespace,
+  masterKey: proxy.masterKey,
+  teamAlias: "Personal",
+  teamId: "team-personal",
+  models: ["coding", "cheap"],
+});
+
+const personalKey = new LiteLLMApiKey("personal-key", {
+  proxyNamespace: proxy.namespace,
+  masterKey: proxy.masterKey,
+  keyAlias: "personal-default",
+  teamId: personalTeam.teamId,
+  models: ["coding", "cheap"],
+});
+```
+
+Notes:
+
+- Internal OpenAI-compatible upstreams can omit `apiKey` and rely on `apiBase` only.
+- Team-scoped aliases compile to unique internal model names such as `personal::coding` while exposing the caller-facing alias through LiteLLM team metadata.
+- `LiteLLMTeam` and `LiteLLMApiKey` use LiteLLM's admin endpoints through the in-cluster deployment.
+
 ## Development
 
 ### Setup

--- a/packages/sector7/litellm/admin.ts
+++ b/packages/sector7/litellm/admin.ts
@@ -1,0 +1,127 @@
+import * as command from "@pulumi/command";
+import * as pulumi from "@pulumi/pulumi";
+import * as random from "@pulumi/random";
+import { getScriptPath } from "../scripts/index.ts";
+import type { LiteLLMApiKeyArgs, LiteLLMTeamArgs } from "./config-types.ts";
+
+function pulumiJsonString(
+	value: pulumi.Input<unknown> | undefined,
+	fallback: unknown,
+): pulumi.Output<string> {
+	const source: pulumi.Input<unknown> = value === undefined ? fallback : value;
+	return pulumi.all([source]).apply(([resolved]) => JSON.stringify(resolved));
+}
+
+function buildAdminEnvironment(
+	args: LiteLLMApiKeyArgs | LiteLLMTeamArgs,
+): Record<string, pulumi.Input<string>> {
+	return {
+		LITELLM_PROXY_NAMESPACE: args.proxyNamespace,
+		LITELLM_MASTER_KEY: args.masterKey,
+		LITELLM_PROXY_DEPLOYMENT: args.proxyDeploymentName ?? "litellm",
+	};
+}
+
+export class LiteLLMApiKey extends pulumi.ComponentResource {
+	public readonly key: pulumi.Output<string>;
+	public readonly tokenId: pulumi.Output<string>;
+
+	constructor(
+		name: string,
+		args: LiteLLMApiKeyArgs,
+		opts?: pulumi.ComponentResourceOptions,
+	) {
+		super("sector7:litellm:ApiKey", name, args, opts);
+
+		const keySecret = new random.RandomPassword(
+			`${name}-secret`,
+			{
+				length: 29,
+				special: false,
+			},
+			{ parent: this },
+		);
+		const actualKey = pulumi.interpolate`sk-${keySecret.result}`;
+		const scriptPath = getScriptPath("litellm-admin.sh");
+
+		const commandResource = new command.local.Command(
+			`${name}-key`,
+			{
+				create: pulumi.interpolate`bash "${scriptPath}" create-key`,
+				delete: pulumi.interpolate`bash "${scriptPath}" delete-key`,
+				environment: {
+					...buildAdminEnvironment(args),
+					LITELLM_KEY_ALIAS: args.keyAlias,
+					LITELLM_KEY_VALUE: actualKey,
+					LITELLM_KEY_MODELS_JSON: pulumiJsonString(args.models, []),
+					LITELLM_KEY_TEAM_ID: pulumi.output(args.teamId ?? ""),
+					LITELLM_KEY_USER_ID: pulumi.output(args.userId ?? ""),
+					LITELLM_KEY_BUDGET_ID: pulumi.output(args.budgetId ?? ""),
+					LITELLM_KEY_MAX_BUDGET: pulumi.output(args.maxBudget).apply((value) =>
+						value === undefined ? "" : String(value),
+					),
+					LITELLM_KEY_BUDGET_DURATION: pulumi.output(
+						args.budgetDuration ?? "",
+					),
+					LITELLM_KEY_DURATION: pulumi.output(args.duration ?? ""),
+					LITELLM_KEY_ALIASES_JSON: pulumiJsonString(args.aliases, {}),
+					LITELLM_KEY_TAGS_JSON: pulumiJsonString(args.tags, []),
+					LITELLM_KEY_METADATA_JSON: pulumiJsonString(args.metadata, {}),
+				},
+			},
+			{ parent: this },
+		);
+
+		this.key = pulumi.secret(actualKey);
+		this.tokenId = commandResource.stdout.apply((stdout) => stdout.trim());
+
+		this.registerOutputs({
+			key: this.key,
+			tokenId: this.tokenId,
+		});
+	}
+}
+
+export class LiteLLMTeam extends pulumi.ComponentResource {
+	public readonly teamId: pulumi.Output<string>;
+
+	constructor(
+		name: string,
+		args: LiteLLMTeamArgs,
+		opts?: pulumi.ComponentResourceOptions,
+	) {
+		super("sector7:litellm:Team", name, args, opts);
+
+		const scriptPath = getScriptPath("litellm-admin.sh");
+		const commandResource = new command.local.Command(
+			`${name}-team`,
+			{
+				create: pulumi.interpolate`bash "${scriptPath}" create-team`,
+				delete: pulumi.interpolate`bash "${scriptPath}" delete-team`,
+				environment: {
+					...buildAdminEnvironment(args),
+					LITELLM_TEAM_ALIAS: args.teamAlias,
+					LITELLM_TEAM_ID: pulumi.output(args.teamId ?? ""),
+					LITELLM_TEAM_MODELS_JSON: pulumiJsonString(args.models, []),
+					LITELLM_TEAM_MAX_BUDGET: pulumi.output(args.maxBudget).apply((value) =>
+						value === undefined ? "" : String(value),
+					),
+					LITELLM_TEAM_BUDGET_DURATION: pulumi.output(
+						args.budgetDuration ?? "",
+					),
+					LITELLM_TEAM_TAGS_JSON: pulumiJsonString(args.tags, []),
+					LITELLM_TEAM_METADATA_JSON: pulumiJsonString(args.metadata, {}),
+				},
+			},
+			{ parent: this },
+		);
+
+		this.teamId = pulumi.output(args.teamId ?? commandResource.stdout).apply((value) =>
+			String(value).trim(),
+		);
+
+		this.registerOutputs({
+			teamId: this.teamId,
+		});
+	}
+}

--- a/packages/sector7/litellm/admin.ts
+++ b/packages/sector7/litellm/admin.ts
@@ -8,8 +8,9 @@ function pulumiJsonString(
 	value: pulumi.Input<unknown> | undefined,
 	fallback: unknown,
 ): pulumi.Output<string> {
-	const source: pulumi.Input<unknown> = value === undefined ? fallback : value;
-	return pulumi.all([source]).apply(([resolved]) => JSON.stringify(resolved));
+	return pulumi
+		.all([value])
+		.apply(([resolved]) => JSON.stringify(resolved ?? fallback));
 }
 
 function buildAdminEnvironment(
@@ -19,6 +20,7 @@ function buildAdminEnvironment(
 		LITELLM_PROXY_NAMESPACE: args.proxyNamespace,
 		LITELLM_MASTER_KEY: args.masterKey,
 		LITELLM_PROXY_DEPLOYMENT: args.proxyDeploymentName ?? "litellm",
+		LITELLM_PROXY_PORT: pulumi.output(args.proxyPort ?? 4000).apply(String),
 	};
 }
 
@@ -69,11 +71,13 @@ export class LiteLLMApiKey extends pulumi.ComponentResource {
 					LITELLM_KEY_METADATA_JSON: pulumiJsonString(args.metadata, {}),
 				},
 			},
-			{ parent: this },
+			{ parent: this, additionalSecretOutputs: ["stdout"] },
 		);
 
 		this.key = pulumi.secret(actualKey);
-		this.tokenId = commandResource.stdout.apply((stdout) => stdout.trim());
+		this.tokenId = pulumi.secret(commandResource.stdout).apply((stdout) =>
+			stdout.trim(),
+		);
 
 		this.registerOutputs({
 			key: this.key,
@@ -116,9 +120,9 @@ export class LiteLLMTeam extends pulumi.ComponentResource {
 			{ parent: this },
 		);
 
-		this.teamId = pulumi.output(args.teamId ?? commandResource.stdout).apply((value) =>
-			String(value).trim(),
-		);
+		this.teamId = pulumi
+			.all([args.teamId, commandResource.stdout])
+			.apply(([teamId, stdout]) => String(teamId ?? stdout).trim());
 
 		this.registerOutputs({
 			teamId: this.teamId,

--- a/packages/sector7/litellm/config-types.ts
+++ b/packages/sector7/litellm/config-types.ts
@@ -11,7 +11,7 @@ export type LiteLLMModelMode =
 	| "rerank";
 
 export interface LiteLLMProviderConfig {
-	apiKey: pulumi.Input<string>;
+	apiKey?: pulumi.Input<string>;
 	envVar?: pulumi.Input<string>;
 	apiBase?: pulumi.Input<string>;
 }
@@ -24,6 +24,12 @@ export interface LiteLLMModelDeployment {
 	mode?: LiteLLMModelMode;
 	baseModel?: string;
 	accessGroups?: string[];
+	teamId?: string;
+	teamAlias?: string;
+	teamPublicModelName?: string;
+	tags?: string[];
+	extraLiteLLMParams?: Record<string, unknown>;
+	extraModelInfo?: Record<string, unknown>;
 	rpm?: number;
 	tpm?: number;
 	rpd?: number;
@@ -41,6 +47,32 @@ export interface LiteLLMModelGroup {
 	fallbacks?: string[];
 	contextWindowFallbacks?: string[];
 	accessGroups?: string[];
+	teamId?: string;
+	teamAlias?: string;
+	teamPublicModelName?: string;
+	tags?: string[];
+	extraModelInfo?: Record<string, unknown>;
+}
+
+export interface LiteLLMTeamCapability {
+	name: string;
+	deploymentIds: string[];
+	fallbacks?: string[];
+	contextWindowFallbacks?: string[];
+	accessGroups?: string[];
+	tags?: string[];
+	extraModelInfo?: Record<string, unknown>;
+}
+
+export interface LiteLLMTeamDefinition {
+	id: string;
+	alias?: string;
+	capabilities: LiteLLMTeamCapability[];
+}
+
+export interface BuildLiteLLMTeamScopedModelGroupsArgs {
+	teams: LiteLLMTeamDefinition[];
+	separator?: string;
 }
 
 export interface LiteLLMObservabilityPolicy {
@@ -112,9 +144,42 @@ export interface LiteLLMProxyArgs {
 	redis?: LiteLLMRedisPolicy;
 	service?: LiteLLMServiceSpec;
 	resources?: k8s.types.input.core.v1.ResourceRequirements;
+	extraLiteLLMSettings?: Record<string, unknown>;
+	extraGeneralSettings?: Record<string, unknown>;
+	extraRouterSettings?: Record<string, unknown>;
 }
 
 export interface LiteLLMGeneratedConfig {
 	configYaml: string;
 	providerEnvVars: string[];
+}
+
+export interface LiteLLMAdminTargetArgs {
+	proxyNamespace: pulumi.Input<string>;
+	masterKey: pulumi.Input<string>;
+	proxyDeploymentName?: pulumi.Input<string>;
+}
+
+export interface LiteLLMApiKeyArgs extends LiteLLMAdminTargetArgs {
+	keyAlias: pulumi.Input<string>;
+	models?: pulumi.Input<pulumi.Input<string>[]>;
+	teamId?: pulumi.Input<string>;
+	userId?: pulumi.Input<string>;
+	budgetId?: pulumi.Input<string>;
+	maxBudget?: pulumi.Input<number>;
+	budgetDuration?: pulumi.Input<string>;
+	duration?: pulumi.Input<string>;
+	aliases?: pulumi.Input<Record<string, pulumi.Input<string>>>;
+	tags?: pulumi.Input<pulumi.Input<string>[]>;
+	metadata?: pulumi.Input<Record<string, pulumi.Input<string>>>;
+}
+
+export interface LiteLLMTeamArgs extends LiteLLMAdminTargetArgs {
+	teamAlias: pulumi.Input<string>;
+	teamId?: pulumi.Input<string>;
+	models?: pulumi.Input<pulumi.Input<string>[]>;
+	maxBudget?: pulumi.Input<number>;
+	budgetDuration?: pulumi.Input<string>;
+	tags?: pulumi.Input<pulumi.Input<string>[]>;
+	metadata?: pulumi.Input<Record<string, pulumi.Input<string>>>;
 }

--- a/packages/sector7/litellm/config-types.ts
+++ b/packages/sector7/litellm/config-types.ts
@@ -158,6 +158,7 @@ export interface LiteLLMAdminTargetArgs {
 	proxyNamespace: pulumi.Input<string>;
 	masterKey: pulumi.Input<string>;
 	proxyDeploymentName?: pulumi.Input<string>;
+	proxyPort?: pulumi.Input<number>;
 }
 
 export interface LiteLLMApiKeyArgs extends LiteLLMAdminTargetArgs {

--- a/packages/sector7/litellm/config.ts
+++ b/packages/sector7/litellm/config.ts
@@ -10,6 +10,7 @@ import type {
 } from "./config-types.ts";
 
 type ResolvedProviderConfig = {
+	hasApiKey?: boolean;
 	envVar?: string;
 	apiBase?: string;
 };
@@ -77,8 +78,16 @@ function toUpperSnakeCase(value: string): string {
 export function getProviderEnvVar(
 	providerName: string,
 	provider: ResolvedProviderConfig,
-): string {
-	return provider.envVar ?? `${toUpperSnakeCase(providerName)}_API_KEY`;
+): string | undefined {
+	if (provider.envVar) {
+		return provider.envVar;
+	}
+
+	if (provider.hasApiKey) {
+		return `${toUpperSnakeCase(providerName)}_API_KEY`;
+	}
+
+	return undefined;
 }
 
 function addIfDefined(
@@ -89,6 +98,19 @@ function addIfDefined(
 	if (value !== undefined) {
 		target[key] = value;
 	}
+}
+
+function mergeObjects(
+	...sources: Array<Record<string, unknown> | undefined>
+): Record<string, unknown> {
+	const merged: Record<string, unknown> = {};
+	for (const source of sources) {
+		if (!source) {
+			continue;
+		}
+		Object.assign(merged, source);
+	}
+	return merged;
 }
 
 function buildFallbackMap(
@@ -164,6 +186,9 @@ export function validateLiteLLMConfig(args: {
 	const envVars = new Set<string>();
 	for (const [providerName, provider] of Object.entries(args.providers)) {
 		const envVar = getProviderEnvVar(providerName, provider);
+		if (!envVar) {
+			continue;
+		}
 		if (envVars.has(envVar)) {
 			throw new Error(`Duplicate LiteLLM provider env var: ${envVar}`);
 		}
@@ -186,12 +211,15 @@ export function generateLiteLLMConfig(args: {
 	redis?: LiteLLMRedisPolicy;
 	router?: LiteLLMRouterPolicy;
 	replicas?: number;
+	extraLiteLLMSettings?: Record<string, unknown>;
+	extraGeneralSettings?: Record<string, unknown>;
+	extraRouterSettings?: Record<string, unknown>;
 }): LiteLLMGeneratedConfig {
 	validateLiteLLMConfig(args);
 
-	const providerEnvVars = Object.entries(args.providers).map(
-		([providerName, provider]) => getProviderEnvVar(providerName, provider),
-	);
+	const providerEnvVars = Object.entries(args.providers)
+		.map(([providerName, provider]) => getProviderEnvVar(providerName, provider))
+		.filter((value): value is string => value !== undefined);
 	const deploymentsById = new Map(
 		args.deployments.map((deployment) => [deployment.id, deployment] as const),
 	);
@@ -207,10 +235,11 @@ export function generateLiteLLMConfig(args: {
 
 			const provider = args.providers[deployment.provider];
 			const envVar = getProviderEnvVar(deployment.provider, provider);
-			const litellmParams: Record<string, unknown> = {
-				model: deployment.providerModel,
-				api_key: `os.environ/${envVar}`,
-			};
+			const litellmParams = mergeObjects(deployment.extraLiteLLMParams);
+			litellmParams.model = deployment.providerModel;
+			if (envVar) {
+				litellmParams.api_key = `os.environ/${envVar}`;
+			}
 			addIfDefined(
 				litellmParams,
 				"api_base",
@@ -218,6 +247,8 @@ export function generateLiteLLMConfig(args: {
 			);
 			addIfDefined(litellmParams, "rpm", deployment.rpm);
 			addIfDefined(litellmParams, "tpm", deployment.tpm);
+			addIfDefined(litellmParams, "rpd", deployment.rpd);
+			addIfDefined(litellmParams, "tpd", deployment.tpd);
 			addIfDefined(litellmParams, "weight", deployment.weight);
 			addIfDefined(litellmParams, "order", deployment.order);
 
@@ -225,10 +256,18 @@ export function generateLiteLLMConfig(args: {
 				...(deployment.accessGroups ?? []),
 				...(group.accessGroups ?? []),
 			]);
+			const tags = new Set<string>([
+				...(deployment.tags ?? []),
+				...(group.tags ?? []),
+			]);
 
-			const modelInfo: Record<string, unknown> = {
-				id: deployment.id,
-			};
+			const modelInfo = mergeObjects(
+				group.extraModelInfo,
+				deployment.extraModelInfo,
+				{
+					id: deployment.id,
+				},
+			);
 			addIfDefined(
 				modelInfo,
 				"base_model",
@@ -251,6 +290,22 @@ export function generateLiteLLMConfig(args: {
 				"output_cost_per_token",
 				deployment.outputCostPerToken,
 			);
+			addIfDefined(
+				modelInfo,
+				"team_id",
+				deployment.teamId ?? group.teamId,
+			);
+			addIfDefined(
+				modelInfo,
+				"team_alias",
+				deployment.teamAlias ?? group.teamAlias,
+			);
+			addIfDefined(
+				modelInfo,
+				"team_public_model_name",
+				deployment.teamPublicModelName ?? group.teamPublicModelName,
+			);
+			addIfDefined(modelInfo, "tags", tags.size > 0 ? [...tags] : undefined);
 
 			return {
 				model_name: group.name,
@@ -299,6 +354,7 @@ export function generateLiteLLMConfig(args: {
 				: {}),
 		};
 	}
+	Object.assign(litellmSettings, args.extraLiteLLMSettings ?? {});
 
 	const governance = {
 		...DEFAULT_GOVERNANCE,
@@ -339,6 +395,7 @@ export function generateLiteLLMConfig(args: {
 		"use_redis_transaction_buffer",
 		args.redis?.useRedisTransactionBuffer,
 	);
+	Object.assign(generalSettings, args.extraGeneralSettings ?? {});
 
 	const router = {
 		...DEFAULT_ROUTER,
@@ -369,6 +426,7 @@ export function generateLiteLLMConfig(args: {
 	if (contextWindowFallbacks.length > 0) {
 		routerSettings.context_window_fallbacks = contextWindowFallbacks;
 	}
+	Object.assign(routerSettings, args.extraRouterSettings ?? {});
 
 	const configYaml = stringify(
 		{

--- a/packages/sector7/litellm/config.ts
+++ b/packages/sector7/litellm/config.ts
@@ -354,8 +354,6 @@ export function generateLiteLLMConfig(args: {
 				: {}),
 		};
 	}
-	Object.assign(litellmSettings, args.extraLiteLLMSettings ?? {});
-
 	const governance = {
 		...DEFAULT_GOVERNANCE,
 		...args.governance,
@@ -376,6 +374,7 @@ export function generateLiteLLMConfig(args: {
 		"default_key_generate_params",
 		args.governance?.defaultKeyGenerateParams,
 	);
+	Object.assign(litellmSettings, args.extraLiteLLMSettings ?? {});
 
 	const generalSettings: Record<string, unknown> = {
 		master_key: "os.environ/LITELLM_MASTER_KEY",

--- a/packages/sector7/litellm/index.ts
+++ b/packages/sector7/litellm/index.ts
@@ -1,14 +1,23 @@
 export { generateLiteLLMConfig } from "./config.ts";
 export type {
+	BuildLiteLLMTeamScopedModelGroupsArgs,
+	LiteLLMAdminTargetArgs,
+	LiteLLMApiKeyArgs,
 	LiteLLMGeneratedConfig,
 	LiteLLMGovernancePolicy,
 	LiteLLMModelDeployment,
 	LiteLLMModelGroup,
+	LiteLLMModelMode,
 	LiteLLMObservabilityPolicy,
 	LiteLLMProviderConfig,
 	LiteLLMProxyArgs,
 	LiteLLMRedisPolicy,
 	LiteLLMRouterPolicy,
 	LiteLLMServiceSpec,
+	LiteLLMTeamArgs,
+	LiteLLMTeamCapability,
+	LiteLLMTeamDefinition,
 } from "./config-types.ts";
+export { LiteLLMApiKey, LiteLLMTeam } from "./admin.ts";
 export { LiteLLMProxy } from "./litellm-proxy.ts";
+export { buildLiteLLMTeamScopedModelGroups } from "./team-plan.ts";

--- a/packages/sector7/litellm/litellm-proxy.ts
+++ b/packages/sector7/litellm/litellm-proxy.ts
@@ -10,7 +10,8 @@ import type {
 
 type ResolvedProviderConfig = {
 	name: string;
-	envVar: string;
+	hasApiKey: boolean;
+	envVar?: string;
 	apiBase?: string;
 };
 
@@ -27,10 +28,19 @@ function resolveProviderConfig(
 	provider: LiteLLMProviderConfig,
 ): pulumi.Output<ResolvedProviderConfig> {
 	return pulumi
-		.all([pulumi.output(provider.envVar), pulumi.output(provider.apiBase)])
-		.apply(([envVar, apiBase]) => ({
+		.all([
+			pulumi.output(provider.apiKey),
+			pulumi.output(provider.envVar),
+			pulumi.output(provider.apiBase),
+		])
+		.apply(([apiKey, envVar, apiBase]) => ({
 			name: providerName,
-			envVar: getProviderEnvVar(providerName, { envVar: envVar ?? undefined }),
+			hasApiKey: apiKey !== undefined,
+			envVar:
+				getProviderEnvVar(providerName, {
+					hasApiKey: apiKey !== undefined,
+					envVar: envVar ?? undefined,
+				}) ?? undefined,
 			apiBase: apiBase ?? undefined,
 		}));
 }
@@ -81,12 +91,24 @@ export class LiteLLMProxy extends pulumi.ComponentResource {
 			Object.entries(args.providers).map(([providerName, provider]) =>
 				pulumi
 					.all([pulumi.output(provider.apiKey), pulumi.output(provider.envVar)])
-					.apply(([apiKey, envVar]) => ({
-						envVar: getProviderEnvVar(providerName, {
+					.apply(([apiKey, envVar]) => {
+						if (apiKey === undefined) {
+							return undefined;
+						}
+						const resolvedEnvVar = getProviderEnvVar(providerName, {
+							hasApiKey: true,
 							envVar: envVar ?? undefined,
-						}),
-						apiKey,
-					})),
+						});
+						if (!resolvedEnvVar) {
+							throw new Error(
+								`Expected env var for LiteLLM provider '${providerName}' with apiKey`,
+							);
+						}
+						return {
+							envVar: resolvedEnvVar,
+							apiKey,
+						};
+					}),
 			),
 		);
 		const resolvedDeployments = pulumi.all(
@@ -95,18 +117,21 @@ export class LiteLLMProxy extends pulumi.ComponentResource {
 
 		const providerSecretName = `${name}-provider-keys`;
 
-		const providerStringData = resolvedProviderSecrets.apply(
-			(secretProviders) =>
-				Object.fromEntries(
-					secretProviders.map((provider) => [
+		const providerStringData = resolvedProviderSecrets.apply((secretProviders) =>
+			Object.fromEntries(
+				secretProviders
+					.filter((provider) => provider !== undefined)
+					.map((provider) => [
 						toSecretKey(provider.envVar),
 						provider.apiKey,
 					]),
-				),
+			),
 		);
 
 		const providerEnvVars = resolvedProviderConfigs.apply((providers) =>
-			providers.map((provider) => provider.envVar),
+			providers
+				.filter((provider) => provider.hasApiKey && provider.envVar)
+				.map((provider) => provider.envVar!)
 		);
 
 		const configYaml = pulumi
@@ -116,6 +141,7 @@ export class LiteLLMProxy extends pulumi.ComponentResource {
 					providers.map((provider) => [
 						provider.name,
 						{
+							hasApiKey: provider.hasApiKey,
 							envVar: provider.envVar,
 							apiBase: provider.apiBase,
 						},
@@ -131,6 +157,9 @@ export class LiteLLMProxy extends pulumi.ComponentResource {
 					redis: args.redis,
 					router: args.router,
 					replicas: resolvedReplicas,
+					extraLiteLLMSettings: args.extraLiteLLMSettings,
+					extraGeneralSettings: args.extraGeneralSettings,
+					extraRouterSettings: args.extraRouterSettings,
 				});
 
 				return generatedConfig.configYaml;

--- a/packages/sector7/litellm/team-plan.ts
+++ b/packages/sector7/litellm/team-plan.ts
@@ -1,0 +1,68 @@
+import type {
+	BuildLiteLLMTeamScopedModelGroupsArgs,
+	LiteLLMModelGroup,
+	LiteLLMTeamDefinition,
+} from "./config-types.ts";
+
+const DEFAULT_SEPARATOR = "::";
+
+function toInternalModelGroupName(
+	team: LiteLLMTeamDefinition,
+	capabilityName: string,
+	separator: string,
+): string {
+	return `${team.id}${separator}${capabilityName}`;
+}
+
+export function buildLiteLLMTeamScopedModelGroups(
+	args: BuildLiteLLMTeamScopedModelGroupsArgs,
+): LiteLLMModelGroup[] {
+	const separator = args.separator ?? DEFAULT_SEPARATOR;
+	const groups: LiteLLMModelGroup[] = [];
+	const internalNames = new Set<string>();
+
+	for (const team of args.teams) {
+		const capabilityNames = new Set<string>();
+		for (const capability of team.capabilities) {
+			if (capabilityNames.has(capability.name)) {
+				throw new Error(
+					`Duplicate capability '${capability.name}' for LiteLLM team '${team.id}'`,
+				);
+			}
+			capabilityNames.add(capability.name);
+		}
+
+		for (const capability of team.capabilities) {
+			const internalName = toInternalModelGroupName(
+				team,
+				capability.name,
+				separator,
+			);
+			if (internalNames.has(internalName)) {
+				throw new Error(
+					`Duplicate internal LiteLLM model group '${internalName}'`,
+				);
+			}
+			internalNames.add(internalName);
+
+			groups.push({
+				name: internalName,
+				deploymentIds: capability.deploymentIds,
+				fallbacks: capability.fallbacks?.map((fallback) =>
+					toInternalModelGroupName(team, fallback, separator),
+				),
+				contextWindowFallbacks: capability.contextWindowFallbacks?.map(
+					(fallback) => toInternalModelGroupName(team, fallback, separator),
+				),
+				accessGroups: capability.accessGroups,
+				teamId: team.id,
+				teamAlias: team.alias,
+				teamPublicModelName: capability.name,
+				tags: capability.tags,
+				extraModelInfo: capability.extraModelInfo,
+			});
+		}
+	}
+
+	return groups;
+}

--- a/packages/sector7/scripts/litellm-admin.sh
+++ b/packages/sector7/scripts/litellm-admin.sh
@@ -1,0 +1,179 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ACTION="${1:-}"
+
+require_env() {
+  local name="$1"
+  if [[ -z "${!name:-}" ]]; then
+    echo "missing required env: $name" >&2
+    exit 1
+  fi
+}
+
+run_proxy_python() {
+  local body_b64="$1"
+  local path="$2"
+
+  kubectl exec -i \
+    -n "$LITELLM_PROXY_NAMESPACE" \
+    "deploy/$LITELLM_PROXY_DEPLOYMENT" -- \
+    python3 - "$LITELLM_MASTER_KEY" "$body_b64" "$path" <<'PYEOF'
+import base64
+import json
+import sys
+import urllib.error
+import urllib.request
+
+master_key = sys.argv[1]
+body = json.loads(base64.b64decode(sys.argv[2]).decode())
+path = sys.argv[3]
+
+req = urllib.request.Request(
+    f"http://localhost:4000{path}",
+    data=json.dumps(body).encode(),
+    headers={
+        "Authorization": f"Bearer {master_key}",
+        "Content-Type": "application/json",
+    },
+    method="POST",
+)
+
+try:
+    with urllib.request.urlopen(req, timeout=30) as resp:
+        payload = json.loads(resp.read().decode())
+        if isinstance(payload, dict) and "error" in payload:
+            print(json.dumps(payload["error"]), file=sys.stderr)
+            sys.exit(1)
+        print(json.dumps(payload))
+except urllib.error.HTTPError as exc:
+    body_text = exc.read().decode()
+    print(f"HTTP {exc.code}: {body_text}", file=sys.stderr)
+    sys.exit(1)
+except Exception as exc:
+    print(str(exc), file=sys.stderr)
+    sys.exit(1)
+PYEOF
+}
+
+extract_field() {
+  local json_text="$1"
+  local field="$2"
+  python3 - "$field" <<'PYEOF' <<<"$json_text"
+import json
+import sys
+
+field = sys.argv[1]
+payload = json.loads(sys.stdin.read())
+value = payload
+for part in field.split('.'):
+    if isinstance(value, dict):
+        value = value.get(part)
+    else:
+        value = None
+        break
+if value is None:
+    sys.exit(1)
+if isinstance(value, (dict, list)):
+    print(json.dumps(value))
+else:
+    print(value)
+PYEOF
+}
+
+require_env LITELLM_PROXY_NAMESPACE
+require_env LITELLM_MASTER_KEY
+require_env LITELLM_PROXY_DEPLOYMENT
+
+case "$ACTION" in
+  create-key)
+    require_env LITELLM_KEY_ALIAS
+    require_env LITELLM_KEY_VALUE
+    body=$(python3 - <<'PYEOF'
+import json
+import os
+
+body = {
+    "key_alias": os.environ["LITELLM_KEY_ALIAS"],
+    "key": os.environ["LITELLM_KEY_VALUE"],
+    "models": json.loads(os.environ.get("LITELLM_KEY_MODELS_JSON", "[]")),
+    "aliases": json.loads(os.environ.get("LITELLM_KEY_ALIASES_JSON", "{}")),
+    "metadata": json.loads(os.environ.get("LITELLM_KEY_METADATA_JSON", "{}")),
+    "tags": json.loads(os.environ.get("LITELLM_KEY_TAGS_JSON", "[]")),
+}
+for env_key, body_key in [
+    ("LITELLM_KEY_TEAM_ID", "team_id"),
+    ("LITELLM_KEY_USER_ID", "user_id"),
+    ("LITELLM_KEY_BUDGET_ID", "budget_id"),
+    ("LITELLM_KEY_MAX_BUDGET", "max_budget"),
+    ("LITELLM_KEY_BUDGET_DURATION", "budget_duration"),
+    ("LITELLM_KEY_DURATION", "duration"),
+]:
+    value = os.environ.get(env_key, "")
+    if value == "":
+        continue
+    if body_key == "max_budget":
+        body[body_key] = float(value)
+    else:
+        body[body_key] = value
+print(json.dumps(body))
+PYEOF
+)
+    response=$(run_proxy_python "$(printf '%s' "$body" | base64)" "/key/generate")
+    extract_field "$response" "token"
+    ;;
+
+  delete-key)
+    token_id="${__PULUMI_COMMAND_ID__:-}"
+    if [[ -z "$token_id" ]]; then
+      exit 0
+    fi
+    body=$(printf '{"keys":["%s"]}' "$token_id")
+    run_proxy_python "$(printf '%s' "$body" | base64)" "/key/delete" >/dev/null || true
+    ;;
+
+  create-team)
+    require_env LITELLM_TEAM_ALIAS
+    body=$(python3 - <<'PYEOF'
+import json
+import os
+
+body = {
+    "team_alias": os.environ["LITELLM_TEAM_ALIAS"],
+    "models": json.loads(os.environ.get("LITELLM_TEAM_MODELS_JSON", "[]")),
+    "tags": json.loads(os.environ.get("LITELLM_TEAM_TAGS_JSON", "[]")),
+    "metadata": json.loads(os.environ.get("LITELLM_TEAM_METADATA_JSON", "{}")),
+}
+for env_key, body_key in [
+    ("LITELLM_TEAM_ID", "team_id"),
+    ("LITELLM_TEAM_MAX_BUDGET", "max_budget"),
+    ("LITELLM_TEAM_BUDGET_DURATION", "budget_duration"),
+]:
+    value = os.environ.get(env_key, "")
+    if value == "":
+        continue
+    if body_key == "max_budget":
+        body[body_key] = float(value)
+    else:
+        body[body_key] = value
+print(json.dumps(body))
+PYEOF
+)
+    response=$(run_proxy_python "$(printf '%s' "$body" | base64)" "/team/new")
+    extract_field "$response" "team_id"
+    ;;
+
+  delete-team)
+    team_id="${LITELLM_TEAM_ID:-${__PULUMI_COMMAND_ID__:-}}"
+    if [[ -z "$team_id" ]]; then
+      exit 0
+    fi
+    body=$(printf '{"team_ids":["%s"]}' "$team_id")
+    run_proxy_python "$(printf '%s' "$body" | base64)" "/team/delete" >/dev/null || true
+    ;;
+
+  *)
+    echo "usage: $0 {create-key|delete-key|create-team|delete-team}" >&2
+    exit 1
+    ;;
+esac

--- a/packages/sector7/scripts/litellm-admin.sh
+++ b/packages/sector7/scripts/litellm-admin.sh
@@ -14,23 +14,26 @@ require_env() {
 run_proxy_python() {
   local body_b64="$1"
   local path="$2"
+  local master_key_b64
+  master_key_b64=$(printf '%s' "$LITELLM_MASTER_KEY" | base64)
 
   kubectl exec -i \
     -n "$LITELLM_PROXY_NAMESPACE" \
     "deploy/$LITELLM_PROXY_DEPLOYMENT" -- \
-    python3 - "$LITELLM_MASTER_KEY" "$body_b64" "$path" <<'PYEOF'
+    python3 - "$body_b64" "$path" "${LITELLM_PROXY_PORT:-4000}" <<PYEOF
 import base64
 import json
 import sys
 import urllib.error
 import urllib.request
 
-master_key = sys.argv[1]
-body = json.loads(base64.b64decode(sys.argv[2]).decode())
-path = sys.argv[3]
+master_key = base64.b64decode("${master_key_b64}").decode()
+body = json.loads(base64.b64decode(sys.argv[1]).decode())
+path = sys.argv[2]
+port = int(sys.argv[3])
 
 req = urllib.request.Request(
-    f"http://localhost:4000{path}",
+    f"http://localhost:{port}{path}",
     data=json.dumps(body).encode(),
     headers={
         "Authorization": f"Bearer {master_key}",
@@ -124,12 +127,12 @@ PYEOF
     ;;
 
   delete-key)
-    token_id="${__PULUMI_COMMAND_ID__:-}"
+    token_id="${PULUMI_COMMAND_STDOUT:-${LITELLM_KEY_VALUE:-}}"
     if [[ -z "$token_id" ]]; then
       exit 0
     fi
     body=$(printf '{"keys":["%s"]}' "$token_id")
-    run_proxy_python "$(printf '%s' "$body" | base64)" "/key/delete" >/dev/null || true
+    run_proxy_python "$(printf '%s' "$body" | base64)" "/key/delete" >/dev/null
     ;;
 
   create-team)
@@ -164,12 +167,12 @@ PYEOF
     ;;
 
   delete-team)
-    team_id="${LITELLM_TEAM_ID:-${__PULUMI_COMMAND_ID__:-}}"
+    team_id="${LITELLM_TEAM_ID:-${PULUMI_COMMAND_STDOUT:-}}"
     if [[ -z "$team_id" ]]; then
       exit 0
     fi
     body=$(printf '{"team_ids":["%s"]}' "$team_id")
-    run_proxy_python "$(printf '%s' "$body" | base64)" "/team/delete" >/dev/null || true
+    run_proxy_python "$(printf '%s' "$body" | base64)" "/team/delete" >/dev/null
     ;;
 
   *)

--- a/packages/sector7/tests/litellm-config.test.ts
+++ b/packages/sector7/tests/litellm-config.test.ts
@@ -139,8 +139,12 @@ describe("generateLiteLLMConfig", () => {
 			observability: {
 				successCallbacks: ["prometheus"],
 			},
+			governance: {
+				maxBudget: 50,
+			},
 			extraLiteLLMSettings: {
 				json_logs: true,
+				max_budget: 999,
 			},
 			extraGeneralSettings: {
 				enforce_user_param: false,
@@ -181,6 +185,7 @@ describe("generateLiteLLMConfig", () => {
 
 		const litellmSettings = parsed.litellm_settings as Record<string, unknown>;
 		expect(litellmSettings.json_logs).toBe(true);
+		expect(litellmSettings.max_budget).toBe(999);
 		expect(litellmSettings.success_callback).toEqual(["prometheus"]);
 	});
 

--- a/packages/sector7/tests/litellm-config.test.ts
+++ b/packages/sector7/tests/litellm-config.test.ts
@@ -1,13 +1,15 @@
 import { describe, expect, it } from "vitest";
 import { parse } from "yaml";
 import { generateLiteLLMConfig } from "../litellm/config.ts";
+import { buildLiteLLMTeamScopedModelGroups } from "../litellm/team-plan.ts";
 
 describe("generateLiteLLMConfig", () => {
 	it("generates grouped model config with fallbacks and env-based secrets", () => {
 		const generated = generateLiteLLMConfig({
 			providers: {
-				anthropic: { envVar: "ANTHROPIC_API_KEY" },
+				anthropic: { hasApiKey: true, envVar: "ANTHROPIC_API_KEY" },
 				openai: {
+					hasApiKey: true,
 					envVar: "OPENAI_API_KEY",
 					apiBase: "https://api.openai.example/v1",
 				},
@@ -88,6 +90,100 @@ describe("generateLiteLLMConfig", () => {
 		expect(generalSettings.master_key).toBe("os.environ/LITELLM_MASTER_KEY");
 	});
 
+	it("supports secretless internal upstreams, team aliases, and extra settings", () => {
+		const modelGroups = buildLiteLLMTeamScopedModelGroups({
+			teams: [
+				{
+					id: "personal",
+					alias: "Personal",
+					capabilities: [
+						{
+							name: "coding",
+							deploymentIds: ["codex-main"],
+							fallbacks: ["cheap"],
+							accessGroups: ["core"],
+							tags: ["personal"],
+						},
+						{
+							name: "cheap",
+							deploymentIds: ["cheap-main"],
+						},
+					],
+				},
+			],
+		});
+
+		const generated = generateLiteLLMConfig({
+			providers: {
+				codex: { apiBase: "http://codex-proxy.default.svc.cluster.local:9879" },
+				openai: { hasApiKey: true },
+			},
+			deployments: [
+				{
+					id: "codex-main",
+					provider: "codex",
+					providerModel: "openai/gpt-5-codex",
+					teamId: "personal",
+					teamPublicModelName: "coding",
+					tags: ["internal"],
+					extraLiteLLMParams: { stream_timeout: 45 },
+					extraModelInfo: { owner: "personal-billing" },
+				},
+				{
+					id: "cheap-main",
+					provider: "openai",
+					providerModel: "openai/gpt-4o-mini",
+				},
+			],
+			modelGroups,
+			observability: {
+				successCallbacks: ["prometheus"],
+			},
+			extraLiteLLMSettings: {
+				json_logs: true,
+			},
+			extraGeneralSettings: {
+				enforce_user_param: false,
+			},
+			extraRouterSettings: {
+				routing_strategy: "least-busy",
+			},
+		});
+
+		expect(generated.providerEnvVars).toEqual(["OPENAI_API_KEY"]);
+
+		const parsed = parse(generated.configYaml) as Record<string, unknown>;
+		const modelList = parsed.model_list as Array<Record<string, unknown>>;
+		const codingEntry = modelList.find(
+			(entry) => entry.model_name === "personal::coding",
+		);
+		const codingParams = codingEntry?.litellm_params as Record<string, unknown>;
+		const codingInfo = codingEntry?.model_info as Record<string, unknown>;
+		expect(codingParams.api_base).toBe(
+			"http://codex-proxy.default.svc.cluster.local:9879",
+		);
+		expect(codingParams.api_key).toBeUndefined();
+		expect(codingParams.stream_timeout).toBe(45);
+		expect(codingInfo.team_id).toBe("personal");
+		expect(codingInfo.team_public_model_name).toBe("coding");
+		expect(codingInfo.team_alias).toBe("Personal");
+		expect(codingInfo.tags).toEqual(["internal", "personal"]);
+		expect(codingInfo.owner).toBe("personal-billing");
+
+		const routerSettings = parsed.router_settings as Record<string, unknown>;
+		expect(routerSettings.routing_strategy).toBe("least-busy");
+		expect(routerSettings.fallbacks).toEqual([
+			{ "personal::coding": ["personal::cheap"] },
+		]);
+
+		const generalSettings = parsed.general_settings as Record<string, unknown>;
+		expect(generalSettings.enforce_user_param).toBe(false);
+
+		const litellmSettings = parsed.litellm_settings as Record<string, unknown>;
+		expect(litellmSettings.json_logs).toBe(true);
+		expect(litellmSettings.success_callback).toEqual(["prometheus"]);
+	});
+
 	it("rejects missing deployment references and multi-replica without redis", () => {
 		expect(() =>
 			generateLiteLLMConfig({
@@ -117,5 +213,23 @@ describe("generateLiteLLMConfig", () => {
 				replicas: 2,
 			}),
 		).toThrow(/replicas > 1 require redis/i);
+	});
+});
+
+describe("buildLiteLLMTeamScopedModelGroups", () => {
+	it("fails loudly on duplicate capability names within a team", () => {
+		expect(() =>
+			buildLiteLLMTeamScopedModelGroups({
+				teams: [
+					{
+						id: "personal",
+						capabilities: [
+							{ name: "coding", deploymentIds: ["dep-1"] },
+							{ name: "coding", deploymentIds: ["dep-2"] },
+						],
+					},
+				],
+			}),
+		).toThrow(/duplicate capability/i);
 	});
 });

--- a/packages/sector7/tests/litellm-proxy.test.ts
+++ b/packages/sector7/tests/litellm-proxy.test.ts
@@ -1,5 +1,6 @@
 import * as pulumi from "@pulumi/pulumi";
 import { beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { LiteLLMApiKey, LiteLLMTeam } from "../litellm/admin.ts";
 import { LiteLLMProxy } from "../litellm/litellm-proxy.ts";
 
 type MockResource = {
@@ -15,7 +16,13 @@ beforeAll(() => {
 		newResource: (args) => {
 			const state = { ...(args.inputs as Record<string, unknown>) };
 			if (args.type === "random:index/randomPassword:RandomPassword") {
-				state.result = "generated-master-key";
+				state.result =
+					args.name === "personal-coding-key-secret"
+						? "generated-api-key"
+						: "generated-master-key";
+			}
+			if (args.type === "command:local:Command") {
+				state.stdout = `${args.name}-stdout`;
 			}
 			resources.push({
 				type: args.type,
@@ -46,6 +53,22 @@ function resolveOutput<T>(value: pulumi.Input<T>): Promise<T> {
 
 function findResource(name: string): MockResource | undefined {
 	return resources.find((resource) => resource.name === name);
+}
+
+async function resolveRecord(
+	value: Record<string, unknown> | undefined,
+): Promise<Record<string, unknown>> {
+	const resolved = await resolveOutput(value ?? {});
+	if (
+		resolved &&
+		typeof resolved === "object" &&
+		"value" in resolved &&
+		typeof resolved.value === "object" &&
+		resolved.value !== null
+	) {
+		return resolved.value as Record<string, unknown>;
+	}
+	return resolved;
 }
 
 describe("LiteLLMProxy", () => {
@@ -155,7 +178,7 @@ describe("LiteLLMProxy", () => {
 			],
 			modelGroups: [{ name: "smart", deploymentIds: ["anthropic-smart"] }],
 			databaseUrl: pulumi.secret(
-				"postgres://db-user:real-pass@db.internal/litellm",
+				"postgres://db-user:***@db.internal/litellm",
 			),
 		});
 
@@ -163,5 +186,60 @@ describe("LiteLLMProxy", () => {
 
 		expect(findResource("shared-proxy-ns")).toBeUndefined();
 		expect(await resolveOutput(proxy.namespace)).toBe("shared-services");
+	});
+
+	it("creates admin command resources for teams and api keys", async () => {
+		const team = new LiteLLMTeam("personal-team", {
+			proxyNamespace: "litellm-prod",
+			masterKey: pulumi.secret("master-key"),
+			teamAlias: "Personal",
+			teamId: "team-personal",
+			models: ["coding", "cheap"],
+			maxBudget: 250,
+			budgetDuration: "30d",
+			tags: ["personal"],
+			metadata: { owner: "jack" },
+		});
+		const apiKey = new LiteLLMApiKey("personal-coding-key", {
+			proxyNamespace: "litellm-prod",
+			masterKey: pulumi.secret("master-key"),
+			keyAlias: "personal-coding",
+			teamId: "team-personal",
+			models: ["coding"],
+			aliases: { default: "coding" },
+			metadata: { owner: "jack" },
+			tags: ["personal"],
+		});
+
+		expect(await resolveOutput(team.teamId)).toBe("team-personal");
+		expect(await resolveOutput(apiKey.key)).toBe("sk-generated-api-key");
+		expect(await resolveOutput(apiKey.tokenId)).toBe(
+			"personal-coding-key-key-stdout",
+		);
+
+		const teamCommand = findResource("personal-team-team");
+		expect(teamCommand?.type).toBe("command:local:Command");
+		const teamEnvironment = await resolveRecord(
+			teamCommand?.inputs.environment as Record<string, unknown> | undefined,
+		);
+		expect(teamEnvironment).toMatchObject({
+			LITELLM_PROXY_NAMESPACE: "litellm-prod",
+			LITELLM_TEAM_ALIAS: "Personal",
+			LITELLM_TEAM_ID: "team-personal",
+			LITELLM_TEAM_MODELS_JSON: '["coding","cheap"]',
+			LITELLM_TEAM_MAX_BUDGET: "250",
+		});
+
+		const keyCommand = findResource("personal-coding-key-key");
+		expect(keyCommand?.type).toBe("command:local:Command");
+		const keyEnvironment = await resolveRecord(
+			keyCommand?.inputs.environment as Record<string, unknown> | undefined,
+		);
+		expect(keyEnvironment).toMatchObject({
+			LITELLM_KEY_ALIAS: "personal-coding",
+			LITELLM_KEY_TEAM_ID: "team-personal",
+			LITELLM_KEY_MODELS_JSON: '["coding"]',
+			LITELLM_KEY_ALIASES_JSON: '{"default":"coding"}',
+		});
 	});
 });

--- a/packages/sector7/tests/litellm-proxy.test.ts
+++ b/packages/sector7/tests/litellm-proxy.test.ts
@@ -224,6 +224,7 @@ describe("LiteLLMProxy", () => {
 		);
 		expect(teamEnvironment).toMatchObject({
 			LITELLM_PROXY_NAMESPACE: "litellm-prod",
+			LITELLM_PROXY_PORT: "4000",
 			LITELLM_TEAM_ALIAS: "Personal",
 			LITELLM_TEAM_ID: "team-personal",
 			LITELLM_TEAM_MODELS_JSON: '["coding","cheap"]',
@@ -237,6 +238,7 @@ describe("LiteLLMProxy", () => {
 		);
 		expect(keyEnvironment).toMatchObject({
 			LITELLM_KEY_ALIAS: "personal-coding",
+			LITELLM_PROXY_PORT: "4000",
 			LITELLM_KEY_TEAM_ID: "team-personal",
 			LITELLM_KEY_MODELS_JSON: '["coding"]',
 			LITELLM_KEY_ALIASES_JSON: '{"default":"coding"}',


### PR DESCRIPTION
## Summary
- add ADR-024 for team-scoped LiteLLM capability aliases on top of ADR-022
- add a high-level builder that compiles team-scoped capabilities into low-level model groups
- add LiteLLM admin resources for team and key lifecycle plus secretless internal-upstream support
- document the new LiteLLM flow in the public Pulumi docs

## Architecture alignment
This keeps ADR-022's low-level deployment and model-group surface intact, but adds the missing abstraction layer above it.

Callers can now ask for stable aliases like `coding` while routing and spend attribution stay team-scoped. Internally the builder emits deterministic model-group names like `personal::coding`, then attaches LiteLLM team metadata so the public alias remains stable per team.

This also makes internal OpenAI-compatible upstreams such as `codex-proxy` first-class. They can now use `apiBase` without forcing a dummy provider API key secret into the deployment.

## What changed
- `buildLiteLLMTeamScopedModelGroups()` builder for team-scoped public aliases
- optional provider `apiKey` handling in config generation and proxy resource wiring
- new `LiteLLMTeam` and `LiteLLMApiKey` resources backed by an in-cluster admin helper script
- team metadata, tags, and extra config passthrough support in LiteLLM config generation
- ADR-024 and public docs for the new flow

## Test plan
- [x] `pnpm test`
- [x] `pnpm build`

## Risks
- the admin resources depend on LiteLLM admin endpoints and assume the proxy deployment is reachable via `kubectl exec`
- team-scoped public alias behavior depends on current LiteLLM team metadata semantics, so downstream rollout should validate against a real proxy before wider adoption
- this grows the LiteLLM package surface, but the low-level escape hatch remains intact

Closes #197

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new routing abstraction and expands config generation/secret handling, plus adds `kubectl exec`-based admin automation that depends on LiteLLM admin endpoints and in-cluster connectivity.
> 
> **Overview**
> Adds a **team-scoped capability alias layer** for LiteLLM by introducing `buildLiteLLMTeamScopedModelGroups()` to generate deterministic internal model-group names (e.g. `team::capability`) while preserving stable caller-facing aliases via team metadata.
> 
> Extends the LiteLLM proxy/config surface to support **secretless internal upstreams** (provider `apiKey` now optional), richer per-model metadata (team fields, tags, extra params/model info), and passthrough `extra*Settings` merged into generated `litellm_settings`/`general_settings`/`router_settings`.
> 
> Introduces Pulumi admin resources `LiteLLMTeam` and `LiteLLMApiKey` backed by a new `litellm-admin.sh` script that calls LiteLLM admin endpoints via `kubectl exec`, plus updates docs and tests to cover the new builder, metadata, and optional-secret behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b91aa4a4cb5713f41b3e91a423780881209e9599. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->