### PR TITLE
deps(renovate): exclude requires-python from version pinning

### DIFF
--- a/renovate/default.json
+++ b/renovate/default.json
@@ -43,9 +43,9 @@
 			"minimumReleaseAge": null
 		},
 		{
-			"description": "Do not pin requires-python in pyproject.toml — keep as minimum version range",
+			"description": "Disable requires-python updates — managed manually per project as a capped minor range (e.g. >=3.13,<3.14)",
 			"matchDepTypes": ["requires-python"],
-			"rangeStrategy": "replace"
+			"enabled": false
 		}
 	]
 }

--- a/renovate/default.json
+++ b/renovate/default.json
@@ -41,6 +41,11 @@
 			"description": "Skip stability days for internal sector7 actions (own repo)",
 			"matchPackageNames": ["jmmaloney4/sector7"],
 			"minimumReleaseAge": null
+		},
+		{
+			"description": "Do not pin requires-python in pyproject.toml — keep as minimum version range",
+			"matchDepTypes": ["requires-python"],
+			"rangeStrategy": "replace"
 		}
 	]
 }


### PR DESCRIPTION
## Summary

The shared `renovate/default.json` preset extends `:pinAllExceptPeerDependencies` with `rangeStrategy: "pin"`, which causes Renovate to pin `requires-python` in `pyproject.toml` to an exact version (e.g. `==3.12.0`). We want `requires-python` to stay as a capped-minor range like `>=3.13,<3.14`, which Renovate cannot synthesize natively (none of `pin`, `replace`, `widen`, `bump` produce an upper-bound cap).

## Changes

- Add a `packageRules` entry in `renovate/default.json` that matches `requires-python` depType and disables Renovate updates for it entirely. The `requires-python` field is a project-level compatibility declaration managed manually when the Python baseline is chosen — not something a bot should bump.

## Test plan

- [x] JSON is valid (lint passed).
- [ ] Confirm downstream repos (garden, yard, etc.) that extend `github>jmmaloney4/sector7//renovate/all.json` pick up this rule.
- [ ] Close or rebase the broken garden PR #549 that pins `requires-python` — after this merges, Renovate should stop proposing changes to it.

## Links

- Context: garden#549 (Renovate pins `requires-python` and breaks things)