### PR TITLE
fix(renovate): add regex matchString for Nix let-binding version patterns

### DIFF
--- a/renovate/nix.json
+++ b/renovate/nix.json
@@ -8,7 +8,9 @@
 		{
 			"customType": "regex",
 			"description": "Update fetchPypi packages in Nix files",
-			"managerFilePatterns": ["/nix/.+\\.nix$/"],
+			"managerFilePatterns": [
+				"/nix/.+\\.nix$/"
+			],
 			"matchStrings": [
 				"pname\\s*=\\s*\"(?<depName>[^\"]+)\";\\s*\\n\\s*version\\s*=\\s*\"(?<currentValue>[^\"]+)\";[\\s\\S]*?sha256\\s*=\\s*\"(?<currentDigest>[a-f0-9]{64})\";"
 			],
@@ -16,10 +18,13 @@
 		},
 		{
 			"customType": "regex",
-			"description": "Update fetchFromGitHub packages in Nix files without hash rewrites",
-			"managerFilePatterns": ["/nix/.+\\.nix$/"],
+			"description": "Update fetchFromGitHub packages in Nix files (rec and let-binding patterns)",
+			"managerFilePatterns": [
+				"/nix/.+\\.nix$/"
+			],
 			"matchStrings": [
-				"pname\\s*=\\s*\"(?<depName>[^\"]+)\";\\s+version\\s*=\\s*\"(?<currentValue>[^\"]+)\";[\\s\\S]*?fetchFromGitHub\\s*\\{[\\s\\S]*?owner\\s*=\\s*\"(?<owner>[^\"]+)\";[\\s\\S]*?repo\\s*=\\s*\"(?<repo>[^\"]+)\";[\\s\\S]*?hash\\s*=\\s*\"[^\"]+\";"
+				"pname\\s*=\\s*\"(?<depName>[^\"]+)\";\\s+version\\s*=\\s*\"(?<currentValue>[^\"]+)\";[\\s\\S]*?fetchFromGitHub\\s*\\{[\\s\\S]*?owner\\s*=\\s*\"(?<owner>[^\"]+)\";[\\s\\S]*?repo\\s*=\\s*\"(?<repo>[^\"]+)\";[\\s\\S]*?(?:sha256|hash)\\s*=\\s*\"[^\"]+\";",
+				"let\\s+version\\s*=\\s*\"(?<currentValue>[^\"]+)\";\\s+in[\\s\\S]*?pname\\s*=\\s*\"(?<depName>[^\"]+)\";[\\s\\S]*?fetchFromGitHub\\s*\\{[\\s\\S]*?owner\\s*=\\s*\"(?<owner>[^\"]+)\";[\\s\\S]*?repo\\s*=\\s*\"(?<repo>[^\"]+)\";[\\s\\S]*?(?:sha256|hash)\\s*=\\s*\"[^\"]+\";"
 			],
 			"datasourceTemplate": "github-releases",
 			"depNameTemplate": "{{{owner}}}/{{{repo}}}"


### PR DESCRIPTION
## Problem

The `fetchFromGitHub` regex manager in `renovate/nix.json` only matches `rec { pname = "..."; version = "..."; ... }` patterns. Helm chart derivations that use `let version = "..."; in pkgs.stdenv.mkDerivation { pname = "..."; inherit version; }` are invisible to Renovate.

This caused Renovate to miss updates for:
- `gha-runner-scale-set-controller-chart` (actions/actions-runner-controller)
- `envoy-gateway-crds-chart` (envoyproxy/gateway)

in `jmmaloney4/garden`.

## Fix

Two changes to the fetchFromGitHub manager:

1. **New matchString** for `let`-binding version patterns — matches `let version = "X.Y.Z"; in ... pname = "foo"; ... fetchFromGitHub { owner; repo; hash; }`
2. **Widen hash field matcher** — accept both `hash` and `sha256` attribute names (the ARC chart uses `sha256` while others use `hash`)

## Testing

Both regexes tested against `nix/helm-charts.nix` from garden:
- `cert-manager-chart` — matched by existing regex
- `rancher-chart` — matched by existing regex
- `gha-runner-scale-set-controller-chart` — matched by new regex
- `envoy-gateway-crds-chart` — matched by new regex

Full coverage, no cross-bleed between patterns.

## Risks

- Low. The new regex is additive — existing patterns still match the same packages. The `(?:sha256|hash)` change to the original regex widens the match but does not change named group captures.
- Could theoretically match unintended `let version = ...` bindings in non-chart Nix files, but `managerFilePatterns` already scopes to `/nix/.+\.nix$/`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change that broadens Renovate regex matching for Nix `fetchFromGitHub` dependencies; main risk is unintended matches in Nix files under `/nix`, which would only affect update detection.
> 
> **Overview**
> Improves `renovate/nix.json` so Renovate can pick up more Nix `fetchFromGitHub` dependencies.
> 
> The `fetchFromGitHub` regex manager now (1) matches `let version = "..."; in ...` derivation patterns in addition to the existing `pname/version` block, and (2) treats both `hash` and `sha256` attributes as valid hash fields when scanning for dependencies.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0d6e2df796dcd2f486514b953a38a3c76a43bf5c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->