### PR TITLE
fix(renovate): support let-bound helm chart versions

### DIFF
--- a/packages/sector7/tests/renovate-nix-regex.test.ts
+++ b/packages/sector7/tests/renovate-nix-regex.test.ts
@@ -28,9 +28,9 @@ const sriHash = "sha256-XRJNwpeGjQSEPub34BLrPJn3Tj6Ie90/PB7LR2+tPmU=";
 
 describe("renovate/nix.json mkHelmChartFromGitHub regex managers", () => {
 	it("matches ARC chart blocks that use real Nix SRI hashes", () => {
-		const arcRegex = managerRegexes(
+		const arcRegexes = managerRegexes(
 			"Update mkHelmChartFromGitHub ARC chart packages in Nix files",
-		)[0];
+		);
 		const arcBlock = [
 			"mkHelmChartFromGitHub rec {",
 			'  pname = "gha-runner-scale-set-controller-chart";',
@@ -42,7 +42,7 @@ describe("renovate/nix.json mkHelmChartFromGitHub regex managers", () => {
 			"};",
 		].join("\n");
 
-		const match = arcBlock.match(arcRegex);
+		const match = firstMatch(arcRegexes, arcBlock);
 		expect(match?.groups?.depName).toBe(
 			"gha-runner-scale-set-controller-chart",
 		);
@@ -88,6 +88,81 @@ describe("renovate/nix.json mkHelmChartFromGitHub regex managers", () => {
 		expect(match?.groups?.currentValue).toBe("1.2.3");
 		expect(match?.groups?.owner).toBe("example");
 		expect(match?.groups?.repo).toBe("repo");
+	});
+
+	it("matches let-bound ARC chart blocks that inherit version inside the attrset", () => {
+		const arcRegexes = managerRegexes(
+			"Update mkHelmChartFromGitHub ARC chart packages in Nix files",
+		);
+		const arcBlock = [
+			"gha-runner-scale-set-controller-chart = let",
+			'  version = "0.14.0";',
+			"in",
+			"  mkHelmChartFromGitHub {",
+			"    inherit version;",
+			'    pname = "gha-runner-scale-set-controller-chart";',
+			'    owner = "actions";',
+			'    repo = "actions-runner-controller";',
+			'    rev = "gha-runner-scale-set-${version}";',
+			`    hash = "${sriHash}";`,
+			'    chartSubdir = "charts/gha-runner-scale-set-controller";',
+			"  };",
+		].join("\n");
+
+		const match = firstMatch(arcRegexes, arcBlock);
+		expect(match?.groups?.depName).toBe(
+			"gha-runner-scale-set-controller-chart",
+		);
+		expect(match?.groups?.currentValue).toBe("0.14.0");
+		expect(match?.groups?.owner).toBe("actions");
+		expect(match?.groups?.repo).toBe("actions-runner-controller");
+	});
+
+	it("matches let-bound generic chart blocks that inherit version inside the attrset", () => {
+		const genericRegexes = managerRegexes(
+			"Update mkHelmChartFromGitHub packages in Nix files",
+		);
+		const genericBlock = [
+			"envoy-gateway-crds-chart = let",
+			'  version = "1.7.3";',
+			"in",
+			"  mkHelmChartFromGitHub {",
+			"    inherit version;",
+			'    pname = "envoy-gateway-crds-chart";',
+			'    owner = "envoyproxy";',
+			'    repo = "gateway";',
+			`    hash = "${sriHash}";`,
+			'    chartSubdir = "charts/gateway-crds-helm";',
+			"  };",
+		].join("\n");
+
+		const match = firstMatch(genericRegexes, genericBlock);
+		expect(match?.groups?.depName).toBe("envoy-gateway-crds-chart");
+		expect(match?.groups?.currentValue).toBe("1.7.3");
+		expect(match?.groups?.owner).toBe("envoyproxy");
+		expect(match?.groups?.repo).toBe("gateway");
+	});
+
+	it("does not let the generic matcher swallow let-bound ARC chart blocks", () => {
+		const genericRegexes = managerRegexes(
+			"Update mkHelmChartFromGitHub packages in Nix files",
+		);
+		const arcBlock = [
+			"gha-runner-scale-set-controller-chart = let",
+			'  version = "0.14.0";',
+			"in",
+			"  mkHelmChartFromGitHub {",
+			"    inherit version;",
+			'    pname = "gha-runner-scale-set-controller-chart";',
+			'    owner = "actions";',
+			'    repo = "actions-runner-controller";',
+			'    rev = "gha-runner-scale-set-${version}";',
+			`    hash = "${sriHash}";`,
+			'    chartSubdir = "charts/gha-runner-scale-set-controller";',
+			"  };",
+		].join("\n");
+
+		expect(firstMatch(genericRegexes, arcBlock)).toBeUndefined();
 	});
 
 	it("does not let the generic matcher swallow ARC chart blocks with rev lines", () => {

--- a/renovate/nix.json
+++ b/renovate/nix.json
@@ -19,7 +19,8 @@
 			"description": "Update mkHelmChartFromGitHub ARC chart packages in Nix files",
 			"managerFilePatterns": ["/nix/.+\\.nix$/"],
 			"matchStrings": [
-				"mkHelmChartFromGitHub\\s*(?:rec\\s*)?\\{[^}]*?pname\\s*=\\s*\"(?<depName>[^\"]+)\";[^}]*?version\\s*=\\s*\"(?<currentValue>[^\"]+)\";[^}]*?owner\\s*=\\s*\"(?<owner>actions)\";[^}]*?repo\\s*=\\s*\"(?<repo>actions-runner-controller)\";[^}]*?rev\\s*=\\s*\"gha-runner-scale-set-\\$\\{version\\}\";[^}]*?hash\\s*=\\s*\"[^\"]+\";"
+				"mkHelmChartFromGitHub\\s*(?:rec\\s*)?\\{[^}]*?pname\\s*=\\s*\"(?<depName>[^\"]+)\";[^}]*?version\\s*=\\s*\"(?<currentValue>[^\"]+)\";[^}]*?owner\\s*=\\s*\"(?<owner>actions)\";[^}]*?repo\\s*=\\s*\"(?<repo>actions-runner-controller)\";[^}]*?rev\\s*=\\s*\"gha-runner-scale-set-\\$\\{version\\}\";[^}]*?hash\\s*=\\s*\"[^\"]+\";",
+				"let\\s+version\\s*=\\s*\"(?<currentValue>[^\"]+)\";\\s*in\\s*mkHelmChartFromGitHub\\s*(?:rec\\s*)?\\{[^}]*?inherit\\s+version;[^}]*?pname\\s*=\\s*\"(?<depName>[^\"]+)\";[^}]*?owner\\s*=\\s*\"(?<owner>actions)\";\\s*repo\\s*=\\s*\"(?<repo>actions-runner-controller)\";\\s*rev\\s*=\\s*\"gha-runner-scale-set-\\$\\{version\\}\";\\s*hash\\s*=\\s*\"[^\"]+\";\\s*chartSubdir\\s*=\\s*\"[^\"]+\";"
 			],
 			"datasourceTemplate": "github-tags",
 			"depNameTemplate": "{{{owner}}}/{{{repo}}}",
@@ -31,7 +32,9 @@
 			"managerFilePatterns": ["/nix/.+\\.nix$/"],
 			"matchStrings": [
 				"mkHelmChartFromGitHub\\s*(?:rec\\s*)?\\{[^}]*?pname\\s*=\\s*\"(?<depName>[^\"]+)\";[^}]*?version\\s*=\\s*\"(?<currentValue>[^\"]+)\";[^}]*?owner\\s*=\\s*\"(?<owner>[^\"]+)\";[^}]*?repo\\s*=\\s*\"(?<repo>[^\"]+)\";[^}]*?hash\\s*=\\s*\"[^\"]+\";",
-				"mkHelmChartFromGitHub\\s*(?:rec\\s*)?\\{[^}]*?pname\\s*=\\s*\"(?<depName>[^\"]+)\";[^}]*?version\\s*=\\s*\"(?<currentValue>[^\"]+)\";[^}]*?owner\\s*=\\s*\"(?<owner>[^\"]+)\";[^}]*?repo\\s*=\\s*\"(?<repo>[^\"]+)\";[^}]*?chartSubdir\\s*=\\s*\"[^\"]+\";[^}]*?hash\\s*=\\s*\"[^\"]+\";"
+				"mkHelmChartFromGitHub\\s*(?:rec\\s*)?\\{[^}]*?pname\\s*=\\s*\"(?<depName>[^\"]+)\";[^}]*?version\\s*=\\s*\"(?<currentValue>[^\"]+)\";[^}]*?owner\\s*=\\s*\"(?<owner>[^\"]+)\";[^}]*?repo\\s*=\\s*\"(?<repo>[^\"]+)\";[^}]*?chartSubdir\\s*=\\s*\"[^\"]+\";[^}]*?hash\\s*=\\s*\"[^\"]+\";",
+				"let\\s+version\\s*=\\s*\"(?<currentValue>[^\"]+)\";\\s*in\\s*mkHelmChartFromGitHub\\s*(?:rec\\s*)?\\{[^}]*?inherit\\s+version;[^}]*?pname\\s*=\\s*\"(?<depName>[^\"]+)\";[^}]*?owner\\s*=\\s*\"(?<owner>[^\"]+)\";\\s*repo\\s*=\\s*\"(?<repo>[^\"]+)\";\\s*hash\\s*=\\s*\"[^\"]+\";",
+				"let\\s+version\\s*=\\s*\"(?<currentValue>[^\"]+)\";\\s*in\\s*mkHelmChartFromGitHub\\s*(?:rec\\s*)?\\{[^}]*?inherit\\s+version;[^}]*?pname\\s*=\\s*\"(?<depName>[^\"]+)\";[^}]*?owner\\s*=\\s*\"(?<owner>[^\"]+)\";\\s*repo\\s*=\\s*\"(?<repo>[^\"]+)\";\\s*hash\\s*=\\s*\"[^\"]+\";\\s*chartSubdir\\s*=\\s*\"[^\"]+\";"
 			],
 			"datasourceTemplate": "github-releases",
 			"depNameTemplate": "{{{owner}}}/{{{repo}}}"


### PR DESCRIPTION
## Summary
- restore Renovate matching for `mkHelmChartFromGitHub` blocks that bind `version` in an outer `let` and use `inherit version` inside the attrset
- add ARC-specific let-bound coverage so `actions/actions-runner-controller` still uses the `gha-runner-scale-set-*` tag stream
- add generic let-bound coverage and a guard that generic matching does not swallow ARC blocks

## Why
`garden` uses a real pattern like:
- `let version = "..."; in mkHelmChartFromGitHub { inherit version; ... }`

PR `jmmaloney4/garden#614` was auto-closed after the sector7 ARC datasource fix because the updated regex managers no longer matched that shape at all. The earlier fix corrected the datasource, but it regressed extraction for let-bound chart definitions.

This patch restores detection without reintroducing the ARC/generic mix-up.

Related:
- jmmaloney4/garden#614
- jmmaloney4/garden#87

## Test Plan
- [x] `pnpm --dir packages/sector7 exec vitest run tests/renovate-nix-regex.test.ts`
- [x] `node -e 'JSON.parse(require("fs").readFileSync("renovate/nix.json", "utf8"))'`
- [x] Verified the updated regex managers match let-bound `garden/nix/helm-charts.nix` content via a local Node probe against `jmmaloney4/garden` main
- [x] `nix flake check -L --no-build`

## Risks
- Regex-manager changes are always a little brittle because they encode structural assumptions about Nix attr ordering
- the new let-bound generic patterns intentionally rely on the `repo -> hash -> chartSubdir` ordering used in `garden` so they do not absorb ARC blocks with `rev = ...`
- if another repo uses a different let-bound ordering, we may need one more narrowly-scoped matcher rather than broadening these patterns again

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes Renovate regex managers that drive automated dependency updates; small regex mistakes could cause missed updates or incorrect matches between ARC-specific and generic helm charts.
> 
> **Overview**
> Restores Renovate matching for `mkHelmChartFromGitHub` helm charts whose `version` is defined in an outer `let` and pulled into the attrset via `inherit version;`, for both the ARC-specific and generic managers.
> 
> Adds regression tests covering the new let-bound patterns and explicitly asserting the generic manager does *not* match ARC blocks (including the let-bound form), preventing datasource/version extraction mix-ups.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e1cf0a88dcc0122fbccf67003b50451f728d7530. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->