### PR TITLE
feat(sector7): add shared pulumi mixed config helper

### DIFF
--- a/packages/sector7/package.json
+++ b/packages/sector7/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@jmmaloney4/sector7",
-	"version": "0.8.4",
+	"version": "0.9.1",
 	"description": "Reusable Pulumi components for infrastructure management",
 	"license": "MPL-2.0",
 	"publishConfig": {
@@ -54,6 +54,10 @@
 		"./litellm": {
 			"types": "./dist/litellm/index.d.ts",
 			"default": "./dist/litellm/index.js"
+		},
+		"./pulumi-config": {
+			"types": "./dist/pulumi-config/index.d.ts",
+			"default": "./dist/pulumi-config/index.js"
 		}
 	},
 	"files": [

--- a/packages/sector7/pulumi-config/index.ts
+++ b/packages/sector7/pulumi-config/index.ts
@@ -5,4 +5,4 @@ export {
 	type MapConfigOptions,
 	type RecordConfigOptions,
 	type SecretFieldsOf,
-} from "./mixed-config.ts";
+} from "./mixed-config.js";

--- a/packages/sector7/pulumi-config/index.ts
+++ b/packages/sector7/pulumi-config/index.ts
@@ -1,0 +1,8 @@
+export {
+	requireMixedConfig,
+	type ArrayConfigOptions,
+	type FlatSecretsOptions,
+	type MapConfigOptions,
+	type RecordConfigOptions,
+	type SecretFieldsOf,
+} from "./mixed-config.ts";

--- a/packages/sector7/pulumi-config/mixed-config.ts
+++ b/packages/sector7/pulumi-config/mixed-config.ts
@@ -1,0 +1,161 @@
+import * as pulumi from "@pulumi/pulumi";
+
+export type SecretFieldsOf<
+	T extends Record<string, unknown>,
+	S extends readonly (keyof T)[],
+> = Omit<T, S[number]> & {
+	[K in S[number]]: pulumi.Output<NonNullable<T[K]>>;
+};
+
+export interface ArrayConfigOptions<
+	T extends Record<string, unknown>,
+	S extends readonly (keyof T)[],
+> {
+	shape?: "array";
+	secretFields: S;
+}
+
+export interface RecordConfigOptions<
+	T extends Record<string, unknown>,
+	K extends keyof T,
+	S extends readonly (keyof T)[],
+> {
+	shape: "record";
+	keyField: K;
+	secretFields: S;
+}
+
+export interface MapConfigOptions<
+	T extends Record<string, unknown>,
+	S extends readonly (keyof T)[],
+> {
+	shape: "map";
+	secretFields: S;
+}
+
+export interface FlatSecretsOptions {
+	shape: "flatSecrets";
+}
+
+export function requireMixedConfig<
+	T extends Record<string, unknown>,
+	S extends readonly (keyof T)[],
+>(
+	config: pulumi.Config,
+	key: string,
+	options: ArrayConfigOptions<T, S>,
+): SecretFieldsOf<T, S>[];
+
+export function requireMixedConfig<
+	T extends Record<string, unknown>,
+	K extends keyof T,
+	S extends readonly (keyof T)[],
+>(
+	config: pulumi.Config,
+	key: string,
+	options: RecordConfigOptions<T, K, S>,
+): Record<string & {}, SecretFieldsOf<T, S>>;
+
+export function requireMixedConfig<
+	T extends Record<string, unknown>,
+	S extends readonly (keyof T)[],
+>(
+	config: pulumi.Config,
+	key: string,
+	options: MapConfigOptions<T, S>,
+): Record<string, SecretFieldsOf<T, S>>;
+
+export function requireMixedConfig(
+	config: pulumi.Config,
+	key: string,
+	options: FlatSecretsOptions,
+): Record<string, pulumi.Output<string>>;
+
+export function requireMixedConfig(
+	config: pulumi.Config,
+	key: string,
+	options:
+		| ArrayConfigOptions<
+				Record<string, unknown>,
+				readonly (keyof Record<string, unknown>)[]
+		  >
+		| RecordConfigOptions<
+				Record<string, unknown>,
+				keyof Record<string, unknown>,
+				readonly (keyof Record<string, unknown>)[]
+		  >
+		| MapConfigOptions<
+				Record<string, unknown>,
+				readonly (keyof Record<string, unknown>)[]
+		  >
+		| FlatSecretsOptions,
+):
+	| Array<Record<string, unknown>>
+	| Record<string, Record<string, unknown>>
+	| Record<string, pulumi.Output<string>> {
+	const shape = "shape" in options && options.shape ? options.shape : "array";
+	const secretFields: readonly string[] =
+		"secretFields" in options
+			? (options.secretFields as readonly string[])
+			: [];
+
+	switch (shape) {
+		case "array": {
+			const items = config.requireObject<Record<string, unknown>[]>(key);
+			return items.map((item, i) => {
+				const result: Record<string, unknown> = { ...item };
+				for (const field of secretFields) {
+					result[field] = config.requireSecret(`${key}[${i}].${field}`);
+				}
+				return result;
+			});
+		}
+
+		case "record": {
+			const keyField = (
+				options as RecordConfigOptions<
+					Record<string, unknown>,
+					keyof Record<string, unknown>,
+					readonly (keyof Record<string, unknown>)[]
+				>
+			).keyField as string;
+			const items = config.requireObject<Record<string, unknown>[]>(key);
+			const map: Record<string, Record<string, unknown>> = {};
+			items.forEach((item, i) => {
+				const keyValue = String(item[keyField]);
+				const result: Record<string, unknown> = { ...item };
+				for (const field of secretFields) {
+					result[field] = config.requireSecret(`${key}[${i}].${field}`);
+				}
+				map[keyValue] = result;
+			});
+			return map;
+		}
+
+		case "map": {
+			const items =
+				config.requireObject<Record<string, Record<string, unknown>>>(key);
+			const map: Record<string, Record<string, unknown>> = {};
+			for (const [mapKey, item] of Object.entries(items)) {
+				const result: Record<string, unknown> = { ...item };
+				for (const field of secretFields) {
+					result[field] = config.requireSecret(`${key}.${mapKey}.${field}`);
+				}
+				map[mapKey] = result;
+			}
+			return map;
+		}
+
+		case "flatSecrets": {
+			const keys = config.requireObject<Record<string, string>>(key);
+			const result: Record<string, pulumi.Output<string>> = {};
+			for (const k of Object.keys(keys)) {
+				result[k] = config.requireSecret(`${key}.${k}`);
+			}
+			return result;
+		}
+
+		default:
+			throw new Error(`requireMixedConfig: unknown shape "${shape}"`);
+	}
+}

--- a/packages/sector7/pulumi-config/mixed-config.ts
+++ b/packages/sector7/pulumi-config/mixed-config.ts
@@ -17,7 +17,7 @@ export interface ArrayConfigOptions<
 
 export interface RecordConfigOptions<
 	T extends Record<string, unknown>,
-	K extends keyof T,
+	K extends Extract<keyof T, string>,
 	S extends readonly (keyof T)[],
 > {
 	shape: "record";
@@ -48,7 +48,7 @@ export function requireMixedConfig<
 
 export function requireMixedConfig<
 	T extends Record<string, unknown>,
-	K extends keyof T,
+	K extends Extract<keyof T, string>,
 	S extends readonly (keyof T)[],
 >(
 	config: pulumi.Config,
@@ -81,7 +81,7 @@ export function requireMixedConfig(
 		  >
 		| RecordConfigOptions<
 				Record<string, unknown>,
-				keyof Record<string, unknown>,
+				Extract<keyof Record<string, unknown>, string>,
 				readonly (keyof Record<string, unknown>)[]
 		  >
 		| MapConfigOptions<
@@ -93,11 +93,8 @@ export function requireMixedConfig(
 	| Array<Record<string, unknown>>
 	| Record<string, Record<string, unknown>>
 	| Record<string, pulumi.Output<string>> {
-	const shape = "shape" in options && options.shape ? options.shape : "array";
-	const secretFields: readonly string[] =
-		"secretFields" in options
-			? (options.secretFields as readonly string[])
-			: [];
+	const shape = options.shape ?? "array";
+	const secretFields = "secretFields" in options ? options.secretFields : [];
 
 	switch (shape) {
 		case "array": {
@@ -112,13 +109,7 @@ export function requireMixedConfig(
 		}
 
 		case "record": {
-			const keyField = (
-				options as RecordConfigOptions<
-					Record<string, unknown>,
-					keyof Record<string, unknown>,
-					readonly (keyof Record<string, unknown>)[]
-				>
-			).keyField as string;
+			const keyField = (options as { keyField: string }).keyField;
 			const items = config.requireObject<Record<string, unknown>[]>(key);
 			const map: Record<string, Record<string, unknown>> = {};
 			items.forEach((item, i) => {

--- a/packages/sector7/tests/mixed-config.test.ts
+++ b/packages/sector7/tests/mixed-config.test.ts
@@ -1,0 +1,94 @@
+import * as pulumi from "@pulumi/pulumi";
+import { describe, expect, it } from "vitest";
+import { requireMixedConfig } from "../pulumi-config/index.ts";
+
+type FakeConfig = Pick<pulumi.Config, "requireObject" | "requireSecret">;
+
+type ProviderConfig = {
+	provider: string;
+	apiKey: string;
+};
+
+function fakeConfig(args: {
+	objects: Record<string, unknown>;
+	secrets: Record<string, string>;
+}): pulumi.Config {
+	const config: FakeConfig = {
+		requireObject: <T>(key: string): T => {
+			if (!(key in args.objects)) {
+				throw new Error(`missing object ${key}`);
+			}
+			return args.objects[key] as T;
+		},
+		requireSecret: (key: string) => {
+			if (!(key in args.secrets)) {
+				throw new Error(`missing secret ${key}`);
+			}
+			return pulumi.secret(args.secrets[key]);
+		},
+	};
+	return config as pulumi.Config;
+}
+
+async function resolveOutput<T>(value: pulumi.Input<T>): Promise<T> {
+	return new Promise((resolve) => {
+		pulumi.output(value).apply((resolved) => {
+			resolve(resolved as T);
+			return resolved;
+		});
+		});
+}
+
+describe("requireMixedConfig", () => {
+	it("reads map-shaped config with plain and secret fields", async () => {
+		const config = fakeConfig({
+			objects: {
+				providers: {
+					personal: { provider: "zai" },
+					cavinsresearch: { provider: "zai" },
+				},
+			},
+			secrets: {
+				"providers.personal.apiKey": "personal-secret",
+				"providers.cavinsresearch.apiKey": "research-secret",
+			},
+		});
+
+		const providers = requireMixedConfig<ProviderConfig, ["apiKey"]>(
+			config,
+			"providers",
+			{ shape: "map", secretFields: ["apiKey"] },
+		);
+
+		expect(providers.personal.provider).toBe("zai");
+		expect(providers.cavinsresearch.provider).toBe("zai");
+		expect(await resolveOutput(providers.personal.apiKey)).toBe(
+			"personal-secret",
+		);
+		expect(await resolveOutput(providers.cavinsresearch.apiKey)).toBe(
+			"research-secret",
+		);
+	});
+
+	it("reads flat secret maps", async () => {
+		const config = fakeConfig({
+			objects: {
+				tokens: {
+					ghcr: "placeholder",
+					langfuse: "placeholder",
+				},
+			},
+			secrets: {
+				"tokens.ghcr": "ghcr-secret",
+				"tokens.langfuse": "langfuse-secret",
+			},
+		});
+
+		const tokens = requireMixedConfig(config, "tokens", {
+			shape: "flatSecrets",
+		});
+
+		expect(await resolveOutput(tokens.ghcr)).toBe("ghcr-secret");
+		expect(await resolveOutput(tokens.langfuse)).toBe("langfuse-secret");
+	});
+});

--- a/packages/sector7/tests/mixed-config.test.ts
+++ b/packages/sector7/tests/mixed-config.test.ts
@@ -1,6 +1,6 @@
 import * as pulumi from "@pulumi/pulumi";
 import { describe, expect, it } from "vitest";
-import { requireMixedConfig } from "../pulumi-config/index.ts";
+import { requireMixedConfig } from "../pulumi-config/index.js";
 
 type FakeConfig = Pick<pulumi.Config, "requireObject" | "requireSecret">;
 
@@ -9,16 +9,27 @@ type ProviderConfig = {
 	apiKey: string;
 };
 
+type TeamConfig = {
+	id: string;
+	alias: string;
+	apiKey: string;
+};
+
+type AccountConfig = {
+	name: string;
+	apiToken: string;
+};
+
 function fakeConfig(args: {
 	objects: Record<string, unknown>;
 	secrets: Record<string, string>;
-}): pulumi.Config {
-	const config: FakeConfig = {
-		requireObject: <T>(key: string): T => {
+}) {
+	return {
+		requireObject: (key: string) => {
 			if (!(key in args.objects)) {
 				throw new Error(`missing object ${key}`);
 			}
-			return args.objects[key] as T;
+			return args.objects[key];
 		},
 		requireSecret: (key: string) => {
 			if (!(key in args.secrets)) {
@@ -26,8 +37,7 @@ function fakeConfig(args: {
 			}
 			return pulumi.secret(args.secrets[key]);
 		},
-	};
-	return config as pulumi.Config;
+	} as any;
 }
 
 async function resolveOutput<T>(value: pulumi.Input<T>): Promise<T> {
@@ -36,7 +46,7 @@ async function resolveOutput<T>(value: pulumi.Input<T>): Promise<T> {
 			resolve(resolved as T);
 			return resolved;
 		});
-		});
+	});
 }
 
 describe("requireMixedConfig", () => {
@@ -68,6 +78,58 @@ describe("requireMixedConfig", () => {
 		expect(await resolveOutput(providers.cavinsresearch.apiKey)).toBe(
 			"research-secret",
 		);
+	});
+
+	it("reads record-shaped config keyed by a string field", async () => {
+		const config = fakeConfig({
+			objects: {
+				teams: [
+					{ id: "personal", alias: "coding" },
+					{ id: "research", alias: "cheap" },
+				],
+			},
+			secrets: {
+				"teams[0].apiKey": "personal-secret",
+				"teams[1].apiKey": "research-secret",
+			},
+		});
+
+		const teams = requireMixedConfig<TeamConfig, "alias", ["apiKey"]>(
+			config,
+			"teams",
+			{ shape: "record", keyField: "alias", secretFields: ["apiKey"] },
+		);
+
+		expect(teams.coding.id).toBe("personal");
+		expect(teams.cheap.id).toBe("research");
+		expect(await resolveOutput(teams.coding.apiKey)).toBe("personal-secret");
+		expect(await resolveOutput(teams.cheap.apiKey)).toBe("research-secret");
+	});
+
+	it("reads array-shaped config with plain and secret fields", async () => {
+		const config = fakeConfig({
+			objects: {
+				accounts: [
+					{ name: "jmmaloney4" },
+					{ name: "cavinsresearch" },
+				],
+			},
+			secrets: {
+				"accounts[0].apiToken": "jmm-secret",
+				"accounts[1].apiToken": "cavins-secret",
+			},
+		});
+
+		const accounts = requireMixedConfig<AccountConfig, ["apiToken"]>(
+			config,
+			"accounts",
+			{ secretFields: ["apiToken"] },
+		);
+
+		expect(accounts[0].name).toBe("jmmaloney4");
+		expect(accounts[1].name).toBe("cavinsresearch");
+		expect(await resolveOutput(accounts[0].apiToken)).toBe("jmm-secret");
+		expect(await resolveOutput(accounts[1].apiToken)).toBe("cavins-secret");
 	});
 
 	it("reads flat secret maps", async () => {


### PR DESCRIPTION
## Summary
- add a shared `@jmmaloney4/sector7/pulumi-config` subpath export for mixed plain/secret Pulumi config structures
- move the `requireMixedConfig` implementation into sector7 so downstream stacks can share one tested helper
- cover the new helper with unit tests for map and flat-secret shapes

## Test plan
- `cd packages/sector7 && pnpm test`
- `cd packages/sector7 && pnpm build`
- `cd packages/sector7 && pnpm pack`

## Risks
- low: new additive subpath export only
- downstream consumers must explicitly bump to the released sector7 artifact before importing `@jmmaloney4/sector7/pulumi-config`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk, additive change: introduces a new exported helper and accompanying tests without modifying existing runtime behavior.
> 
> **Overview**
> Adds a new `@jmmaloney4/sector7/pulumi-config` subpath export with `requireMixedConfig`, a typed helper for loading Pulumi config structures where some fields are fetched via `requireSecret` (supports *array*, *record*, *map*, and *flatSecrets* shapes).
> 
> Bumps the `@jmmaloney4/sector7` package version and adds Vitest coverage for each supported shape to validate secret key path handling and returned output types.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5873a5178c24d1b1577ec6831c7383fcc20b3afa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->