### PR TITLE
feat: add Renovate preset for sector7 release tarballs

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,16 @@ Configure Renovate with our presets:
 }
 ```
 
+If a consumer repository depends on the packed Sector7 GitHub Release tarball URL, add the dedicated preset or use `all.json`:
+
+```json
+{
+  "extends": [
+    "github>jmmaloney4/sector7//renovate/sector7-release-tarballs.json"
+  ]
+}
+```
+
 ## 🛠️ Development Environment
 
 This repository includes a Nix flake that provides a consistent development environment across all supported platforms.

--- a/docs/public/renovate.md
+++ b/docs/public/renovate.md
@@ -16,8 +16,11 @@ This directory contains composable Renovate presets that can be shared across pr
 
 - **`nix.json`** - Nix-specific configuration with safe regex managers for `fetchPypi` plus `fetchFromGitHub` version bumps; `fetchFromGitHub` hashes are left for manual recomputation (see ADR-023)
 - **`pulumi.json`** - Pulumi-specific configuration and version management
+- **`sector7-release-tarballs.json`** - Package.json dependency updates for `@jmmaloney4/sector7` GitHub release tarballs
 
 > Note: `renovate/nix.json` now still detects `fetchFromGitHub` version bumps, but it does not rewrite the hash. Maintainers recompute the new hash manually before merge.
+
+> Note: `renovate/sector7-release-tarballs.json` handles the packed GitHub Release asset URLs used by consumer repos. It updates the tarball URL in `package.json` and leaves lockfile regeneration to Renovate's normal package manager flow.
 
 ## Usage
 

--- a/flake.nix
+++ b/flake.nix
@@ -54,6 +54,7 @@
           "renovate/minor-patch-automerge.json"
           "renovate/nix.json"
           "renovate/pulumi.json"
+          "renovate/sector7-release-tarballs.json"
           "renovate/security.json"
         ];
 

--- a/renovate/README.md
+++ b/renovate/README.md
@@ -16,6 +16,7 @@ This directory contains composable Renovate presets that can be shared across pr
 
 - **`nix.json`** - Nix-specific configuration with safe regex managers for `fetchPypi` plus `fetchFromGitHub` version bumps; `fetchFromGitHub` hashes are left for manual recomputation (see ADR-023)
 - **`pulumi.json`** - Pulumi-specific configuration and version management
+- **`sector7-release-tarballs.json`** - Package.json dependency updates for `@jmmaloney4/sector7` GitHub release tarballs
 
 ## Usage
 

--- a/renovate/all.json
+++ b/renovate/all.json
@@ -8,6 +8,7 @@
 		"github>jmmaloney4/sector7//renovate/security.json",
 		"github>jmmaloney4/sector7//renovate/pulumi.json",
 		"github>jmmaloney4/sector7//renovate/nix.json",
-		"github>jmmaloney4/sector7//renovate/lock-maintenance.json"
+		"github>jmmaloney4/sector7//renovate/lock-maintenance.json",
+		"github>jmmaloney4/sector7//renovate/sector7-release-tarballs.json"
 	]
 }

--- a/renovate/sector7-release-tarballs.json
+++ b/renovate/sector7-release-tarballs.json
@@ -7,11 +7,12 @@
 			"description": "Update @jmmaloney4/sector7 release tarball URLs in package.json files",
 			"managerFilePatterns": ["/(^|/)package\\.json$/"],
 			"matchStrings": [
-				"\"(?<depName>@jmmaloney4/sector7)\":\\s*\"https://github\\.com/jmmaloney4/sector7/releases/download/sector7-v(?<currentValue>\\d+\\.\\d+\\.\\d+)-[0-9a-f]+/jmmaloney4-sector7-(?:\\d+\\.\\d+\\.\\d+)\\.tgz\""
+				"\"(?<depName>@jmmaloney4/sector7)\":\\s*\"https://github\\.com/jmmaloney4/sector7/releases/download/sector7-v(?<currentValue>\\d+\\.\\d+\\.\\d+-[0-9a-f]+)/jmmaloney4-sector7-(?:\\d+\\.\\d+\\.\\d+)\\.tgz\""
 			],
+			"packageNameTemplate": "jmmaloney4/sector7",
 			"datasourceTemplate": "github-releases",
 			"versioningTemplate": "semver",
-			"autoReplaceStringTemplate": "\"{{{depName}}}\": \"https://github.com/jmmaloney4/sector7/releases/download/sector7-v{{{newValue}}}/jmmaloney4-sector7-{{{newValue}}}.tgz\""
+			"autoReplaceStringTemplate": "\"{{{depName}}}\": \"https://github.com/jmmaloney4/sector7/releases/download/sector7-v{{{newValue}}}/jmmaloney4-sector7-{{{replace '-[0-9a-f]+$' '' newValue}}}.tgz\""
 		}
 	],
 	"packageRules": [

--- a/renovate/sector7-release-tarballs.json
+++ b/renovate/sector7-release-tarballs.json
@@ -21,7 +21,7 @@
 			"matchDatasources": ["github-releases"],
 			"matchPackageNames": ["jmmaloney4/sector7"],
 			"minimumReleaseAge": null,
-			"extractVersion": "^sector7-v(?<version>\\d+\\.\\d+\\.\\d+)-[0-9a-f]+$"
+			"extractVersion": "^sector7-v(?<version>\\d+\\.\\d+\\.\\d+-[0-9a-f]+)$"
 		}
 	]
 }

--- a/renovate/sector7-release-tarballs.json
+++ b/renovate/sector7-release-tarballs.json
@@ -1,0 +1,26 @@
+{
+	"$schema": "https://docs.renovatebot.com/renovate-schema.json",
+	"description": "Renovate configuration for Sector7 GitHub release tarball dependencies",
+	"customManagers": [
+		{
+			"customType": "regex",
+			"description": "Update @jmmaloney4/sector7 release tarball URLs in package.json files",
+			"managerFilePatterns": ["/(^|/)package\\.json$/"],
+			"matchStrings": [
+				"\"(?<depName>@jmmaloney4/sector7)\":\\s*\"https://github\\.com/jmmaloney4/sector7/releases/download/sector7-v(?<currentValue>\\d+\\.\\d+\\.\\d+)-[0-9a-f]+/jmmaloney4-sector7-(?:\\d+\\.\\d+\\.\\d+)\\.tgz\""
+			],
+			"datasourceTemplate": "github-releases",
+			"versioningTemplate": "semver",
+			"autoReplaceStringTemplate": "\"{{{depName}}}\": \"https://github.com/jmmaloney4/sector7/releases/download/sector7-v{{{newValue}}}/jmmaloney4-sector7-{{{newValue}}}.tgz\""
+		}
+	],
+	"packageRules": [
+		{
+			"description": "Treat Sector7 release tarballs as internal dependencies without a stability delay",
+			"matchDatasources": ["github-releases"],
+			"matchPackageNames": ["jmmaloney4/sector7"],
+			"minimumReleaseAge": null,
+			"extractVersion": "^sector7-v(?<version>\\d+\\.\\d+\\.\\d+)-[0-9a-f]+$"
+		}
+	]
+}


### PR DESCRIPTION
## Summary
- Add a Renovate preset for `@jmmaloney4/sector7` GitHub release tarball URLs in consumer `package.json` files
- Wire the preset into the aggregate Renovate config and document it for downstream repos
- Include the new preset in flake-based config validation

## Test plan
- `RENOVATE_CONFIG_FILE=renovate/sector7-release-tarballs.json nix develop -c renovate-config-validator --strict`
- `git diff --check`

## Risks
- This is intentionally scoped to GitHub release tarball URLs, not npm registry packages
- Full `nix flake check -L` still has unrelated treefmt noise elsewhere in the worktree

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new Renovate preset and wires it into config validation and documentation, without changing runtime or deployment code.
> 
> **Overview**
> Adds a new Renovate preset, `renovate/sector7-release-tarballs.json`, that uses a regex custom manager to bump `@jmmaloney4/sector7` dependencies pinned to GitHub Release tarball URLs (and removes any release-age delay for those updates).
> 
> Wires the preset into the aggregate `renovate/all.json`, includes it in Nix flake-based `renovate-config-validator` checks, and documents usage in `README.md` and `docs/public/renovate.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2bd0d6a1fb1bc0b94c9765c86d446c20b6ffcbf3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->