### PR TITLE
feat(nix-output): add eager preview resolution

### DIFF
--- a/docs/internal/designs/021-nix-output-component.md
+++ b/docs/internal/designs/021-nix-output-component.md
@@ -83,6 +83,17 @@ export interface NixOutputArgs {
    * output is in the local store.
    */
   mode?: "resolve" | "build";
+  /**
+   * Preview path resolution strategy.
+   *
+   * "resource" keeps the child command as the source of truth, which can
+   * leave `storePath` unknown during preview when the command needs to rerun.
+   *
+   * "eager" attempts to resolve the path during preview when all required
+   * inputs are already plain strings, preserving better downstream diff
+   * fidelity for consumers like local Helm charts.
+   */
+  previewStrategy?: "resource" | "eager";
   /** Extra environment variables to pass to the build command. */
   env?: Record<string, pulumi.Input<string>>;
 }
@@ -165,6 +176,7 @@ For `NixImage`, the default trigger remains `imageTag` since that's the deployme
 - **General-purpose**: Any nix attribute that produces a derivable output can be represented, not just nix2container images.
 - **Resolve-first default**: The default mode is "resolve" — if the derivation already exists in the store, no build is triggered. This is the correct Pulumi-aligned default: declare desired state, only build if necessary.
 - **Cleaner separation of concerns**: Image push logic no longer shares a command with nix build logic. Each step has its own command, its own triggers, its own error surface.
+- **Optional preview fidelity**: Consumers that use local file-path inputs downstream can opt into preview-time store-path resolution when their `NixOutput` inputs are already concrete strings.
 
 ## Negative / Risks
 
@@ -206,7 +218,7 @@ Balances declarative intent ("output" of the nix system) with generality. An out
 
 1. **Should `NixOutput` have a `subOutput` arg?** Yes. Added `subOutput` to select named outputs from multi-output derivations. Implemented as `nixAttr^subOutput` syntax passed to the shell script via `SUB_OUTPUT` env var.
 
-2. **What happens on `pulumi preview`?** `NixOutput` with `mode="build"` shows a diff on preview because `command.local.Command` doesn't execute during preview. This is expected and consistent with how NixImage worked before. Document in the README.
+2. **What happens on `pulumi preview`?** By default, `NixOutput` keeps the resource-backed behavior, so `mode="build"` can still leave `storePath` unknown during preview because `command.local.Command` doesn't execute in preview. Consumers that need a concrete preview-time path can opt into `previewStrategy="eager"`, which runs the resolver script during preview when all required inputs are already plain strings.
 
 3. **Should `NixOutput` support caching?** No explicit caching in the component. Nix daemon cache handles this naturally. The `--no-link --print-out-paths` build approach doesn't create symlinks to clean up. Leave caching to the nix daemon.
 

--- a/packages/sector7/nix-output/nix-output.ts
+++ b/packages/sector7/nix-output/nix-output.ts
@@ -1,3 +1,4 @@
+import { execFileSync } from "node:child_process";
 import * as command from "@pulumi/command";
 import * as pulumi from "@pulumi/pulumi";
 import { getScriptPath } from "../scripts/index.ts";
@@ -38,8 +39,55 @@ export interface NixOutputArgs {
 	 * output is in the local store.
 	 */
 	mode?: "resolve" | "build";
+	/**
+	 * Preview path resolution strategy.
+	 *
+	 * "resource" (default) keeps the existing Pulumi resource-backed
+	 * behavior, which means `storePath` can be unknown during preview when
+	 * the child command needs to rerun.
+	 *
+	 * "eager" attempts to resolve the store path during preview when all
+	 * inputs needed by the script are plain strings. This preserves better
+	 * downstream preview fidelity for consumers like local Helm charts.
+	 * If any required input is still dynamic, it falls back to
+	 * resource-backed behavior.
+	 */
+	previewStrategy?: "resource" | "eager";
 	/** Extra environment variables to pass to the command. */
 	env?: Record<string, pulumi.Input<string>>;
+}
+
+function parseStorePath(stdout: string, name: string): string {
+	const match = stdout.trim().match(/STORE_PATH_OUTPUT:(\/nix\/store\/[^\s]+)/);
+	if (!match) {
+		throw new Error(`Could not parse STORE_PATH_OUTPUT from output for ${name}`);
+	}
+	return match[1];
+}
+
+function isStringRecord(
+	value: Record<string, pulumi.Input<string>>,
+): value is Record<string, string> {
+	return Object.values(value).every((entry) => typeof entry === "string");
+}
+
+export function resolvePreviewStorePath(
+	name: string,
+	scriptPath: string,
+	env: Record<string, pulumi.Input<string>>,
+): string | undefined {
+	if (!isStringRecord(env)) {
+		return undefined;
+	}
+
+	const stdout = execFileSync("bash", [scriptPath], {
+		encoding: "utf8",
+		env: {
+			...process.env,
+			...env,
+		},
+	});
+	return parseStorePath(stdout, name);
 }
 
 export class NixOutput extends pulumi.ComponentResource {
@@ -66,6 +114,7 @@ export class NixOutput extends pulumi.ComponentResource {
 		const scriptPath = getScriptPath("nix-output-resolve.sh");
 		const commandLogStem = `.pulumi/command-logs/${name}`;
 		const mode = args.mode ?? "resolve";
+		const previewStrategy = args.previewStrategy ?? "resource";
 
 		const env: Record<string, pulumi.Input<string>> = {
 			...(args.env ?? {}),
@@ -87,17 +136,15 @@ export class NixOutput extends pulumi.ComponentResource {
 			{ parent: this },
 		);
 
-		this.storePath = cmd.stdout.apply((stdout: string) => {
-			const match = stdout
-				.trim()
-				.match(/STORE_PATH_OUTPUT:(\/nix\/store\/[^\s]+)/);
-			if (!match) {
-				throw new Error(
-					`Could not parse STORE_PATH_OUTPUT from output for ${name}`,
-				);
-			}
-			return match[1];
-		});
+		const eagerStorePath =
+			previewStrategy === "eager" && pulumi.runtime.isDryRun()
+				? resolvePreviewStorePath(name, scriptPath, env)
+				: undefined;
+
+		this.storePath =
+			eagerStorePath !== undefined
+				? pulumi.output(eagerStorePath)
+				: cmd.stdout.apply((stdout: string) => parseStorePath(stdout, name));
 
 		this.registerOutputs({
 			storePath: this.storePath,

--- a/packages/sector7/tests/nix-output.test.ts
+++ b/packages/sector7/tests/nix-output.test.ts
@@ -1,7 +1,11 @@
-import * as command from "@pulumi/command";
+import { execFileSync } from "node:child_process";
 import * as pulumi from "@pulumi/pulumi";
-import { beforeAll, beforeEach, describe, expect, it } from "vitest";
-import { NixOutput } from "../nix-output/nix-output";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NixOutput, resolvePreviewStorePath } from "../nix-output/nix-output";
+
+vi.mock("node:child_process", () => ({
+	execFileSync: vi.fn(),
+}));
 
 type MockResource = {
 	type: string;
@@ -12,51 +16,59 @@ type MockResource = {
 
 const resources: MockResource[] = [];
 
-beforeAll(() => {
-	pulumi.runtime.setMocks({
-		newResource: (args) => {
-			const state = args.inputs;
+function installMocks(preview = false): void {
+	pulumi.runtime.setMocks(
+		{
+			newResource: (args: pulumi.runtime.MockResourceArgs) => {
+				const state = args.inputs;
 
-			// For command.local.Command, simulate stdout with STORE_PATH_OUTPUT marker
-			if (args.type === "command:local:Command") {
-				const create = state.create as string | undefined;
+				// For command.local.Command, simulate stdout with STORE_PATH_OUTPUT marker
+				if (args.type === "command:local:Command") {
+					const create = state.create as string | undefined;
 
-				if (create?.includes("nix-output-resolve.sh")) {
-					const env = state.environment as Record<string, string> | undefined;
-					const subPath = env?.SUB_PATH;
-					const baseStorePath = "/nix/store/abc123-myapp-1.0.0";
-					const storePath = subPath
-						? `${baseStorePath}/${subPath}`
-						: baseStorePath;
+					if (create?.includes("nix-output-resolve.sh")) {
+						const env = state.environment as Record<string, string> | undefined;
+						const subPath = env?.SUB_PATH;
+						const baseStorePath = "/nix/store/abc123-myapp-1.0.0";
+						const storePath = subPath
+							? `${baseStorePath}/${subPath}`
+							: baseStorePath;
 
-					(state as Record<string, unknown>).stdout =
-						`=== Resolved: ${storePath} ===\nSTORE_PATH_OUTPUT:${storePath}\n`;
+						(state as Record<string, unknown>).stdout =
+							`=== Resolved: ${storePath} ===\nSTORE_PATH_OUTPUT:${storePath}\n`;
+					}
 				}
-			}
 
-			resources.push({
-				type: args.type,
-				name: args.name,
-				inputs: state as Record<string, unknown>,
-				parent: args.parent?.urn ?? undefined,
-			});
+				resources.push({
+					type: args.type,
+					name: args.name,
+					inputs: state as Record<string, unknown>,
+					parent: args.parent?.urn ?? undefined,
+				});
 
-			return {
-				id: `${args.name}-id`,
-				state,
-			};
+				return {
+					id: `${args.name}-id`,
+					state,
+				};
+			},
+			call: (args: pulumi.runtime.MockCallArgs) => args.inputs,
 		},
-		call: (args) => args.inputs,
-	});
-});
+		undefined,
+		undefined,
+		preview,
+	);
+}
 
 beforeEach(() => {
 	resources.length = 0;
+	vi.clearAllMocks();
+	vi.restoreAllMocks();
+	installMocks(false);
 });
 
 function resolveOutput<T>(value: pulumi.Input<T>): Promise<T> {
 	return new Promise((resolve) => {
-		pulumi.output(value).apply((resolved) => {
+		pulumi.output(value).apply((resolved: T) => {
 			resolve(resolved as T);
 			return resolved;
 		});
@@ -251,5 +263,58 @@ describe("NixOutput", () => {
 		const env = cmds[0].inputs.environment as Record<string, unknown>;
 		expect(env).not.toHaveProperty("SUB_OUTPUT");
 		expect(env).not.toHaveProperty("SUB_PATH");
+	});
+
+	it("eager preview helper resolves a concrete store path when env is static", () => {
+		const execSpy = vi.mocked(execFileSync).mockReturnValue(
+			"=== Resolved: /nix/store/eager123-myapp-1.0.0 ===\nSTORE_PATH_OUTPUT:/nix/store/eager123-myapp-1.0.0\n",
+		);
+
+		const storePath = resolvePreviewStorePath(
+			"test-preview-eager",
+			"/tmp/nix-output-resolve.sh",
+			{
+				NIX_ATTR: "packages.x86_64-linux.myapp",
+				REPO_ROOT: "/home/user/my-repo",
+				SCRIPT_MODE: "build",
+				COMMAND_LOG_STEM: ".pulumi/command-logs/test-preview-eager",
+				EXTRA_FLAG: "enabled",
+			},
+		);
+
+		expect(storePath).toBe("/nix/store/eager123-myapp-1.0.0");
+		expect(execSpy).toHaveBeenCalledOnce();
+		expect(execSpy).toHaveBeenCalledWith(
+			"bash",
+			["/tmp/nix-output-resolve.sh"],
+			expect.objectContaining({
+				encoding: "utf8",
+				env: expect.objectContaining({
+					NIX_ATTR: "packages.x86_64-linux.myapp",
+					REPO_ROOT: "/home/user/my-repo",
+					SCRIPT_MODE: "build",
+					COMMAND_LOG_STEM: ".pulumi/command-logs/test-preview-eager",
+					EXTRA_FLAG: "enabled",
+				}),
+			}),
+		);
+	});
+
+	it("eager preview helper returns undefined when any env input is dynamic", () => {
+		const execSpy = vi.mocked(execFileSync);
+
+		const storePath = resolvePreviewStorePath(
+			"test-preview-fallback",
+			"/tmp/nix-output-resolve.sh",
+			{
+				NIX_ATTR: "packages.x86_64-linux.myapp",
+				REPO_ROOT: pulumi.output("/home/user/my-repo"),
+				SCRIPT_MODE: "build",
+				COMMAND_LOG_STEM: ".pulumi/command-logs/test-preview-fallback",
+			},
+		);
+
+		expect(storePath).toBeUndefined();
+		expect(execSpy).not.toHaveBeenCalled();
 	});
 });


### PR DESCRIPTION
## Summary
- add an opt-in `previewStrategy: "eager"` mode to `NixOutput`
- resolve the store path during `pulumi preview` when all resolver inputs are already concrete strings
- keep the existing resource-backed behavior as the default and document the tradeoff in ADR 021

## Why
`NixOutput` currently wraps a `command.local.Command`, so when the child command needs to rerun, `storePath` becomes unknown during preview. That is fine for many consumers, but it degrades preview fidelity for local file-path consumers like `k8s.helm.v4.Chart`, which then lose field-level diffs and fall back to broad unknown-value previews.

This PR gives callers an explicit escape hatch without changing the default contract.

Fixes #208.

## Test plan
- `cd packages/sector7 && pnpm test`
- `cd packages/sector7 && pnpm run build`
- real usage path: not exercised from this clone because the motivating consumer lives in `garden`; the behavior was designed against the previously reproduced `actions-runner-controller` chart preview regression described in #208

## Risks
- `previewStrategy: "eager"` runs the resolver script during preview, so callers opt into preview-time work explicitly
- eager preview only applies when all required env inputs are plain strings; dynamic Pulumi inputs still fall back to the existing resource-backed behavior

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds an opt-in code path that executes the resolver bash script via `execFileSync` during `pulumi preview`, which can introduce unexpected local side effects/perf issues if misused. Default behavior remains unchanged, and eager resolution is gated on all inputs being plain strings.
> 
> **Overview**
> Adds an opt-in `previewStrategy: "eager"` to `NixOutput` to attempt resolving `storePath` during `pulumi preview` when all required env inputs are concrete strings, improving downstream diff fidelity.
> 
> Implements a small helper (`resolvePreviewStorePath`) that runs the existing resolver script and reuses shared `STORE_PATH_OUTPUT` parsing, with tests updated to mock `execFileSync` and cover both eager and fallback-to-resource behavior; ADR-021 is updated to document the new preview tradeoff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4b4ee8e16993e0a854a9c07aaa09df48438cc468. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->