### PR TITLE
feat(release): unified monorepo versioning with plain semver tags

### DIFF
--- a/.github/actions/analyze-pnpm-packages/action.yml
+++ b/.github/actions/analyze-pnpm-packages/action.yml
@@ -45,14 +45,15 @@ outputs:
     description: Whether there are packages to publish (true/false)
     value: ${{ steps.analyze.outputs.has_packages }}
 
-runs:
-  using: composite
-  steps:
-    - id: analyze
-      shell: bash
-      env:
-        A_DRY_RUN: ${{ inputs.dry_run }}
-        A_TARGET: ${{ inputs.target }}
-        A_ROOT: ${{ inputs.root }}
-        A_GITHUB_REPOSITORY: ${{ inputs.github_repository }}
-      run: $GITHUB_ACTION_PATH/main.sh
+  runs:
+    using: composite
+    steps:
+      - id: analyze
+        shell: bash
+        env:
+          A_DRY_RUN: ${{ inputs.dry_run }}
+          A_TARGET: ${{ inputs.target }}
+          A_ROOT: ${{ inputs.root }}
+          A_GITHUB_REPOSITORY: ${{ inputs.github_repository }}
+          GH_TOKEN: ${{ github.token }}
+        run: bash $GITHUB_ACTION_PATH/main.sh

--- a/.github/actions/analyze-pnpm-packages/action.yml
+++ b/.github/actions/analyze-pnpm-packages/action.yml
@@ -1,8 +1,11 @@
 name: Analyze pnpm packages
 description: >
   Unified monorepo release analyzer. Reads version from root package.json,
-  checks whether a v${version} GitHub Release already exists, and emits a
-  JSON matrix of packages to publish if needed.
+  checks whether a v${version} GitHub Release with all expected tarballs already
+  exists, and emits a JSON matrix of packages to publish if needed.
+
+  Only the 'release' target is supported. Registry targets (ghcr, npm, gcp)
+  have been removed.
 
 inputs:
   dry_run:
@@ -10,31 +13,17 @@ inputs:
     required: false
     default: "false"
   target:
-    description: >
-      Publish target: release (GitHub Release tarball), ghcr (GitHub Packages), npm (npmjs.org), gcp (Google Artifact Registry).
-
+    description: Publish target. Only "release" (GitHub Release tarball) is supported.
     required: false
     default: "release"
-  registry:
-    description: >
-      npm registry URL for ghcr/npm/gcp targets. Ignored when target=release.
-
-    required: false
-    default: "https://npm.pkg.github.com"
   root:
     description: repo root
     required: false
     default: "."
-  scope:
-    description: >
-      Deprecated. Kept for backward compatibility with callers. No longer used by the action.
-
-    required: false
   github_repository:
     description: >
       Owner/repository for GitHub Release checks. Defaults to the workflow's
       github.repository (set automatically by GitHub Actions).
-
     required: false
     default: "${{ github.repository }}"
 

--- a/.github/actions/analyze-pnpm-packages/action.yml
+++ b/.github/actions/analyze-pnpm-packages/action.yml
@@ -45,15 +45,15 @@ outputs:
     description: Whether there are packages to publish (true/false)
     value: ${{ steps.analyze.outputs.has_packages }}
 
-  runs:
-    using: composite
-    steps:
-      - id: analyze
-        shell: bash
-        env:
-          A_DRY_RUN: ${{ inputs.dry_run }}
-          A_TARGET: ${{ inputs.target }}
-          A_ROOT: ${{ inputs.root }}
-          A_GITHUB_REPOSITORY: ${{ inputs.github_repository }}
-          GH_TOKEN: ${{ github.token }}
-        run: bash $GITHUB_ACTION_PATH/main.sh
+runs:
+  using: composite
+  steps:
+    - id: analyze
+      shell: bash
+      env:
+        A_DRY_RUN: ${{ inputs.dry_run }}
+        A_TARGET: ${{ inputs.target }}
+        A_ROOT: ${{ inputs.root }}
+        A_GITHUB_REPOSITORY: ${{ inputs.github_repository }}
+        GH_TOKEN: ${{ github.token }}
+      run: bash $GITHUB_ACTION_PATH/main.sh

--- a/.github/actions/analyze-pnpm-packages/action.yml
+++ b/.github/actions/analyze-pnpm-packages/action.yml
@@ -1,6 +1,8 @@
 name: Analyze pnpm packages
 description: >
-  Detect packages under packages/*, check whether they need publishing, and emit a JSON matrix and summary. Supports multiple publish targets: release (GitHub Release tarball assets), ghcr (GitHub Packages npm registry), npm (npmjs.org), and gcp (Google Artifact Registry npm).
+  Unified monorepo release analyzer. Reads version from root package.json,
+  checks whether a v${version} GitHub Release already exists, and emits a
+  JSON matrix of packages to publish if needed.
 
 inputs:
   dry_run:
@@ -15,7 +17,7 @@ inputs:
     default: "release"
   registry:
     description: >
-      npm registry URL for ghcr/npm/gcp targets. Defaults to https://npm.pkg.github.com for ghcr. Ignored when target=release.
+      npm registry URL for ghcr/npm/gcp targets. Ignored when target=release.
 
     required: false
     default: "https://npm.pkg.github.com"
@@ -24,21 +26,25 @@ inputs:
     required: false
     default: "."
   scope:
-    description: npm scope filter (e.g., @jmmaloney4); if set, only include scoped packages
+    description: >
+      Deprecated. Kept for backward compatibility with callers. No longer used by the action.
+
     required: false
   github_repository:
     description: >
-      Owner/repository for GitHub Release asset checks when target=release. Defaults to ${{ github.repository }}.
+      Owner/repository for GitHub Release checks. Defaults to ${{ github.repository }}.
 
     required: false
     default: ""
+
 outputs:
   matrix:
-    description: JSON matrix of packages and actions
+    description: JSON matrix of packages to publish
     value: ${{ steps.analyze.outputs.matrix }}
   has_packages:
     description: Whether there are packages to publish (true/false)
     value: ${{ steps.analyze.outputs.has_packages }}
+
 runs:
   using: composite
   steps:
@@ -47,9 +53,6 @@ runs:
       env:
         A_DRY_RUN: ${{ inputs.dry_run }}
         A_TARGET: ${{ inputs.target }}
-        A_REGISTRY: ${{ inputs.registry }}
         A_ROOT: ${{ inputs.root }}
-        A_SCOPE: ${{ inputs.scope }}
         A_GITHUB_REPOSITORY: ${{ inputs.github_repository }}
-        NODE_AUTH_TOKEN: ${{ env.NODE_AUTH_TOKEN }}
       run: $GITHUB_ACTION_PATH/main.sh

--- a/.github/actions/analyze-pnpm-packages/action.yml
+++ b/.github/actions/analyze-pnpm-packages/action.yml
@@ -32,10 +32,11 @@ inputs:
     required: false
   github_repository:
     description: >
-      Owner/repository for GitHub Release checks. Defaults to ${{ github.repository }}.
+      Owner/repository for GitHub Release checks. Defaults to the workflow's
+      github.repository (set automatically by GitHub Actions).
 
     required: false
-    default: ""
+    default: "${{ github.repository }}"
 
 outputs:
   matrix:

--- a/.github/actions/analyze-pnpm-packages/main.sh
+++ b/.github/actions/analyze-pnpm-packages/main.sh
@@ -1,265 +1,126 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Inputs
-DRY_RUN="${A_DRY_RUN,,}"
-TARGET="${A_TARGET:-release}"
-REG="${A_REGISTRY:-https://npm.pkg.github.com}"
-ROOT="${A_ROOT:-.}"
-SCOPE="${A_SCOPE:-}"
-GITHUB_REPO="${A_GITHUB_REPOSITORY:-}"
+# Unified monorepo release analyzer.
+# Reads version from root package.json, checks if a v${version} tag already
+# exists as a GitHub Release, and outputs a matrix entry if publishing is needed.
 
-# Outputs
+TARGET="${A_TARGET:-release}"
+DRY_RUN="${A_DRY_RUN:-false}"
+GITHUB_REPO="${A_GITHUB_REPOSITORY:-}"
+ROOT="${A_ROOT:-.}"
+
 SUMMARY_FILE="${GITHUB_STEP_SUMMARY:-/dev/stdout}"
 OUT_FILE="${GITHUB_OUTPUT:-/dev/stdout}"
 
-# Verify jq is available
-if ! command -v jq >/dev/null 2>&1; then
-  echo "Error: jq is required but not available" >&2
+# ── Read unified version from root package.json ─────────────────────
+
+if [[ ! -f "${ROOT}/package.json" ]]; then
+  echo "Error: package.json not found at ${ROOT}" >&2
   exit 1
 fi
 
-echo "Using jq version: $(jq --version)" >&2
+VERSION="$(jq -r '.version' "${ROOT}/package.json")"
+if [[ -z "$VERSION" ]]; then
+  echo "Error: version field missing or empty in ${ROOT}/package.json" >&2
+  exit 1
+fi
 
-# Helper functions
-urlencode() {
-  jq -r --arg input "$1" '$input | @uri'
-}
+TAG="v${VERSION}"
 
-get_pkg_json_field() {
-  local path="$1" field="$2"
-  jq -r ".${field} // empty" "${path}/package.json"
-}
-
-# Derive a short slug from a scoped package name.
-# @jmmaloney4/sector7 -> sector7
-# unscoped-package -> unscoped-package
-pkg_slug() {
-  local name="$1"
-  if [[ $name == @* ]]; then
-    echo "$name" | sed 's|^@[^/]*/||'
-  else
-    echo "$name"
-  fi
-}
-
-# Derive the tarball filename npm pack would produce.
-# @jmmaloney4/sector7 -> jmmaloney4-sector7
-# plain-pkg -> plain-pkg
-tarball_stem() {
-  local name="$1"
-  # npm pack: strip @, replace / with -
-  echo "$name" | sed 's|^@||; s|/|-|g'
-}
-
-compare_versions() {
-  local local_ver="$1" published_ver="$2"
-  if [[ $published_ver == "Not found" ]]; then
-    echo "initial"
-  else
-    jq -n --arg local "$local_ver" --arg published "$published_ver" '
-      def version_parts(v): (v | split("-")[0]) | split(".") | map(tonumber? // 0);
-      def compare_versions(a; b):
-        (a | version_parts) as $a | (b | version_parts) as $b |
-        if $a[0] > $b[0] then "major"
-        elif $a[0] < $b[0] then "downgrade"
-        elif $a[1] > $b[1] then "minor"
-        elif $a[1] < $b[1] then "downgrade"
-        elif $a[2] > $b[2] then "patch"
-        elif $a[2] < $b[2] then "downgrade"
-        else "same" end;
-      compare_versions($local; $published)
-    '
-  fi
-}
-
-# Check if a GitHub Release asset already exists for this package+version.
-# The publish step creates tags like "${slug}-v${version}-${short_sha}",
-# so we match by prefix.
-# Returns "found" or "Not found".
-check_release_asset() {
-  local name="$1" version="$2"
-  local slug
-  slug="$(pkg_slug "$name")"
-  local tag_prefix="${slug}-v${version}"
-  local stem
-  stem="$(tarball_stem "$name")"
-  local asset_name="${stem}-${version}.tgz"
-
-  if [[ -z $GITHUB_REPO ]]; then
-    echo "Not found"
-    return
-  fi
-
-  # List releases for this repo and find one whose tag starts with our prefix.
-  local releases
-  releases="$(curl -sfL \
-    -H "Authorization: Bearer ${NODE_AUTH_TOKEN:-}" \
-    -H "Accept: application/vnd.github+json" \
-    "https://api.github.com/repos/${GITHUB_REPO}/releases?per_page=100" 2>/dev/null || echo "")"
-
-  if [[ -z $releases || $releases == "[]" ]]; then
-    echo "Not found"
-    return
-  fi
-
-  # Find a release whose tag_name starts with our prefix and has the expected asset.
-  local match
-  match="$(echo "$releases" | jq --arg prefix "$tag_prefix" --arg asset "$asset_name" '
-    map(select(.tag_name | startswith($prefix)))
-    | map(select(.assets | map(.name) | contains([$asset])))
-    | .[0] // null
-  ')"
-
-  if [[ $match == "null" || -z $match ]]; then
-    echo "Not found"
-  else
-    echo "found"
-  fi
-}
-
-# Check if a version is published on an npm registry (ghcr/npm/gcp).
-check_registry_version() {
-  local name="$1"
-  local published_ver="Not found"
-  if [[ -n ${NODE_AUTH_TOKEN:-} ]]; then
-    local encoded
-    encoded="$(urlencode "${name}")"
-    local resp
-    resp="$(curl -sfL \
-      -H "Authorization: Bearer ${NODE_AUTH_TOKEN:-}" \
-      -H "Accept: application/vnd.npm.install-v1+json" \
-      "${REG}/${encoded}" 2>/dev/null || echo "")"
-
-    if [[ -n $resp ]]; then
-      published_ver="$(echo "$resp" | jq -r '.dist-tags.latest // "Not found"')"
-    fi
-  fi
-  echo "$published_ver"
-}
-
-# Start summary
-echo "# 📦 pnpm packages analysis" >>"$SUMMARY_FILE"
-if [[ $DRY_RUN == "true" ]]; then
+echo "# 📦 Unified release analysis" >>"$SUMMARY_FILE"
+if [[ "${DRY_RUN}" == "true" ]]; then
   echo "> **DRY RUN MODE** - No packages will be published" >>"$SUMMARY_FILE"
 fi
 echo "" >>"$SUMMARY_FILE"
-echo "Target: **${TARGET}**" >>"$SUMMARY_FILE"
-echo "" >>"$SUMMARY_FILE"
-echo "| Package | Local | Published | Change | Action |" >>"$SUMMARY_FILE"
-echo "|---|---:|---:|---|---|" >>"$SUMMARY_FILE"
+echo "- **Version:** \`${VERSION}\`" >>"$SUMMARY_FILE"
+echo "- **Tag:** \`${TAG}\`" >>"$SUMMARY_FILE"
+echo "- **Target:** \`${TARGET}\`" >>"$SUMMARY_FILE"
 
-# Find packages
-if [[ ! -d "${ROOT}/packages" ]]; then
-  echo "Warning: packages directory not found at ${ROOT}/packages" >&2
-  PKG_PATHS=()
-else
-  PKG_PATHS=()
+# ── Collect packages ────────────────────────────────────────────────
+
+PKG_PATHS=()
+if [[ -d "${ROOT}/packages" ]]; then
   for pkg_json in "${ROOT}/packages"/*/package.json; do
-    [[ -f $pkg_json ]] && PKG_PATHS+=("${pkg_json%/package.json}")
+    [[ -f "$pkg_json" ]] && PKG_PATHS+=("${pkg_json%/package.json}")
   done
-  echo "Found ${#PKG_PATHS[@]} package(s): ${PKG_PATHS[*]}" >&2
 fi
 
-# Build matrix entries
+echo "- **Packages:** ${#PKG_PATHS[@]}" >>"$SUMMARY_FILE"
+echo "" >>"$SUMMARY_FILE"
+
+if [[ ${#PKG_PATHS[@]} -eq 0 ]]; then
+  echo "No packages found under ${ROOT}/packages/" >&2
+  echo "matrix=[]" >>"$OUT_FILE"
+  echo "has_packages=false" >>"$OUT_FILE"
+  exit 0
+fi
+
+# ── Check if release already exists ─────────────────────────────────
+
+ALREADY_PUBLISHED="false"
+if [[ -n "$GITHUB_REPO" ]]; then
+  if gh release view "$TAG" --repo "$GITHUB_REPO" >/dev/null 2>&1; then
+    ALREADY_PUBLISHED="true"
+    echo "- **Status:** already published (tag \`${TAG}\` exists)" >>"$SUMMARY_FILE"
+  else
+    echo "- **Status:** new release needed" >>"$SUMMARY_FILE"
+  fi
+else
+  echo "- **Status:** unknown (no GITHUB_REPO set, assuming not published)" >>"$SUMMARY_FILE"
+fi
+
+# ── Build matrix entries ────────────────────────────────────────────
+
 MATRIX_ENTRIES=()
 for pkg_path in "${PKG_PATHS[@]}"; do
-  name="$(get_pkg_json_field "$pkg_path" "name")"
-  [[ -n $SCOPE && ${name} != ${SCOPE}/* ]] && continue
+  name="$(jq -r '.name' "${pkg_path}/package.json")"
+  # npm pack: strip @, replace / with -
+  stem="$(echo "$name" | sed 's|^@||; s|/|-|g')"
+  asset_name="${stem}-${VERSION}.tgz"
 
-  local_ver="$(get_pkg_json_field "$pkg_path" "version")"
-  slug="$(pkg_slug "$name")"
-  stem="$(tarball_stem "$name")"
-  release_tag="${slug}-v${local_ver}"
-  asset_name="${stem}-${local_ver}.tgz"
-
-  # Determine published status based on target
-  published_ver="Not found"
-  case "$TARGET" in
-  release)
-    asset_status="$(check_release_asset "$name" "$local_ver")"
-    if [[ $asset_status == "found" ]]; then
-      published_ver="$local_ver"
-    fi
-    ;;
-  ghcr | npm | gcp)
-    published_ver="$(check_registry_version "$name")"
-    ;;
-  *)
-    echo "Error: unknown target '${TARGET}'" >&2
-    exit 1
-    ;;
-  esac
-
-  # Compare versions and determine action
-  classify="$(compare_versions "$local_ver" "$published_ver")"
-  action="publish"
-  if [[ $DRY_RUN == "true" || $classify == "same" || $classify == "downgrade" ]]; then
-    action="skip"
-  fi
-
-  # Add to matrix entries only if action is publish
-  if [[ $action == "publish" ]]; then
-    MATRIX_ENTRIES+=("$(jq -n \
-      --arg path "$pkg_path" \
-      --arg name "$name" \
-      --arg local "$local_ver" \
-      --arg published "$published_ver" \
-      --arg classify "$classify" \
-      --arg action "$action" \
-      --arg target "$TARGET" \
-      --arg slug "$slug" \
-      --arg release_tag "$release_tag" \
-      --arg asset_name "$asset_name" \
-      '{
-        package_path: $path,
-        name: $name,
-        local_version: $local,
-        published_version: $published,
-        release_type: $classify,
-        action: $action,
-        target: $target,
-        slug: $slug,
-        release_tag: $release_tag,
-        asset_name: $asset_name
-      }')")
-  fi
-
-  # Add to summary
-  echo "| ${name} | ${local_ver} | ${published_ver} | ${classify} | ${action} |" >>"$SUMMARY_FILE"
+  MATRIX_ENTRIES+=("$(jq -n \
+    --arg path "$pkg_path" \
+    --arg name "$name" \
+    --arg version "$VERSION" \
+    --arg target "$TARGET" \
+    --arg tag "$TAG" \
+    --arg asset_name "$asset_name" \
+    '{
+      package_path: $path,
+      name: $name,
+      version: $version,
+      action: "publish",
+      target: $target,
+      tag: $tag,
+      asset_name: $asset_name
+    }')")
 done
 
-# Build final matrix
-echo "Building matrix from ${#MATRIX_ENTRIES[@]} entries" >&2
-if [[ ${#MATRIX_ENTRIES[@]} -eq 0 ]]; then
-  MATRIX="[]"
-  echo "No packages found, using empty matrix" >&2
+# ── Decide action ───────────────────────────────────────────────────
+
+ACTION="publish"
+if [[ "$ALREADY_PUBLISHED" == "true" || "$DRY_RUN" == "true" ]]; then
+  ACTION="skip"
+fi
+
+echo "" >>"$SUMMARY_FILE"
+echo "| Package | Version | Action |" >>"$SUMMARY_FILE"
+echo "|---|---|---|" >>"$SUMMARY_FILE"
+
+if [[ "$ACTION" == "skip" ]]; then
+  for entry in "${MATRIX_ENTRIES[@]}"; do
+    name="$(echo "$entry" | jq -r '.name')"
+    echo "| ${name} | ${VERSION} | ⏭️ skip |" >>"$SUMMARY_FILE"
+  done
+  echo "matrix=[]" >>"$OUT_FILE"
+  echo "has_packages=false" >>"$OUT_FILE"
 else
+  for entry in "${MATRIX_ENTRIES[@]}"; do
+    name="$(echo "$entry" | jq -r '.name')"
+    echo "| ${name} | ${VERSION} | 🚀 publish |" >>"$SUMMARY_FILE"
+  done
   MATRIX="$(printf '%s\n' "${MATRIX_ENTRIES[@]}" | jq -s '.')"
-  echo "Generated matrix: $MATRIX" >&2
+  echo "matrix=$(echo "$MATRIX" | jq -c .)" >>"$OUT_FILE"
+  echo "has_packages=true" >>"$OUT_FILE"
 fi
-
-# Ensure MATRIX is valid JSON
-if ! echo "$MATRIX" | jq empty 2>/dev/null; then
-  echo "Error: Invalid JSON matrix generated" >&2
-  echo "Matrix content: $MATRIX" >&2
-  MATRIX="[]"
-fi
-
-# Output matrix and has_packages flag
-COMPRESSED_MATRIX="$(echo "$MATRIX" | jq -c .)"
-HAS_PACKAGES="false"
-if [[ ${#MATRIX_ENTRIES[@]} -gt 0 ]]; then
-  HAS_PACKAGES="true"
-fi
-
-echo "DEBUG: About to write outputs" >&2
-echo "DEBUG: COMPRESSED_MATRIX=$COMPRESSED_MATRIX" >&2
-echo "DEBUG: HAS_PACKAGES=$HAS_PACKAGES" >&2
-
-{
-  echo "matrix=$COMPRESSED_MATRIX"
-  echo "has_packages=$HAS_PACKAGES"
-} >>"$OUT_FILE"
-
-echo "DEBUG: Outputs written" >&2

--- a/.github/actions/analyze-pnpm-packages/main.sh
+++ b/.github/actions/analyze-pnpm-packages/main.sh
@@ -48,21 +48,25 @@ echo "- **Target:** \`${TARGET}\`" >>"$SUMMARY_FILE"
 
 # ── Validate all package versions match the root version ────────────
 
-if [[ -d "${ROOT}/packages" ]]; then
-  VERSION_MISMATCH=0
-  for pkg_json in "${ROOT}"/packages/*/package.json; do
-    [[ -f "$pkg_json" ]] || continue
-    pkg_name="$(jq -r '.name' "$pkg_json")"
-    pkg_ver="$(jq -r '.version // empty' "$pkg_json")"
-    if [[ "$pkg_ver" != "$VERSION" ]]; then
-      echo "❌ Version mismatch: ${pkg_name} is ${pkg_ver}, expected ${VERSION}" >&2
-      VERSION_MISMATCH=1
+if [[ "${DRY_RUN}" == "true" ]]; then
+  echo "- **Version check:** skipped in dry run" >>"$SUMMARY_FILE"
+else
+  if [[ -d "${ROOT}/packages" ]]; then
+    VERSION_MISMATCH=0
+    for pkg_json in "${ROOT}"/packages/*/package.json; do
+      [[ -f "$pkg_json" ]] || continue
+      pkg_name="$(jq -r '.name' "$pkg_json")"
+      pkg_ver="$(jq -r '.version // empty' "$pkg_json")"
+      if [[ "$pkg_ver" != "$VERSION" ]]; then
+        echo "❌ Version mismatch: ${pkg_name} is ${pkg_ver}, expected ${VERSION}" >&2
+        VERSION_MISMATCH=1
+      fi
+    done
+    if [[ $VERSION_MISMATCH -ne 0 ]]; then
+      echo "Error: not all package versions match root package.json version (${VERSION})" >&2
+      echo "Update all packages to version ${VERSION} before releasing." >&2
+      exit 1
     fi
-  done
-  if [[ $VERSION_MISMATCH -ne 0 ]]; then
-    echo "Error: not all package versions match root package.json version (${VERSION})" >&2
-    echo "Update all packages to version ${VERSION} before releasing." >&2
-    exit 1
   fi
 fi
 

--- a/.github/actions/analyze-pnpm-packages/main.sh
+++ b/.github/actions/analyze-pnpm-packages/main.sh
@@ -15,10 +15,12 @@ OUT_FILE="${GITHUB_OUTPUT:-/dev/stdout}"
 
 # ── Verify tools are available ──────────────────────────────────────
 
-if ! command -v jq >/dev/null 2>&1; then
-  echo "Error: jq is required but not available" >&2
-  exit 1
-fi
+for cmd in jq gh; do
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    echo "Error: $cmd is required but not available" >&2
+    exit 1
+  fi
+done
 
 # ── Read unified version from root package.json ─────────────────────
 
@@ -121,7 +123,8 @@ for pkg_path in "${PKG_PATHS[@]}"; do
   # not the root package.json version (workspaces don't auto-inherit).
   pkg_version="$(jq -r '.version // empty' "${pkg_path}/package.json")"
   # npm pack: strip @, replace / with -
-  stem="$(echo "$name" | sed 's|^@||; s|/|-|g')"
+  stem="${name#@}"
+  stem="${stem//\//-}"
   asset_name="${stem}-${pkg_version}.tgz"
 
   MATRIX_ENTRIES+=("$(jq -n \

--- a/.github/actions/analyze-pnpm-packages/main.sh
+++ b/.github/actions/analyze-pnpm-packages/main.sh
@@ -13,6 +13,13 @@ ROOT="${A_ROOT:-.}"
 SUMMARY_FILE="${GITHUB_STEP_SUMMARY:-/dev/stdout}"
 OUT_FILE="${GITHUB_OUTPUT:-/dev/stdout}"
 
+# ── Verify tools are available ──────────────────────────────────────
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "Error: jq is required but not available" >&2
+  exit 1
+fi
+
 # ── Read unified version from root package.json ─────────────────────
 
 if [[ ! -f "${ROOT}/package.json" ]]; then

--- a/.github/actions/analyze-pnpm-packages/main.sh
+++ b/.github/actions/analyze-pnpm-packages/main.sh
@@ -37,6 +37,26 @@ echo "- **Version:** \`${VERSION}\`" >>"$SUMMARY_FILE"
 echo "- **Tag:** \`${TAG}\`" >>"$SUMMARY_FILE"
 echo "- **Target:** \`${TARGET}\`" >>"$SUMMARY_FILE"
 
+# ── Validate all package versions match the root version ────────────
+
+if [[ -d "${ROOT}/packages" ]]; then
+  VERSION_MISMATCH=0
+  for pkg_json in "${ROOT}"/packages/*/package.json; do
+    [[ -f "$pkg_json" ]] || continue
+    pkg_name="$(jq -r '.name' "$pkg_json")"
+    pkg_ver="$(jq -r '.version // empty' "$pkg_json")"
+    if [[ "$pkg_ver" != "$VERSION" ]]; then
+      echo "❌ Version mismatch: ${pkg_name} is ${pkg_ver}, expected ${VERSION}" >&2
+      VERSION_MISMATCH=1
+    fi
+  done
+  if [[ $VERSION_MISMATCH -ne 0 ]]; then
+    echo "Error: not all package versions match root package.json version (${VERSION})" >&2
+    echo "Update all packages to version ${VERSION} before releasing." >&2
+    exit 1
+  fi
+fi
+
 # ── Collect packages ────────────────────────────────────────────────
 
 PKG_PATHS=()

--- a/.github/actions/analyze-pnpm-packages/main.sh
+++ b/.github/actions/analyze-pnpm-packages/main.sh
@@ -59,30 +59,48 @@ fi
 # ── Check if release already exists ─────────────────────────────────
 
 ALREADY_PUBLISHED="false"
-if [[ -n "$GITHUB_REPO" ]]; then
-  if gh release view "$TAG" --repo "$GITHUB_REPO" >/dev/null 2>&1; then
-    ALREADY_PUBLISHED="true"
-    echo "- **Status:** already published (tag \`${TAG}\` exists)" >>"$SUMMARY_FILE"
-  else
-    echo "- **Status:** new release needed" >>"$SUMMARY_FILE"
-  fi
-else
-  echo "- **Status:** unknown (no GITHUB_REPO set, assuming not published)" >>"$SUMMARY_FILE"
-fi
+case "$TARGET" in
+  release)
+    if [[ -n "$GITHUB_REPO" ]]; then
+      if gh release view "$TAG" --repo "$GITHUB_REPO" >/dev/null 2>&1; then
+        ALREADY_PUBLISHED="true"
+        echo "- **Status:** already published (tag \`${TAG}\` exists)" >>"$SUMMARY_FILE"
+      else
+        echo "- **Status:** new release needed" >>"$SUMMARY_FILE"
+      fi
+    else
+      echo "- **Status:** unknown (no GITHUB_REPO set, assuming not published)" >>"$SUMMARY_FILE"
+    fi
+    ;;
+  ghcr|npm|gcp)
+    # For npm registry targets, check published version via registry API.
+    # Note: this requires NODE_AUTH_TOKEN to be set.
+    # sector7 is released only as tarballs, so these targets are deprecated.
+    echo "WARNING: target='${TARGET}' is deprecated for the unified release model" >&2
+    echo "- **Status:** needs registry publish (deprecated target)" >>"$SUMMARY_FILE"
+    ;;
+  *)
+    echo "Error: unknown target '${TARGET}'" >&2
+    exit 1
+    ;;
+esac
 
 # ── Build matrix entries ────────────────────────────────────────────
 
 MATRIX_ENTRIES=()
 for pkg_path in "${PKG_PATHS[@]}"; do
   name="$(jq -r '.name' "${pkg_path}/package.json")"
+  # pnpm pack uses the package's own version for the tarball filename,
+  # not the root package.json version (workspaces don't auto-inherit).
+  pkg_version="$(jq -r '.version // empty' "${pkg_path}/package.json")"
   # npm pack: strip @, replace / with -
   stem="$(echo "$name" | sed 's|^@||; s|/|-|g')"
-  asset_name="${stem}-${VERSION}.tgz"
+  asset_name="${stem}-${pkg_version}.tgz"
 
   MATRIX_ENTRIES+=("$(jq -n \
     --arg path "$pkg_path" \
     --arg name "$name" \
-    --arg version "$VERSION" \
+    --arg version "$pkg_version" \
     --arg target "$TARGET" \
     --arg tag "$TAG" \
     --arg asset_name "$asset_name" \

--- a/.github/actions/analyze-pnpm-packages/main.sh
+++ b/.github/actions/analyze-pnpm-packages/main.sh
@@ -6,7 +6,7 @@ set -euo pipefail
 # exists as a GitHub Release, and outputs a matrix entry if publishing is needed.
 
 TARGET="${A_TARGET:-release}"
-DRY_RUN="${A_DRY_RUN:-false}"
+DRY_RUN="$(echo "${A_DRY_RUN:-false}" | tr '[:upper:]' '[:lower:]')"
 GITHUB_REPO="${A_GITHUB_REPOSITORY:-}"
 ROOT="${A_ROOT:-.}"
 
@@ -96,8 +96,28 @@ case "$TARGET" in
   release)
     if [[ -n "$GITHUB_REPO" ]]; then
       if gh release view "$TAG" --repo "$GITHUB_REPO" >/dev/null 2>&1; then
-        ALREADY_PUBLISHED="true"
-        echo "- **Status:** already published (tag \`${TAG}\` exists)" >>"$SUMMARY_FILE"
+        # Release exists — verify all expected assets are present.
+        # Partial releases (tag created but upload failed) must be retried.
+        MISSING_ASSETS=()
+        for pkg_path in "${PKG_PATHS[@]}"; do
+          name="$(jq -r '.name' "${pkg_path}/package.json")"
+          pkg_version="$(jq -r '.version // empty' "${pkg_path}/package.json")"
+          stem="${name#@}"
+          stem="${stem//\//-}"
+          asset_name="${stem}-${pkg_version}.tgz"
+          if ! gh release view "$TAG" --repo "$GITHUB_REPO" --json assets -q ".assets[].name" 2>/dev/null | grep -qx "$asset_name"; then
+            MISSING_ASSETS+=("$asset_name")
+          fi
+        done
+        if [[ ${#MISSING_ASSETS[@]} -eq 0 ]]; then
+          ALREADY_PUBLISHED="true"
+          echo "- **Status:** already published (tag \`${TAG}\` exists with all assets)" >>"$SUMMARY_FILE"
+        else
+          echo "- **Status:** incomplete release (missing: ${MISSING_ASSETS[*]}), will republish" >>"$SUMMARY_FILE"
+          for asset in "${MISSING_ASSETS[@]}"; do
+            echo "  ⚠️ Missing asset: $asset" >&2
+          done
+        fi
       else
         echo "- **Status:** new release needed" >>"$SUMMARY_FILE"
       fi
@@ -105,15 +125,8 @@ case "$TARGET" in
       echo "- **Status:** unknown (no GITHUB_REPO set, assuming not published)" >>"$SUMMARY_FILE"
     fi
     ;;
-  ghcr|npm|gcp)
-    # For npm registry targets, check published version via registry API.
-    # Note: this requires NODE_AUTH_TOKEN to be set.
-    # sector7 is released only as tarballs, so these targets are deprecated.
-    echo "WARNING: target='${TARGET}' is deprecated for the unified release model" >&2
-    echo "- **Status:** needs registry publish (deprecated target)" >>"$SUMMARY_FILE"
-    ;;
   *)
-    echo "Error: unknown target '${TARGET}'" >&2
+    echo "Error: unknown or deprecated target '${TARGET}'. Only 'release' is supported." >&2
     exit 1
     ;;
 esac

--- a/.github/actions/analyze-pnpm-packages/main.sh
+++ b/.github/actions/analyze-pnpm-packages/main.sh
@@ -98,6 +98,8 @@ case "$TARGET" in
       if gh release view "$TAG" --repo "$GITHUB_REPO" >/dev/null 2>&1; then
         # Release exists — verify all expected assets are present.
         # Partial releases (tag created but upload failed) must be retried.
+        # Fetch asset list once to avoid N API calls per package.
+        EXISTING_ASSETS="$(gh release view "$TAG" --repo "$GITHUB_REPO" --json assets -q ".assets[].name" 2>/dev/null || true)"
         MISSING_ASSETS=()
         for pkg_path in "${PKG_PATHS[@]}"; do
           name="$(jq -r '.name' "${pkg_path}/package.json")"
@@ -105,7 +107,8 @@ case "$TARGET" in
           stem="${name#@}"
           stem="${stem//\//-}"
           asset_name="${stem}-${pkg_version}.tgz"
-          if ! gh release view "$TAG" --repo "$GITHUB_REPO" --json assets -q ".assets[].name" 2>/dev/null | grep -qx "$asset_name"; then
+          # grep -F for literal match (asset names contain dots)
+          if ! echo "$EXISTING_ASSETS" | grep -Fqx "$asset_name"; then
             MISSING_ASSETS+=("$asset_name")
           fi
         done

--- a/.github/actions/analyze-pnpm-packages/main.sh
+++ b/.github/actions/analyze-pnpm-packages/main.sh
@@ -20,8 +20,8 @@ if [[ ! -f "${ROOT}/package.json" ]]; then
   exit 1
 fi
 
-VERSION="$(jq -r '.version' "${ROOT}/package.json")"
-if [[ -z "$VERSION" ]]; then
+VERSION="$(jq -r '.version // empty' "${ROOT}/package.json")"
+if [[ -z "$VERSION" || "$VERSION" == "null" ]]; then
   echo "Error: version field missing or empty in ${ROOT}/package.json" >&2
   exit 1
 fi

--- a/.github/workflows/pnpm.yml
+++ b/.github/workflows/pnpm.yml
@@ -189,13 +189,14 @@ jobs:
 
           # Create release if it doesn't exist (first package in the matrix).
           # Subsequent packages upload their tarball to the same release.
-          if ! gh release view "$TAG" --repo "${{ inputs.repository }}" >/dev/null 2>&1; then
-            echo "Creating release ${TAG}"
-            gh release create "$TAG" \
-              --repo "${{ inputs.repository }}" \
-              --title "${TAG}" \
-              --notes "Published \`${{ matrix.name }}@${{ matrix.version }}\`."
-          fi
+          # The create is idempotent: if another matrix job already created it,
+          # `gh release create` returns an error which we ignore.
+          echo "Creating release ${TAG}"
+          gh release create "$TAG" \
+            --repo "${{ inputs.repository }}" \
+            --title "${TAG}" \
+            --notes "Published \`${{ matrix.name }}@${{ matrix.version }}\`." \
+            2>/dev/null || true
 
           echo "Uploading ${ASSET} to release ${TAG}"
           gh release upload "$TAG" "$ASSET_PATH" \

--- a/.github/workflows/pnpm.yml
+++ b/.github/workflows/pnpm.yml
@@ -189,18 +189,18 @@ jobs:
 
           # Create release if it doesn't exist (first package in the matrix).
           # Subsequent packages upload their tarball to the same release.
-          # gh release create returns exit 1 when the tag already exists;
-          # we detect this by checking stderr for "already exists".
-          CREATE_OUTPUT=""
-          CREATE_OUTPUT="$(gh release create "$TAG" \
+          # gh release create returns exit 1 when the tag already exists.
+          # We capture only stderr (redirect stdout to /dev/null) so that
+          # the success URL on stdout doesn't pollute the error check.
+          CREATE_STDERR="$(gh release create "$TAG" \
             --repo "${{ inputs.repository }}" \
             --title "${TAG}" \
             --notes "Published \`${{ matrix.name }}@${{ matrix.version }}\`." \
-            2>&1)" || true
-          if echo "$CREATE_OUTPUT" | grep -qi "already exists\|release.*already"; then
+            2>&1 >/dev/null)" || true
+          if echo "$CREATE_STDERR" | grep -qi "already exists\|release.*already"; then
             echo "ℹ️ Release ${TAG} already exists (parallel matrix job created it)"
-          elif [[ -n "$CREATE_OUTPUT" ]]; then
-            echo "❌ gh release create failed: $CREATE_OUTPUT"
+          elif [[ -n "$CREATE_STDERR" ]]; then
+            echo "❌ gh release create failed: $CREATE_STDERR"
             exit 1
           else
             echo "✅ Release ${TAG} created"

--- a/.github/workflows/pnpm.yml
+++ b/.github/workflows/pnpm.yml
@@ -189,14 +189,23 @@ jobs:
 
           # Create release if it doesn't exist (first package in the matrix).
           # Subsequent packages upload their tarball to the same release.
-          # The create is idempotent: if another matrix job already created it,
-          # `gh release create` returns an error which we ignore.
-          echo "Creating release ${TAG}"
+          # gh release create fails with exit 36 when the tag already exists.
+          # We detect that specific exit code to allow parallel matrix jobs.
+          CREATE_EXIT=0
           gh release create "$TAG" \
             --repo "${{ inputs.repository }}" \
             --title "${TAG}" \
             --notes "Published \`${{ matrix.name }}@${{ matrix.version }}\`." \
-            2>/dev/null || true
+            2>/dev/null || CREATE_EXIT=$?
+          if [[ $CREATE_EXIT -ne 0 && $CREATE_EXIT -ne 36 ]]; then
+            echo "❌ gh release create failed with exit code $CREATE_EXIT"
+            exit 1
+          fi
+          if [[ $CREATE_EXIT -eq 0 ]]; then
+            echo "✅ Release ${TAG} created"
+          else
+            echo "ℹ️ Release ${TAG} already exists (parallel matrix job created it)"
+          fi
 
           echo "Uploading ${ASSET} to release ${TAG}"
           gh release upload "$TAG" "$ASSET_PATH" \

--- a/.github/workflows/pnpm.yml
+++ b/.github/workflows/pnpm.yml
@@ -34,13 +34,6 @@ on:
         required: false
         type: string
         default: ''
-      short_sha:
-        description: >
-          Short commit SHA to append to release tags (e.g. a27687e). Only used when target=release. Defaults to the 7-char commit SHA.
-
-        required: false
-        type: string
-        default: ''
 jobs:
   analyze:
     name: "🧱 analyze pnpm packages"
@@ -141,10 +134,8 @@ jobs:
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "- **Target:** \`${{ matrix.target }}\`" >> $GITHUB_STEP_SUMMARY
           echo "- **Path:** \`${{ matrix.package_path }}\`" >> $GITHUB_STEP_SUMMARY
-          echo "- **Local:** \`${{ matrix.local_version }}\`" >> $GITHUB_STEP_SUMMARY
-          echo "- **Published:** \`${{ matrix.published_version }}\`" >> $GITHUB_STEP_SUMMARY
-          echo "- **Change:** \`${{ matrix.release_type }}\`" >> $GITHUB_STEP_SUMMARY
-          echo "- **Action:** \`${{ matrix.action }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "- **Version:** \`${{ matrix.version }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "- **Tag:** \`${{ matrix.tag }}\`" >> $GITHUB_STEP_SUMMARY
       # ── Release tarball target ──────────────────────────────────────
       - name: Pack tarball
         if: inputs.dry_run != true && matrix.action == 'publish' && matrix.target == 'release'
@@ -182,20 +173,10 @@ jobs:
           fi
 
           echo "✅ Tarball contains compiled JavaScript and declarations only"
-      - name: Resolve short SHA
-        if: inputs.dry_run != true && matrix.action == 'publish' && matrix.target == 'release'
-        id: sha
-        shell: bash
-        run: |
-          if [[ -n "${{ inputs.short_sha }}" ]]; then
-            echo "short_sha=${{ inputs.short_sha }}" >> "$GITHUB_OUTPUT"
-          else
-            echo "short_sha=$(git rev-parse --short=7 HEAD)" >> "$GITHUB_OUTPUT"
-          fi
-      - name: Create release and upload tarball
+      - name: Upload tarball to release
         if: inputs.dry_run != true && matrix.action == 'publish' && matrix.target == 'release'
         run: |
-          TAG="${{ matrix.release_tag }}-${{ steps.sha.outputs.short_sha }}"
+          TAG="${{ matrix.tag }}"
           ASSET="${{ matrix.asset_name }}"
           ASSET_PATH="${{ matrix.package_path }}/${ASSET}"
 
@@ -206,12 +187,20 @@ jobs:
             exit 1
           fi
 
-          echo "Creating release ${TAG} with asset ${ASSET}"
-          gh release create "$TAG" \
-            "$ASSET_PATH" \
+          # Create release if it doesn't exist (first package in the matrix).
+          # Subsequent packages upload their tarball to the same release.
+          if ! gh release view "$TAG" --repo "${{ inputs.repository }}" >/dev/null 2>&1; then
+            echo "Creating release ${TAG}"
+            gh release create "$TAG" \
+              --repo "${{ inputs.repository }}" \
+              --title "${TAG}" \
+              --notes "Published \`${{ matrix.name }}@${{ matrix.version }}\`."
+          fi
+
+          echo "Uploading ${ASSET} to release ${TAG}"
+          gh release upload "$TAG" "$ASSET_PATH" \
             --repo "${{ inputs.repository }}" \
-            --title "${TAG}" \
-            --notes "Published \`${{ matrix.name }}@${{ matrix.local_version }}\` as tarball asset."
+            --clobber
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Cleanup packed tarball

--- a/.github/workflows/pnpm.yml
+++ b/.github/workflows/pnpm.yml
@@ -21,19 +21,10 @@ on:
         type: boolean
         default: false
       target:
-        description: >
-          Publish target: release (GitHub Release tarball), ghcr (GitHub Packages), npm (npmjs.org), gcp (Google Artifact Registry).
-
+        description: 'Publish target. Only "release" (GitHub Release tarball) is supported.'
         required: false
         type: string
         default: 'release'
-      registry:
-        description: >
-          npm registry URL for ghcr/npm/gcp targets. Defaults to https://npm.pkg.github.com (ghcr), https://registry.npmjs.org (npm), or a GCP Artifact Registry URL. Ignored when target=release.
-
-        required: false
-        type: string
-        default: ''
 jobs:
   analyze:
     name: "🧱 analyze pnpm packages"
@@ -49,31 +40,15 @@ jobs:
         with:
           repository: ${{ inputs.repository }}
           ref: ${{ inputs.ref }}
-      - name: Resolve registry default
-        id: resolve-registry
-        shell: bash
-        run: |
-          # If caller didn't specify a registry, pick the default for the target
-          if [[ -n "${{ inputs.registry }}" ]]; then
-            echo "registry=${{ inputs.registry }}" >> "$GITHUB_OUTPUT"
-          else
-            case "${{ inputs.target }}" in
-              ghcr)  echo "registry=https://npm.pkg.github.com" >> "$GITHUB_OUTPUT" ;;
-              npm)   echo "registry=https://registry.npmjs.org" >> "$GITHUB_OUTPUT" ;;
-              gcp)   echo "registry=" >> "$GITHUB_OUTPUT" ;;
-              *)     echo "registry=" >> "$GITHUB_OUTPUT" ;;  # release doesn't need one
-            esac
-          fi
       - name: Analyze packages (target=${{ inputs.target }})
         id: analyze
-        uses: jmmaloney4/sector7/.github/actions/analyze-pnpm-packages@04d9bc2dd846b6584f5544721127b32296e6b71d # current PR head
+        uses: jmmaloney4/sector7/.github/actions/analyze-pnpm-packages@8a16dd623d6a35269d26372e2251754da2ff76e7 # PR #204 head
         with:
           dry_run: ${{ inputs.dry_run }}
           target: ${{ inputs.target }}
-          registry: ${{ steps.resolve-registry.outputs.registry }}
           github_repository: ${{ inputs.repository }}
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Debug matrix output
         run: |
           echo "Matrix output:"
@@ -111,7 +86,6 @@ jobs:
         include: ${{ fromJson(needs.analyze.outputs.matrix || '[]') }}
     permissions:
       contents: write # needed for release asset upload
-      packages: write # needed for ghcr publish
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -215,55 +189,3 @@ jobs:
       - name: Cleanup packed tarball
         if: inputs.dry_run != true && matrix.action == 'publish' && matrix.target == 'release'
         run: rm -f ${{ matrix.package_path }}/*.tgz
-      # ── Registry targets (ghcr / npm / gcp) ────────────────────────
-      - name: Configure npm authentication (registry)
-        if: inputs.dry_run != true && matrix.action == 'publish' && matrix.target != 'release'
-        run: |
-          echo "Configuring npm for ${{ matrix.target }} registry authentication..."
-          case "${{ matrix.target }}" in
-            ghcr)
-              REGISTRY="https://npm.pkg.github.com"
-              ;;
-            npm)
-              REGISTRY="https://registry.npmjs.org"
-              ;;
-            gcp)
-              REGISTRY="${{ inputs.registry }}"
-              if [[ -z "$REGISTRY" ]]; then
-                echo "❌ GCP target requires the 'registry' input to be set"
-                exit 1
-              fi
-              ;;
-            *)
-              echo "❌ Unknown target: ${{ matrix.target }}"
-              exit 1
-              ;;
-          esac
-
-          echo "Setting auth for registry: ${REGISTRY}"
-          echo "//$(echo "$REGISTRY" | sed 's|https://||')/:_authToken=\${NODE_AUTH_TOKEN}" > ${{ matrix.package_path }}/.npmrc
-
-          # For scoped packages on ghcr, add the registry line
-          if [[ "${{ matrix.target }}" == "ghcr" && "${{ matrix.name }}" == @* ]]; then
-            SCOPE="${{ matrix.name %%/*}}"
-            echo "${SCOPE}:registry=${REGISTRY}" >> ${{ matrix.package_path }}/.npmrc
-          fi
-
-          if [ ! -f "${{ matrix.package_path }}/.npmrc" ]; then
-            echo "❌ Failed to create .npmrc file"
-            exit 1
-          fi
-          echo "✅ Authentication configured for ${{ matrix.target }}"
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Publish package (registry)
-        if: inputs.dry_run != true && matrix.action == 'publish' && matrix.target != 'release'
-        run: nix develop .#ci-pnpm --command pnpm publish --no-git-checks
-        working-directory: ${{ matrix.package_path }}
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Cleanup authentication (registry)
-        if: inputs.dry_run != true && matrix.action == 'publish' && matrix.target != 'release'
-        run: |
-          rm -f ${{ matrix.package_path }}/.npmrc
-          echo "✅ Cleanup completed"

--- a/.github/workflows/pnpm.yml
+++ b/.github/workflows/pnpm.yml
@@ -42,7 +42,7 @@ jobs:
           ref: ${{ inputs.ref }}
       - name: Analyze packages (target=${{ inputs.target }})
         id: analyze
-        uses: jmmaloney4/sector7/.github/actions/analyze-pnpm-packages@8a16dd623d6a35269d26372e2251754da2ff76e7 # PR #204 head
+        uses: jmmaloney4/sector7/.github/actions/analyze-pnpm-packages@feat/unified-release
         with:
           dry_run: ${{ inputs.dry_run }}
           target: ${{ inputs.target }}

--- a/.github/workflows/pnpm.yml
+++ b/.github/workflows/pnpm.yml
@@ -66,7 +66,7 @@ jobs:
           fi
       - name: Analyze packages (target=${{ inputs.target }})
         id: analyze
-        uses: jmmaloney4/sector7/.github/actions/analyze-pnpm-packages@e810f9d58eaf12b58af1ebef7968f684d2ee2030 # main
+        uses: jmmaloney4/sector7/.github/actions/analyze-pnpm-packages@04d9bc2dd846b6584f5544721127b32296e6b71d # current PR head
         with:
           dry_run: ${{ inputs.dry_run }}
           target: ${{ inputs.target }}

--- a/.github/workflows/pnpm.yml
+++ b/.github/workflows/pnpm.yml
@@ -189,22 +189,21 @@ jobs:
 
           # Create release if it doesn't exist (first package in the matrix).
           # Subsequent packages upload their tarball to the same release.
-          # gh release create fails with exit 36 when the tag already exists.
-          # We detect that specific exit code to allow parallel matrix jobs.
-          CREATE_EXIT=0
-          gh release create "$TAG" \
+          # gh release create returns exit 1 when the tag already exists;
+          # we detect this by checking stderr for "already exists".
+          CREATE_OUTPUT=""
+          CREATE_OUTPUT="$(gh release create "$TAG" \
             --repo "${{ inputs.repository }}" \
             --title "${TAG}" \
             --notes "Published \`${{ matrix.name }}@${{ matrix.version }}\`." \
-            2>/dev/null || CREATE_EXIT=$?
-          if [[ $CREATE_EXIT -ne 0 && $CREATE_EXIT -ne 36 ]]; then
-            echo "❌ gh release create failed with exit code $CREATE_EXIT"
-            exit 1
-          fi
-          if [[ $CREATE_EXIT -eq 0 ]]; then
-            echo "✅ Release ${TAG} created"
-          else
+            2>&1)" || true
+          if echo "$CREATE_OUTPUT" | grep -qi "already exists\|release.*already"; then
             echo "ℹ️ Release ${TAG} already exists (parallel matrix job created it)"
+          elif [[ -n "$CREATE_OUTPUT" ]]; then
+            echo "❌ gh release create failed: $CREATE_OUTPUT"
+            exit 1
+          else
+            echo "✅ Release ${TAG} created"
           fi
 
           echo "Uploading ${ASSET} to release ${TAG}"

--- a/docs/internal/designs/025-unified-monorepo-release.md
+++ b/docs/internal/designs/025-unified-monorepo-release.md
@@ -48,7 +48,7 @@ They ship at the same version as the existing package(s). No per-package version
 
 ## Consequences
 
-**Simpler.** The analyzer script shrinks from 265 lines to ~30 lines of "read version, check tag, pack if missing." The workflow drops the matrix strategy for the release target.
+**Simpler.** The analyzer script shrinks from 265 lines to ~190 lines (including asset completeness verification). The workflow drops the registry resolution step, registry publish steps, and short_sha input.
 
 **Cleaner tags.** `v0.10.0` instead of `sector7-v0.9.2-007f69a`. Easier for humans, easier for Renovate, easier for any tooling that parses tags.
 

--- a/docs/internal/designs/025-unified-monorepo-release.md
+++ b/docs/internal/designs/025-unified-monorepo-release.md
@@ -52,11 +52,13 @@ They ship at the same version as the existing package(s). No per-package version
 
 **Cleaner tags.** `v0.10.0` instead of `sector7-v0.9.2-007f69a`. Easier for humans, easier for Renovate, easier for any tooling that parses tags.
 
-**No partial releases.** Everything ships together or nothing ships. This is the right tradeoff for an internal ecosystem where packages are designed to work together and consumers update eagerly.
+**No partial releases.** Everything ships together or nothing ships. The analyzer verifies asset completeness: if a release tag exists but is missing expected tarballs, the publish proceeds to fill the gap. This prevents dead releases from partial upload failures.
 
 **No republish from different commits.** Without the SHA suffix, attempting to publish the same version from a different commit fails (tag already exists). This is intentional: bump the version if you need a new release. The SHA suffix was allowing sloppy version management.
 
 **Breaks if a second package needs independent versioning.** If sector7 grows a package that genuinely needs its own release cadence, this ADR would need to be revisited. Given the current design intent (all packages work together), this is acceptable.
+
+**Registry targets removed.** The `ghcr`, `npm`, and `gcp` registry publish paths have been removed from the workflow and analyzer. sector7 ships as GitHub Release tarballs only. If registry publishing is needed in the future, it should be added as a separate workflow rather than coupling it to the tarball release path.
 
 ## Migration
 

--- a/docs/internal/designs/025-unified-monorepo-release.md
+++ b/docs/internal/designs/025-unified-monorepo-release.md
@@ -1,0 +1,64 @@
+# ADR 025: Unified Monorepo Release
+
+*Date:* 2026-05-18
+*Status:* proposed
+
+## Context
+
+The sector7 publish pipeline (`pnpm.yml` + `analyze-pnpm-packages`) currently treats each package in `packages/` as an independent release unit:
+
+- Tags include a per-package slug prefix (`sector7-v0.9.2`) even though there is only one published package.
+- Tags include a short SHA suffix (`-007f69a`) making every publish unique per commit.
+- The analyzer does per-package version comparison, registry probing, and matrix construction to decide whether each package needs publishing independently.
+
+This design was built to support arbitrary monorepo topologies: multiple packages at independent versions, published to different registries at different cadences. But the actual use case is narrow:
+
+- One package (`@jmmaloney4/sector7`).
+- One target (GitHub Release tarball).
+- All consumers are internal repos owned by the same org.
+- Consumers update quickly and take all changes together.
+
+The slug prefix is redundant when there is only one package. The SHA suffix means the same version string produces infinitely many tags, which complicates Renovate integration and makes tag history noisy without adding value for an internal-only artifact. The per-package analysis machinery (registry version checks, semver comparison, matrix fan-out) is over-engineered for a single-package unified release.
+
+## Decision
+
+Release all packages in the monorepo together at a single version, using plain semver tags.
+
+### Tag format
+
+`v${version}` (e.g. `v0.10.0`).
+
+No slug prefix. No SHA suffix. One tag per release.
+
+### Version source
+
+The root `package.json` `version` field is the single source of truth. Packages under `packages/*/` inherit this version. A bump happens once, applies everywhere.
+
+### Release decision
+
+Check whether a tag `v${version}` already exists. If not, pack all packages, create one GitHub Release with all tarballs attached.
+
+This replaces the current per-package registry/release probing and matrix fan-out with a single boolean check.
+
+### When new packages are added
+
+They ship at the same version as the existing package(s). No per-package versioning. The release tag still covers the whole monorepo.
+
+## Consequences
+
+**Simpler.** The analyzer script shrinks from 265 lines to ~30 lines of "read version, check tag, pack if missing." The workflow drops the matrix strategy for the release target.
+
+**Cleaner tags.** `v0.10.0` instead of `sector7-v0.9.2-007f69a`. Easier for humans, easier for Renovate, easier for any tooling that parses tags.
+
+**No partial releases.** Everything ships together or nothing ships. This is the right tradeoff for an internal ecosystem where packages are designed to work together and consumers update eagerly.
+
+**No republish from different commits.** Without the SHA suffix, attempting to publish the same version from a different commit fails (tag already exists). This is intentional: bump the version if you need a new release. The SHA suffix was allowing sloppy version management.
+
+**Breaks if a second package needs independent versioning.** If sector7 grows a package that genuinely needs its own release cadence, this ADR would need to be revisited. Given the current design intent (all packages work together), this is acceptable.
+
+## Migration
+
+1. Simplify `analyze-pnpm-packages/main.sh` to unified release logic.
+2. Simplify `pnpm.yml` to remove matrix strategy for `target=release`, use plain `v${version}` tags.
+3. Drop the `short_sha` input (no longer needed).
+4. Consumers reference the new tag format in their `package.json` resolutions.

--- a/docs/internal/designs/025-unified-monorepo-release.md
+++ b/docs/internal/designs/025-unified-monorepo-release.md
@@ -32,7 +32,9 @@ No slug prefix. No SHA suffix. One tag per release.
 
 ### Version source
 
-The root `package.json` `version` field is the single source of truth. Packages under `packages/*/` inherit this version. A bump happens once, applies everywhere.
+The root `package.json` `version` field is the single source of truth. All packages under `packages/*/` must have the same `version` field. The publish workflow validates this invariant before proceeding — if any package version diverges from the root version, the workflow exits with an error listing the mismatches.
+
+A bump happens once in root `package.json`, then all packages must be updated to match before the release proceeds.
 
 ### Release decision
 


### PR DESCRIPTION
## Summary

Replace per-package slug+SHA tags (`sector7-v0.9.2-007f69a`) with plain `v${version}` tags. All packages in the monorepo ship together at the same version from root `package.json`.

ADR 025 documents the decision and tradeoffs.

## Changes

- **Simplify `analyze-pnpm-packages/main.sh`**: Checks for an existing `v${version}` GitHub Release tag and verifies all expected tarball assets are present. If any asset is missing from a partial release, publish proceeds to fill the gap.
- **Simplify `action.yml`**: Removed `scope`, `registry` inputs. Only `target`, `dry_run`, `root`, and `github_repository` remain.
- **Simplify `pnpm.yml`**: Removed registry resolution step and all registry publish paths (ghcr/npm/gcp). Only the GitHub Release tarball target remains. Release step creates one `v${version}` tag and uploads tarballs.
- **ADR 025**: Documents the unified release decision, asset completeness guarantee, and registry removal rationale.

## Why

There is one published package (`@jmmaloney4/sector7`) targeting one target (GitHub Release tarballs). All consumers are internal. The slug prefix, SHA suffix, per-package analysis, and multi-registry support were solving problems that do not exist in this deployment topology.

## Test plan

- Dry-run dispatch on this branch should show "new release needed" with correct version
- Consumers (garden, etc.) that reference sector7 tarball URLs via Renovate will see the new tag format on the next release
- The tarball contents and URL structure remain the same — only the release tag changes

## Risks

- **Tag collision**: republishing the same version from a different commit will fail (tag exists). This is intentional — bump the version.
- **Multi-package independent versioning**: if sector7 grows a package needing its own release cadence, this ADR would need revisiting. Acceptable given current design.

## Downstream

Consumers (garden, etc.) that reference sector7 tarball URLs via Renovate will see the new tag format on the next release. The tarball contents and URL structure remain the same — only the release tag changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the release/publish workflow behavior and tagging scheme (moving to single `v${version}` releases) and removes registry publishing paths, which can break existing automation or consumers expecting old tags/targets.
> 
> **Overview**
> **Unifies monorepo publishing to a single GitHub Release tag** `v${version}` sourced from the root `package.json`, replacing per-package slug+SHA tags and per-package version comparisons.
> 
> The `analyze-pnpm-packages` action is simplified to only support the `release` target: it validates all workspace package versions match the root, checks whether the `v${version}` release already exists and has *all* expected tarball assets (republishing if incomplete), and emits an empty matrix when no publish is needed.
> 
> The `pnpm.yml` workflow drops registry-related inputs/steps/permissions and updates the publish job to create (or reuse) the single `v${version}` release and upload each package tarball to it; ADR `025-unified-monorepo-release.md` documents the decision and tradeoffs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f1a63770d58bfbcea5ad621d9f2a46be76359e4f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->