### PR TITLE
fix(nix-output): harden eager preview fallback

### DIFF
--- a/packages/sector7/nix-output/nix-output.ts
+++ b/packages/sector7/nix-output/nix-output.ts
@@ -58,11 +58,15 @@ export interface NixOutputArgs {
 }
 
 function parseStorePath(stdout: string, name: string): string {
-	const match = stdout.trim().match(/STORE_PATH_OUTPUT:(\/nix\/store\/[^\s]+)/);
-	if (!match) {
+	const prefix = "STORE_PATH_OUTPUT:";
+	const line = stdout
+		.trim()
+		.split(/\r?\n/)
+		.find((entry) => entry.startsWith(prefix));
+	if (!line) {
 		throw new Error(`Could not parse STORE_PATH_OUTPUT from output for ${name}`);
 	}
-	return match[1];
+	return line.slice(prefix.length);
 }
 
 function isStringRecord(
@@ -80,14 +84,18 @@ export function resolvePreviewStorePath(
 		return undefined;
 	}
 
-	const stdout = execFileSync("bash", [scriptPath], {
-		encoding: "utf8",
-		env: {
-			...process.env,
-			...env,
-		},
-	});
-	return parseStorePath(stdout, name);
+	try {
+		const stdout = execFileSync("bash", [scriptPath], {
+			encoding: "utf8",
+			env: {
+				...process.env,
+				...env,
+			},
+		});
+		return parseStorePath(stdout, name);
+	} catch {
+		return undefined;
+	}
 }
 
 export class NixOutput extends pulumi.ComponentResource {

--- a/packages/sector7/tests/nix-output.test.ts
+++ b/packages/sector7/tests/nix-output.test.ts
@@ -300,6 +300,45 @@ describe("NixOutput", () => {
 		);
 	});
 
+	it("eager preview helper returns undefined when the script fails", () => {
+		const execSpy = vi.mocked(execFileSync).mockImplementation(() => {
+			throw new Error("nix failed");
+		});
+
+		const storePath = resolvePreviewStorePath(
+			"test-preview-failure",
+			"/tmp/nix-output-resolve.sh",
+			{
+				NIX_ATTR: "packages.x86_64-linux.myapp",
+				REPO_ROOT: "/home/user/my-repo",
+				SCRIPT_MODE: "build",
+				COMMAND_LOG_STEM: ".pulumi/command-logs/test-preview-failure",
+			},
+		);
+
+		expect(storePath).toBeUndefined();
+		expect(execSpy).toHaveBeenCalledOnce();
+	});
+
+	it("eager preview helper preserves spaces in parsed store paths", () => {
+		vi.mocked(execFileSync).mockReturnValue(
+			"=== Resolved: /nix/store/eager123-my app-1.0.0 ===\nSTORE_PATH_OUTPUT:/nix/store/eager123-my app-1.0.0\n",
+		);
+
+		const storePath = resolvePreviewStorePath(
+			"test-preview-spaces",
+			"/tmp/nix-output-resolve.sh",
+			{
+				NIX_ATTR: "packages.x86_64-linux.myapp",
+				REPO_ROOT: "/home/user/my-repo",
+				SCRIPT_MODE: "build",
+				COMMAND_LOG_STEM: ".pulumi/command-logs/test-preview-spaces",
+			},
+		);
+
+		expect(storePath).toBe("/nix/store/eager123-my app-1.0.0");
+	});
+
 	it("eager preview helper returns undefined when any env input is dynamic", () => {
 		const execSpy = vi.mocked(execFileSync);
 


### PR DESCRIPTION
This follow-up hardens the new eager-preview path in `NixOutput`.

## What changed

- `resolvePreviewStorePath` now falls back to the existing resource-backed path when the eager preview command fails.
- `parseStorePath` now parses the `STORE_PATH_OUTPUT:` line by prefix so whitespace in the parsed suffix is preserved.
- Added tests for the failure fallback and whitespace-preserving parsing.

## Why

- The eager path should improve preview fidelity only when it can actually resolve a concrete path. If the script fails, we should keep the existing Pulumi behavior instead of crashing preview.
- Parsing by prefix is simpler and avoids truncating valid output.

## Context: the two-part fix

This PR is a hardening follow-up to the preview strategy feature introduced in #209. The overall fix for stale Helm chart paths in the garden ARC stack is two parts:

1. **Correctness fix** (garden-side): Switched `deploy/services/actions-runner-controller/index.ts` from trusting a devshell-exported chart path to constructing the chart path from Nix at deploy time via `NixOutput`. This stops the stack from pointing at stale chart directories after a flake bump.

2. **Preview fidelity fix** (sector7-side): `NixOutput` historically resolves paths via a child `command.local.Command`. During preview, if that command is going to rerun, `cmd.stdout` is unknown, making Helm preview incomplete. The `previewStrategy: "eager"` option solves this by synchronously resolving the store path when inputs are plain strings.

This PR hardens the eager-preview path so it fails safely:
- If eager preview resolution fails, preview falls back to resource-backed behavior instead of crashing.
- Store path parsing preserves whitespace in the resolved suffix.

## Will existing users of NixOutput be affected?

No, unless they opt in.

The `previewStrategy` argument defaults to `"resource"`:
- `const previewStrategy = args.previewStrategy ?? "resource";`

Existing callers get the exact existing model:
- path resolution is resource-backed
- preview may still show unknowns where the child command reruns
- no eager preview execution happens unless they explicitly set `previewStrategy: "eager"`

Who is affected:
- **Existing users who do nothing** — not affected
- **Existing users who set `previewStrategy: "eager"`** — get more concrete previews; if eager resolution fails, it falls back safely instead of blowing up
- **Garden ARC stack** — intended consumer of the feature

## Validation

- `cd packages/sector7 && pnpm test`
- `cd packages/sector7 && pnpm run build`

## Follow-up

After this lands, cut a new release so garden can switch ARC to `previewStrategy: "eager"`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: limited to preview-time path parsing and error handling; runtime resource-backed behavior is unchanged aside from safer fallback when eager resolution fails.
> 
> **Overview**
> **Hardens eager preview resolution for `NixOutput`.** `resolvePreviewStorePath` now catches script execution failures and returns `undefined` so preview falls back to the existing resource-backed path instead of erroring.
> 
> **Improves store path parsing.** `parseStorePath` now finds the `STORE_PATH_OUTPUT:` line by prefix and slices the remainder, preserving whitespace in the resolved path.
> 
> Adds targeted tests covering the failure fallback and whitespace-preserving parsing in the eager preview helper.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a6bdc52da7563186194ee0656b1a8df7b044e67d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->