### PR TITLE
fix: handle prefixed ARC helm chart tags in Renovate

### DIFF
--- a/docs/public/renovate.md
+++ b/docs/public/renovate.md
@@ -14,11 +14,11 @@ This directory contains composable Renovate presets that can be shared across pr
 
 ### Technology-Specific Presets
 
-- **`nix.json`** - Nix-specific configuration with safe regex managers for `fetchPypi` plus `mkHelmChartFromGitHub` version bumps (see ADR-038 in jackpkgs); hashes are left for manual recomputation (see ADR-023)
+- **`nix.json`** - Nix-specific configuration with safe regex managers for `fetchPypi` plus `mkHelmChartFromGitHub` version bumps (see ADR-038 in jackpkgs); Nix SRI hashes such as `sha256-XRJNwpeGjQSEPub34BLrPJn3Tj6Ie90/PB7LR2+tPmU=` are matched structurally but left for manual recomputation (see ADR-023)
 - **`pulumi.json`** - Pulumi-specific configuration and version management
 - **`sector7-release-tarballs.json`** - Package.json dependency updates for `@jmmaloney4/sector7` GitHub release tarballs
 
-> Note: `renovate/nix.json` detects `mkHelmChartFromGitHub` version bumps (and `fetchPypi`), but does not rewrite the hash. Maintainers recompute the new hash manually before merge.
+> Note: `renovate/nix.json` detects `mkHelmChartFromGitHub` version bumps (and `fetchPypi`), including the usual quoted Nix SRI hash form like `sha256-XRJNwpeGjQSEPub34BLrPJn3Tj6Ie90/PB7LR2+tPmU=`, but does not rewrite the hash. Maintainers recompute the new hash manually before merge.
 
 > Note: `renovate/sector7-release-tarballs.json` handles the packed GitHub Release asset URLs used by consumer repos. It updates the tarball URL in `package.json` and leaves lockfile regeneration to Renovate's normal package manager flow.
 

--- a/packages/sector7/tests/renovate-nix-regex.test.ts
+++ b/packages/sector7/tests/renovate-nix-regex.test.ts
@@ -11,22 +11,26 @@ const nixConfig = JSON.parse(
 	}>;
 };
 
-function managerRegex(description: string): RegExp {
+function managerRegexes(description: string): RegExp[] {
 	const manager = nixConfig.customManagers.find(
 		(candidate) => candidate.description === description,
 	);
 
 	expect(manager).toBeDefined();
-	return new RegExp(manager!.matchStrings[0], "m");
+	return manager!.matchStrings.map((pattern) => new RegExp(pattern, "m"));
+}
+
+function firstMatch(regexes: RegExp[], input: string) {
+	return regexes.map((regex) => input.match(regex)).find(Boolean);
 }
 
 const sriHash = "sha256-XRJNwpeGjQSEPub34BLrPJn3Tj6Ie90/PB7LR2+tPmU=";
 
 describe("renovate/nix.json mkHelmChartFromGitHub regex managers", () => {
 	it("matches ARC chart blocks that use real Nix SRI hashes", () => {
-		const arcRegex = managerRegex(
+		const arcRegex = managerRegexes(
 			"Update mkHelmChartFromGitHub ARC chart packages in Nix files",
-		);
+		)[0];
 		const arcBlock = [
 			"mkHelmChartFromGitHub rec {",
 			'  pname = "gha-runner-scale-set-controller-chart";',
@@ -48,7 +52,7 @@ describe("renovate/nix.json mkHelmChartFromGitHub regex managers", () => {
 	});
 
 	it("matches generic chart blocks that use real Nix SRI hashes", () => {
-		const genericRegex = managerRegex(
+		const genericRegexes = managerRegexes(
 			"Update mkHelmChartFromGitHub packages in Nix files",
 		);
 		const genericBlock = `mkHelmChartFromGitHub {
@@ -59,15 +63,35 @@ describe("renovate/nix.json mkHelmChartFromGitHub regex managers", () => {
   hash = "${sriHash}";
 };`;
 
-		const match = genericBlock.match(genericRegex);
+		const match = firstMatch(genericRegexes, genericBlock);
 		expect(match?.groups?.depName).toBe("envoy-gateway-crds-chart");
 		expect(match?.groups?.currentValue).toBe("1.8.0");
 		expect(match?.groups?.owner).toBe("envoyproxy");
 		expect(match?.groups?.repo).toBe("gateway");
 	});
 
+	it("matches generic chart blocks with chartSubdir before hash", () => {
+		const genericRegexes = managerRegexes(
+			"Update mkHelmChartFromGitHub packages in Nix files",
+		);
+		const chartSubdirBlock = `mkHelmChartFromGitHub rec {
+  pname = "some-chart";
+  version = "1.2.3";
+  owner = "example";
+  repo = "repo";
+  chartSubdir = "charts/some-chart";
+  hash = "${sriHash}";
+};`;
+
+		const match = firstMatch(genericRegexes, chartSubdirBlock);
+		expect(match?.groups?.depName).toBe("some-chart");
+		expect(match?.groups?.currentValue).toBe("1.2.3");
+		expect(match?.groups?.owner).toBe("example");
+		expect(match?.groups?.repo).toBe("repo");
+	});
+
 	it("does not let the generic matcher swallow ARC chart blocks with rev lines", () => {
-		const genericRegex = managerRegex(
+		const genericRegexes = managerRegexes(
 			"Update mkHelmChartFromGitHub packages in Nix files",
 		);
 		const arcBlock = [
@@ -81,6 +105,6 @@ describe("renovate/nix.json mkHelmChartFromGitHub regex managers", () => {
 			"};",
 		].join("\n");
 
-		expect(arcBlock.match(genericRegex)).toBeNull();
+		expect(arcBlock.match(genericRegexes[0])).toBeNull();
 	});
 });

--- a/packages/sector7/tests/renovate-nix-regex.test.ts
+++ b/packages/sector7/tests/renovate-nix-regex.test.ts
@@ -1,0 +1,86 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const nixConfig = JSON.parse(
+	readFileSync(resolve(process.cwd(), "../../renovate/nix.json"), "utf8"),
+) as {
+	customManagers: Array<{
+		description: string;
+		matchStrings: string[];
+	}>;
+};
+
+function managerRegex(description: string): RegExp {
+	const manager = nixConfig.customManagers.find(
+		(candidate) => candidate.description === description,
+	);
+
+	expect(manager).toBeDefined();
+	return new RegExp(manager!.matchStrings[0], "m");
+}
+
+const sriHash = "sha256-XRJNwpeGjQSEPub34BLrPJn3Tj6Ie90/PB7LR2+tPmU=";
+
+describe("renovate/nix.json mkHelmChartFromGitHub regex managers", () => {
+	it("matches ARC chart blocks that use real Nix SRI hashes", () => {
+		const arcRegex = managerRegex(
+			"Update mkHelmChartFromGitHub ARC chart packages in Nix files",
+		);
+		const arcBlock = [
+			"mkHelmChartFromGitHub rec {",
+			'  pname = "gha-runner-scale-set-controller-chart";',
+			'  version = "v0.27.6";',
+			'  owner = "actions";',
+			'  repo = "actions-runner-controller";',
+			'  rev = "gha-runner-scale-set-${version}";',
+			`  hash = "${sriHash}";`,
+			"};",
+		].join("\n");
+
+		const match = arcBlock.match(arcRegex);
+		expect(match?.groups?.depName).toBe(
+			"gha-runner-scale-set-controller-chart",
+		);
+		expect(match?.groups?.currentValue).toBe("v0.27.6");
+		expect(match?.groups?.owner).toBe("actions");
+		expect(match?.groups?.repo).toBe("actions-runner-controller");
+	});
+
+	it("matches generic chart blocks that use real Nix SRI hashes", () => {
+		const genericRegex = managerRegex(
+			"Update mkHelmChartFromGitHub packages in Nix files",
+		);
+		const genericBlock = `mkHelmChartFromGitHub {
+  pname = "envoy-gateway-crds-chart";
+  version = "1.8.0";
+  owner = "envoyproxy";
+  repo = "gateway";
+  hash = "${sriHash}";
+};`;
+
+		const match = genericBlock.match(genericRegex);
+		expect(match?.groups?.depName).toBe("envoy-gateway-crds-chart");
+		expect(match?.groups?.currentValue).toBe("1.8.0");
+		expect(match?.groups?.owner).toBe("envoyproxy");
+		expect(match?.groups?.repo).toBe("gateway");
+	});
+
+	it("does not let the generic matcher swallow ARC chart blocks with rev lines", () => {
+		const genericRegex = managerRegex(
+			"Update mkHelmChartFromGitHub packages in Nix files",
+		);
+		const arcBlock = [
+			"mkHelmChartFromGitHub rec {",
+			'  pname = "gha-runner-scale-set-controller-chart";',
+			'  version = "v0.27.6";',
+			'  owner = "actions";',
+			'  repo = "actions-runner-controller";',
+			'  rev = "gha-runner-scale-set-${version}";',
+			`  hash = "${sriHash}";`,
+			"};",
+		].join("\n");
+
+		expect(arcBlock.match(genericRegex)).toBeNull();
+	});
+});

--- a/renovate/README.md
+++ b/renovate/README.md
@@ -14,7 +14,7 @@ This directory contains composable Renovate presets that can be shared across pr
 
 ### Technology-Specific Presets
 
-- **`nix.json`** - Nix-specific configuration with safe regex managers for `fetchPypi` plus `mkHelmChartFromGitHub` version bumps (see ADR-038 in jackpkgs); hashes are left for manual recomputation (see ADR-023)
+- **`nix.json`** - Nix-specific configuration with safe regex managers for `fetchPypi` plus `mkHelmChartFromGitHub` version bumps (see ADR-038 in jackpkgs); Nix SRI hashes such as `sha256-XRJNwpeGjQSEPub34BLrPJn3Tj6Ie90/PB7LR2+tPmU=` are matched structurally but left for manual recomputation (see ADR-023)
 - **`pulumi.json`** - Pulumi-specific configuration and version management
 - **`sector7-release-tarballs.json`** - Package.json dependency updates for `@jmmaloney4/sector7` GitHub release tarballs
 

--- a/renovate/nix.json
+++ b/renovate/nix.json
@@ -19,7 +19,7 @@
 			"description": "Update mkHelmChartFromGitHub ARC chart packages in Nix files",
 			"managerFilePatterns": ["/nix/.+\\.nix$/"],
 			"matchStrings": [
-				"mkHelmChartFromGitHub\\s*\\{[\\s\\S]*?pname\\s*=\\s*\"(?<depName>[^\"]+)\";[\\s\\S]*?version\\s*=\\s*\"(?<currentValue>[^\"]+)\";[\\s\\S]*?owner\\s*=\\s*\"(?<owner>actions)\";[\\s\\S]*?repo\\s*=\\s*\"(?<repo>actions-runner-controller)\";[\\s\\S]*?rev\\s*=\\s*\"gha-runner-scale-set-\\$\\{version\\}\";[\\s\\S]*?hash\\s*=\\s*\"[^\"]+\";"
+				"mkHelmChartFromGitHub\\s*(?:rec\\s*)?\\{[\\s\\S]*?pname\\s*=\\s*\"(?<depName>[^\"]+)\";[\\s\\S]*?version\\s*=\\s*\"(?<currentValue>[^\"]+)\";[\\s\\S]*?owner\\s*=\\s*\"(?<owner>actions)\";[\\s\\S]*?repo\\s*=\\s*\"(?<repo>actions-runner-controller)\";[\\s\\S]*?rev\\s*=\\s*\"gha-runner-scale-set-\\$\\{version\\}\";[\\s\\S]*?hash\\s*=\\s*\"[^\"]+\";"
 			],
 			"datasourceTemplate": "github-tags",
 			"depNameTemplate": "{{{owner}}}/{{{repo}}}",
@@ -30,7 +30,7 @@
 			"description": "Update mkHelmChartFromGitHub packages in Nix files",
 			"managerFilePatterns": ["/nix/.+\\.nix$/"],
 			"matchStrings": [
-				"mkHelmChartFromGitHub\\s*\\{(?![\\s\\S]*?rev\\s*=)[\\s\\S]*?pname\\s*=\\s*\"(?<depName>[^\"]+)\";[\\s\\S]*?version\\s*=\\s*\"(?<currentValue>[^\"]+)\";[\\s\\S]*?owner\\s*=\\s*\"(?<owner>[^\"]+)\";[\\s\\S]*?repo\\s*=\\s*\"(?<repo>[^\"]+)\";[\\s\\S]*?hash\\s*=\\s*\"[^\"]+\";"
+				"mkHelmChartFromGitHub\\s*(?:rec\\s*)?\\{[\\s\\S]*?pname\\s*=\\s*\"(?<depName>[^\"]+)\";[\\s\\S]*?version\\s*=\\s*\"(?<currentValue>[^\"]+)\";[\\s\\S]*?owner\\s*=\\s*\"(?<owner>[^\"]+)\";[\\s\\S]*?repo\\s*=\\s*\"(?<repo>[^\"]+)\";\\s*hash\\s*=\\s*\"[^\"]+\";"
 			],
 			"datasourceTemplate": "github-releases",
 			"depNameTemplate": "{{{owner}}}/{{{repo}}}"

--- a/renovate/nix.json
+++ b/renovate/nix.json
@@ -19,7 +19,7 @@
 			"description": "Update mkHelmChartFromGitHub ARC chart packages in Nix files",
 			"managerFilePatterns": ["/nix/.+\\.nix$/"],
 			"matchStrings": [
-				"mkHelmChartFromGitHub\\s*(?:rec\\s*)?\\{[\\s\\S]*?pname\\s*=\\s*\"(?<depName>[^\"]+)\";[\\s\\S]*?version\\s*=\\s*\"(?<currentValue>[^\"]+)\";[\\s\\S]*?owner\\s*=\\s*\"(?<owner>actions)\";[\\s\\S]*?repo\\s*=\\s*\"(?<repo>actions-runner-controller)\";[\\s\\S]*?rev\\s*=\\s*\"gha-runner-scale-set-\\$\\{version\\}\";[\\s\\S]*?hash\\s*=\\s*\"[^\"]+\";"
+				"mkHelmChartFromGitHub\\s*(?:rec\\s*)?\\{[^}]*?pname\\s*=\\s*\"(?<depName>[^\"]+)\";[^}]*?version\\s*=\\s*\"(?<currentValue>[^\"]+)\";[^}]*?owner\\s*=\\s*\"(?<owner>actions)\";[^}]*?repo\\s*=\\s*\"(?<repo>actions-runner-controller)\";[^}]*?rev\\s*=\\s*\"gha-runner-scale-set-\\$\\{version\\}\";[^}]*?hash\\s*=\\s*\"[^\"]+\";"
 			],
 			"datasourceTemplate": "github-tags",
 			"depNameTemplate": "{{{owner}}}/{{{repo}}}",
@@ -30,7 +30,8 @@
 			"description": "Update mkHelmChartFromGitHub packages in Nix files",
 			"managerFilePatterns": ["/nix/.+\\.nix$/"],
 			"matchStrings": [
-				"mkHelmChartFromGitHub\\s*(?:rec\\s*)?\\{[\\s\\S]*?pname\\s*=\\s*\"(?<depName>[^\"]+)\";[\\s\\S]*?version\\s*=\\s*\"(?<currentValue>[^\"]+)\";[\\s\\S]*?owner\\s*=\\s*\"(?<owner>[^\"]+)\";[\\s\\S]*?repo\\s*=\\s*\"(?<repo>[^\"]+)\";\\s*hash\\s*=\\s*\"[^\"]+\";"
+				"mkHelmChartFromGitHub\\s*(?:rec\\s*)?\\{[^}]*?pname\\s*=\\s*\"(?<depName>[^\"]+)\";[^}]*?version\\s*=\\s*\"(?<currentValue>[^\"]+)\";[^}]*?owner\\s*=\\s*\"(?<owner>[^\"]+)\";[^}]*?repo\\s*=\\s*\"(?<repo>[^\"]+)\";[^}]*?hash\\s*=\\s*\"[^\"]+\";",
+				"mkHelmChartFromGitHub\\s*(?:rec\\s*)?\\{[^}]*?pname\\s*=\\s*\"(?<depName>[^\"]+)\";[^}]*?version\\s*=\\s*\"(?<currentValue>[^\"]+)\";[^}]*?owner\\s*=\\s*\"(?<owner>[^\"]+)\";[^}]*?repo\\s*=\\s*\"(?<repo>[^\"]+)\";[^}]*?chartSubdir\\s*=\\s*\"[^\"]+\";[^}]*?hash\\s*=\\s*\"[^\"]+\";"
 			],
 			"datasourceTemplate": "github-releases",
 			"depNameTemplate": "{{{owner}}}/{{{repo}}}"

--- a/renovate/nix.json
+++ b/renovate/nix.json
@@ -16,10 +16,21 @@
 		},
 		{
 			"customType": "regex",
+			"description": "Update mkHelmChartFromGitHub ARC chart packages in Nix files",
+			"managerFilePatterns": ["/nix/.+\\.nix$/"],
+			"matchStrings": [
+				"mkHelmChartFromGitHub\\s*\\{[\\s\\S]*?pname\\s*=\\s*\"(?<depName>[^\"]+)\";[\\s\\S]*?version\\s*=\\s*\"(?<currentValue>[^\"]+)\";[\\s\\S]*?owner\\s*=\\s*\"(?<owner>actions)\";[\\s\\S]*?repo\\s*=\\s*\"(?<repo>actions-runner-controller)\";[\\s\\S]*?rev\\s*=\\s*\"gha-runner-scale-set-\\$\\{version\\}\";[\\s\\S]*?hash\\s*=\\s*\"[^\"]+\";"
+			],
+			"datasourceTemplate": "github-tags",
+			"depNameTemplate": "{{{owner}}}/{{{repo}}}",
+			"extractVersionTemplate": "^gha-runner-scale-set-(?<version>.*)$"
+		},
+		{
+			"customType": "regex",
 			"description": "Update mkHelmChartFromGitHub packages in Nix files",
 			"managerFilePatterns": ["/nix/.+\\.nix$/"],
 			"matchStrings": [
-				"mkHelmChartFromGitHub\\s*\\{[\\s\\S]*?pname\\s*=\\s*\"(?<depName>[^\"]+)\";[\\s\\S]*?version\\s*=\\s*\"(?<currentValue>[^\"]+)\";[\\s\\S]*?owner\\s*=\\s*\"(?<owner>[^\"]+)\";[\\s\\S]*?repo\\s*=\\s*\"(?<repo>[^\"]+)\";[\\s\\S]*?hash\\s*=\\s*\"[^\"]+\";"
+				"mkHelmChartFromGitHub\\s*\\{(?![\\s\\S]*?rev\\s*=)[\\s\\S]*?pname\\s*=\\s*\"(?<depName>[^\"]+)\";[\\s\\S]*?version\\s*=\\s*\"(?<currentValue>[^\"]+)\";[\\s\\S]*?owner\\s*=\\s*\"(?<owner>[^\"]+)\";[\\s\\S]*?repo\\s*=\\s*\"(?<repo>[^\"]+)\";[\\s\\S]*?hash\\s*=\\s*\"[^\"]+\";"
 			],
 			"datasourceTemplate": "github-releases",
 			"depNameTemplate": "{{{owner}}}/{{{repo}}}"


### PR DESCRIPTION
## Summary
- Add a specific Renovate regex manager for `actions/actions-runner-controller` chart blocks that use the `gha-runner-scale-set-${version}` rev pattern.
- Keep the existing generic `mkHelmChartFromGitHub` manager on `github-releases` for ordinary charts such as `envoyproxy/gateway`.
- Prevent the generic manager from matching blocks that contain a `rev =` line so ARC is handled only by the new tag-based rule.

This is the preset-side fix for the bad ARC update surfaced in garden PR https://github.com/jmmaloney4/garden/pull/614 and related issue https://github.com/jmmaloney4/garden/issues/87.

## Validation
- Parsed the updated `renovate/nix.json` as JSON.
- Exercised both regex managers against sample `mkHelmChartFromGitHub` blocks in Node.js.
- Verified the ARC-specific rule matches the `gha-runner-scale-set-${version}` pattern.
- Verified the generic rule still matches a normal chart block like `envoyproxy/gateway` and does not match the ARC block.

## Risks
- This is a narrow exception for the ARC chart family. If more charts adopt prefixed `rev` tag families, they will need their own explicit Renovate rule instead of relying on the generic release-stream matcher.
- The generic matcher now intentionally excludes `rev =` blocks, so any future `mkHelmChartFromGitHub` call site with a different tag family should be added explicitly rather than implicitly inherited.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes Renovate regex managers that control automated dependency bumps for Nix files; incorrect matching could cause missed or wrong updates.
> 
> **Overview**
> **Fixes Renovate matching for `mkHelmChartFromGitHub` in Nix files** by introducing an ARC-specific regex manager that tracks `actions/actions-runner-controller` via `github-tags` and extracts versions from the `gha-runner-scale-set-${version}` `rev` pattern.
> 
> Tightens the generic `mkHelmChartFromGitHub` matcher (and adds a `chartSubdir`-aware variant) so it no longer accidentally matches ARC-style blocks with `rev`, and adds a Vitest suite to validate these regexes against realistic Nix SRI hash examples; docs are updated to clarify SRI-hash handling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 56d11c312a57f637d33473f69a993ae7bda74de2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->