### PR TITLE
feat(litellm): add Cloud SQL Auth Proxy sidecar injection

### DIFF
--- a/packages/sector7/litellm/config-types.ts
+++ b/packages/sector7/litellm/config-types.ts
@@ -128,6 +128,52 @@ export interface LiteLLMServiceSpec {
 	port?: number;
 }
 
+/**
+ * Cloud SQL Auth Proxy sidecar configuration.
+ *
+ * When provided, the proxy component injects a `cloud-sql-proxy` sidecar
+ * container that forwards a local port to the Cloud SQL instance via the
+ * Cloud SQL Auth Proxy. The DATABASE_URL is rewritten to point at
+ * `localhost:<proxyPort>` so the LiteLLM container connects through the
+ * sidecar instead of hitting the public IP directly.
+ *
+ * This eliminates the need for authorized networks and client certificates.
+ * Authentication is handled by the proxy using either a GCP service account
+ * key (via a Kubernetes secret) or IAM credentials.
+ */
+export interface CloudSqlAuthProxy {
+	/** Cloud SQL connection name: `project:region:instance`. */
+	connectionName: pulumi.Input<string>;
+
+	/**
+	 * Local port the auth proxy listens on inside the pod.
+	 * The DATABASE_URL host is rewritten to `127.0.0.1:<proxyPort>`.
+	 * @default 5432
+	 */
+	proxyPort?: number;
+
+	/** Container image for the Cloud SQL Auth Proxy. */
+	image?: pulumi.Input<string>;
+
+	/**
+	 * GCP service account key (JSON) for IAM authentication.
+	 * When provided, the key is stored in a Kubernetes secret and mounted
+	 * as an environment variable in the sidecar.
+	 *
+	 * If omitted, the sidecar relies on Workload Identity or the node's
+	 * default service account.
+	 */
+	serviceAccountKey?: pulumi.Input<string>;
+
+	/** Extra args passed to the cloud-sql-proxy binary. */
+	extraArgs?: pulumi.Input<pulumi.Input<string>[]>;
+
+	/** Resource requests/limits for the sidecar container. */
+	resources?: pulumi.Input<
+		import("@pulumi/kubernetes").types.input.core.v1.ResourceRequirements
+	>;
+}
+
 export interface LiteLLMProxyArgs {
 	namespace?: pulumi.Input<string>;
 	createNamespace?: boolean;
@@ -143,6 +189,7 @@ export interface LiteLLMProxyArgs {
 	observability?: LiteLLMObservabilityPolicy;
 	redis?: LiteLLMRedisPolicy;
 	service?: LiteLLMServiceSpec;
+	cloudSqlAuthProxy?: CloudSqlAuthProxy;
 	resources?: k8s.types.input.core.v1.ResourceRequirements;
 	extraLiteLLMSettings?: Record<string, unknown>;
 	extraGeneralSettings?: Record<string, unknown>;

--- a/packages/sector7/litellm/index.ts
+++ b/packages/sector7/litellm/index.ts
@@ -1,6 +1,7 @@
 export { generateLiteLLMConfig } from "./config.ts";
 export type {
 	BuildLiteLLMTeamScopedModelGroupsArgs,
+	CloudSqlAuthProxy,
 	LiteLLMAdminTargetArgs,
 	LiteLLMApiKeyArgs,
 	LiteLLMGeneratedConfig,

--- a/packages/sector7/litellm/litellm-proxy.ts
+++ b/packages/sector7/litellm/litellm-proxy.ts
@@ -69,7 +69,7 @@ function rewriteDatabaseUrlForProxy(
 ): string {
 	const rewritten = url.replace(
 		/(\/\/[^@]+@)([^:\/]+)(:\d+)?/,
-		`$1127.0.0.1:${proxyPort}`,
+		(_, prefix, _host, _port) => `${prefix}127.0.0.1:${proxyPort}`,
 	);
 	return rewritten.replace(/sslmode=[^&]+/, "sslmode=disable");
 }

--- a/packages/sector7/litellm/litellm-proxy.ts
+++ b/packages/sector7/litellm/litellm-proxy.ts
@@ -3,6 +3,7 @@ import * as pulumi from "@pulumi/pulumi";
 import * as random from "@pulumi/random";
 import { generateLiteLLMConfig, getProviderEnvVar } from "./config.ts";
 import type {
+	CloudSqlAuthProxy,
 	LiteLLMModelDeployment,
 	LiteLLMProviderConfig,
 	LiteLLMProxyArgs,
@@ -57,6 +58,61 @@ function resolveDeployment(
 	});
 }
 
+/**
+ * Rewrite a PostgreSQL DATABASE_URL to point at the Cloud SQL Auth Proxy
+ * sidecar listening on localhost. The proxy handles TLS to Cloud SQL, so
+ * sslmode is set to disable for the local hop.
+ */
+function rewriteDatabaseUrlForProxy(
+	url: string,
+	proxyPort: number,
+): string {
+	const rewritten = url.replace(
+		/(\/\/[^@]+@)([^:\/]+)(:\d+)?/,
+		`$1127.0.0.1:${proxyPort}`,
+	);
+	return rewritten.replace(/sslmode=[^&]+/, "sslmode=disable");
+}
+
+function buildCloudSqlSidecar(args: {
+	config: CloudSqlAuthProxy;
+	connectionName: string;
+	image: string;
+	extraArgs?: string[];
+	saKeySecretName?: string;
+}): k8s.types.input.core.v1.Container {
+	const proxyPort = args.config.proxyPort ?? 5432;
+	const sidecarArgs: string[] = [
+		args.connectionName,
+		`--port=${String(proxyPort)}`,
+	];
+	if (args.saKeySecretName) {
+		sidecarArgs.push("--credentials-file=/cloudsql/credentials.json");
+	}
+	if (args.extraArgs) {
+		sidecarArgs.push(...args.extraArgs);
+	}
+
+	return {
+		name: "cloud-sql-proxy",
+		image: args.image,
+		args: sidecarArgs,
+		...(args.config.resources && { resources: args.config.resources }),
+		...(args.saKeySecretName && {
+			volumeMounts: [
+				{
+					name: "cloudsql-sa-key",
+					mountPath: "/cloudsql",
+					readOnly: true,
+				},
+			],
+		}),
+		securityContext: {
+			runAsNonRoot: true,
+		},
+	};
+}
+
 export class LiteLLMProxy extends pulumi.ComponentResource {
 	public readonly namespaceResource: k8s.core.v1.Namespace | undefined;
 	public readonly providerSecret: k8s.core.v1.Secret;
@@ -68,6 +124,7 @@ export class LiteLLMProxy extends pulumi.ComponentResource {
 	public readonly proxyUrl: pulumi.Output<string>;
 	public readonly masterKey: pulumi.Output<string>;
 	public readonly configYaml: pulumi.Output<string>;
+	public readonly cloudSqlSaKeySecret: k8s.core.v1.Secret | undefined;
 
 	constructor(
 		name: string,
@@ -188,6 +245,20 @@ export class LiteLLMProxy extends pulumi.ComponentResource {
 
 		const parentAndProvider = { ...opts, parent: this };
 
+		// When Cloud SQL Auth Proxy sidecar is configured, rewrite the
+		// DATABASE_URL to point at the sidecar's local port instead of
+		// the Cloud SQL public IP. The proxy handles TLS to Cloud SQL.
+		const cloudSqlConfig = args.cloudSqlAuthProxy;
+		const proxyPort = cloudSqlConfig?.proxyPort ?? 5432;
+		const proxyImage =
+			cloudSqlConfig?.image ??
+			"gcr.io/cloud-sql-connectors/cloud-sql-proxy:2";
+		const effectiveDatabaseUrl = cloudSqlConfig
+			? pulumi.output(args.databaseUrl).apply((url) =>
+					rewriteDatabaseUrlForProxy(url, proxyPort),
+				)
+			: args.databaseUrl;
+
 		this.providerSecret = new k8s.core.v1.Secret(
 			`${name}-providers`,
 			{
@@ -220,7 +291,7 @@ export class LiteLLMProxy extends pulumi.ComponentResource {
 					namespace: this.namespace,
 				},
 				stringData: pulumi
-					.all([this.masterKey, args.databaseUrl])
+					.all([this.masterKey, effectiveDatabaseUrl])
 					.apply(([masterKey, databaseUrl]) => ({
 						LITELLM_MASTER_KEY: masterKey,
 						DATABASE_URL: databaseUrl,
@@ -242,6 +313,46 @@ export class LiteLLMProxy extends pulumi.ComponentResource {
 			},
 			parentAndProvider,
 		);
+
+		// --- Cloud SQL Auth Proxy: optional SA key secret ---
+		const cloudSqlSaKeySecret = cloudSqlConfig?.serviceAccountKey
+			? new k8s.core.v1.Secret(
+					`${name}-cloudsql-sa-key`,
+					{
+						metadata: {
+							name: `${name}-cloudsql-sa-key`,
+							namespace: this.namespace,
+						},
+						stringData: {
+							"credentials.json": cloudSqlConfig.serviceAccountKey,
+						},
+					},
+					parentAndProvider,
+				)
+			: undefined;
+
+		this.cloudSqlSaKeySecret = cloudSqlSaKeySecret;
+
+		// Build the sidecar container spec (resolved from pulumi.Outputs).
+		const cloudSqlSidecarContainer = cloudSqlConfig
+			? pulumi
+					.all([
+						pulumi.output(cloudSqlConfig.connectionName),
+						pulumi.output(proxyImage),
+						pulumi.output(cloudSqlConfig.extraArgs),
+						cloudSqlSaKeySecret?.metadata.name ?? "",
+					])
+					.apply(
+						([connectionName, image, extraArgs, saKeySecretName]) =>
+							buildCloudSqlSidecar({
+								config: cloudSqlConfig,
+								connectionName,
+								image,
+								extraArgs,
+								saKeySecretName: saKeySecretName || undefined,
+							}),
+					)
+			: undefined;
 
 		const appLabels = {
 			"app.kubernetes.io/name": "litellm",
@@ -303,49 +414,77 @@ export class LiteLLMProxy extends pulumi.ComponentResource {
 							labels: appLabels,
 						},
 						spec: {
-							containers: [
-								{
-									name: "litellm",
-									image,
-									args: ["--config", "/app/config.yaml"],
-									ports: [{ containerPort: servicePort }],
-									env,
-									volumeMounts: [
-										{
-											name: "config-volume",
-											mountPath: "/app/config.yaml",
-											subPath: "config.yaml",
-											readOnly: true,
+							containers: pulumi
+								.all([env, cloudSqlSidecarContainer ?? null])
+								.apply(([envVars, sidecar]) => {
+									const main: k8s.types.input.core.v1.Container = {
+										name: "litellm",
+										image,
+										args: ["--config", "/app/config.yaml"],
+										ports: [{ containerPort: servicePort }],
+										env: envVars,
+										volumeMounts: [
+											{
+												name: "config-volume",
+												mountPath: "/app/config.yaml",
+												subPath: "config.yaml",
+												readOnly: true,
+											},
+										],
+										livenessProbe: {
+											httpGet: {
+												path: "/health/liveliness",
+												port: servicePort,
+											},
+											initialDelaySeconds: 180,
+											periodSeconds: 15,
+											timeoutSeconds: 10,
+											failureThreshold: 3,
 										},
-									],
-									livenessProbe: {
-										httpGet: { path: "/health/liveliness", port: servicePort },
-										initialDelaySeconds: 180,
-										periodSeconds: 15,
-										timeoutSeconds: 10,
-										failureThreshold: 3,
+										readinessProbe: {
+											httpGet: {
+												path: "/health/readiness",
+												port: servicePort,
+											},
+											initialDelaySeconds: 30,
+											periodSeconds: 15,
+											timeoutSeconds: 10,
+											failureThreshold: 3,
+										},
+										resources: args.resources ?? {
+											requests: {
+												cpu: "250m",
+												memory: "512Mi",
+											},
+											limits: { cpu: "1", memory: "2Gi" },
+										},
+									};
+									return sidecar ? [main, sidecar] : [main];
+								}),
+							volumes: pulumi
+								.all([
+									this.configMap.metadata.name,
+									cloudSqlSaKeySecret?.metadata.name ?? "",
+								])
+								.apply(
+									([configMapName, saKeySecretName]) => {
+										const result: k8s.types.input.core.v1.Volume[] = [
+											{
+												name: "config-volume",
+												configMap: { name: configMapName },
+											},
+										];
+										if (saKeySecretName) {
+											result.push({
+												name: "cloudsql-sa-key",
+												secret: {
+													secretName: saKeySecretName,
+												},
+											});
+										}
+										return result;
 									},
-									readinessProbe: {
-										httpGet: { path: "/health/readiness", port: servicePort },
-										initialDelaySeconds: 30,
-										periodSeconds: 15,
-										timeoutSeconds: 10,
-										failureThreshold: 3,
-									},
-									resources: args.resources ?? {
-										requests: { cpu: "250m", memory: "512Mi" },
-										limits: { cpu: "1", memory: "2Gi" },
-									},
-								},
-							],
-							volumes: [
-								{
-									name: "config-volume",
-									configMap: {
-										name: this.configMap.metadata.name,
-									},
-								},
-							],
+								),
 						},
 					},
 				},

--- a/packages/sector7/litellm/litellm-proxy.ts
+++ b/packages/sector7/litellm/litellm-proxy.ts
@@ -67,11 +67,11 @@ function rewriteDatabaseUrlForProxy(
 	url: string,
 	proxyPort: number,
 ): string {
-	const rewritten = url.replace(
-		/(\/\/[^@]+@)([^:\/]+)(:\d+)?/,
-		(_, prefix, _host, _port) => `${prefix}127.0.0.1:${proxyPort}`,
-	);
-	return rewritten.replace(/sslmode=[^&]+/, "sslmode=disable");
+	const parsed = new URL(url);
+	parsed.hostname = "127.0.0.1";
+	parsed.port = String(proxyPort);
+	parsed.searchParams.set("sslmode", "disable");
+	return parsed.toString();
 }
 
 function buildCloudSqlSidecar(args: {

--- a/packages/sector7/tests/litellm-proxy.test.ts
+++ b/packages/sector7/tests/litellm-proxy.test.ts
@@ -164,6 +164,55 @@ describe("LiteLLMProxy", () => {
 		expect(service?.type).toBe("kubernetes:core/v1:Service");
 	});
 
+	it("creates Cloud SQL Auth Proxy sidecar when configured", async () => {
+		const proxy = new LiteLLMProxy("sidecar-proxy", {
+			namespace: "litellm-prod",
+			providers: { anthropic: { apiKey: pulumi.secret("anthropic-secret") } },
+			deployments: [
+				{
+					id: "anthropic-smart",
+					provider: "anthropic",
+					providerModel: "anthropic/claude-sonnet-4-20250514",
+				},
+			],
+			modelGroups: [{ name: "smart", deploymentIds: ["anthropic-smart"] }],
+			databaseUrl: pulumi.secret(
+				"postgresql://user:pass@34.162.159.18:5432/mydb?sslmode=require",
+			),
+			cloudSqlAuthProxy: {
+				connectionName: "my-project:us-east5:my-instance",
+				serviceAccountKey: pulumi.secret('{"type": "service_account"}'),
+				resources: {
+					requests: { cpu: "50m", memory: "64Mi" },
+					limits: { cpu: "200m", memory: "256Mi" },
+				},
+			},
+		});
+
+		await Promise.all([
+			resolveOutput(proxy.proxyUrl),
+			resolveOutput(proxy.deployment.id),
+			resolveOutput(proxy.cloudSqlSaKeySecret?.id),
+		]);
+
+		// SA key secret should be created.
+		const saKeySecret = findResource("sidecar-proxy-cloudsql-sa-key");
+		expect(saKeySecret?.type).toBe("kubernetes:core/v1:Secret");
+
+		// Runtime secret should have the rewritten DATABASE_URL pointing at localhost.
+		const runtimeSecret = findResource("sidecar-proxy-runtime");
+		const runtimeData = runtimeSecret?.inputs.stringData as {
+			value: Record<string, string>;
+		};
+		expect(runtimeData.value.DATABASE_URL).toBe(
+			"postgresql://user:pass@127.0.0.1:5432/mydb?sslmode=disable",
+		);
+
+		// Deployment should exist.
+		const deployment = findResource("sidecar-proxy-deployment");
+		expect(deployment?.type).toBe("kubernetes:apps/v1:Deployment");
+	});
+
 	it("can skip namespace creation", async () => {
 		const proxy = new LiteLLMProxy("shared-proxy", {
 			createNamespace: false,


### PR DESCRIPTION
## Summary

The LiteLLM proxy pod in `litellm-prod` crashes because it tries to connect to Cloud SQL PostgreSQL via the public IP directly, which is unreachable from the RKE2 cluster (no authorized networks, no direct route).

This PR adds optional Cloud SQL Auth Proxy sidecar injection to the `LiteLLMProxy` component. When configured:

1. **DATABASE_URL rewrite**: The original URL (pointing at the Cloud SQL public IP) is rewritten to `127.0.0.1:<proxyPort>` so LiteLLM connects through the local sidecar
2. **SA key secret**: A Kubernetes Secret is created from the provided GCP service account key JSON
3. **Sidecar container**: A `cloud-sql-proxy` sidecar is injected into the Deployment, forwarding the local port to the Cloud SQL instance via IAM auth
4. **Volume mount**: The SA key is mounted into the sidecar for authentication

This eliminates the need for authorized networks and client SSL certificates. The sidecar handles IAM auth and TLS termination automatically.

## Changes

- `config-types.ts`: New `CloudSqlAuthProxy` interface + `cloudSqlAuthProxy` field on `LiteLLMProxyArgs`
- `litellm-proxy.ts`: Sidecar injection logic — `rewriteDatabaseUrl` helper, SA key secret, dynamic containers/volumes via `pulumi.all().apply()`
- `index.ts`: Export `CloudSqlAuthProxy`
- `tests/litellm-proxy.test.ts`: New test for sidecar configuration (SA key secret created, DATABASE_URL rewritten, deployment exists)

## Test plan

- [x] All 138 existing tests pass (13 suites)
- [x] New sidecar test verifies: SA key secret creation, DATABASE_URL rewrite to `127.0.0.1:5432`, deployment creation
- [ ] Manual: deploy garden litellm stack with `cloudSqlAuthProxy` config, verify pod starts healthy
- [ ] Manual: verify Cloud SQL connection through sidecar (check LiteLLM health endpoints)

## Risks

- The sidecar is fully opt-in — no behavior change when `cloudSqlAuthProxy` is not provided
- `rewriteDatabaseUrl` also sets `sslmode=disable` since the proxy handles TLS termination; this is correct for the proxy path but would be wrong if applied without the sidecar
- The `cloudSqlSaKeySecret` is a public property on the class for downstream stack references

## Follow-up (garden repo)

After this merges, the garden `deploy/services/litellm` stack needs:
1. Add `cloudSqlAuthProxy` config to the Pulumi stack
2. Verify the SA key secret exists in the cluster
3. Run `pulumi up` to deploy the updated proxy with sidecar
4. Verify pod health

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds optional sidecar/secret wiring and rewrites `DATABASE_URL` (including forcing `sslmode=disable`) when enabled, which can impact connectivity and security posture if misconfigured. Otherwise behavior is unchanged when `cloudSqlAuthProxy` is omitted.
> 
> **Overview**
> Adds an **opt-in Cloud SQL Auth Proxy sidecar** to `LiteLLMProxy` via a new `cloudSqlAuthProxy` config.
> 
> When configured, the component **rewrites `DATABASE_URL` to `127.0.0.1:<port>` and sets `sslmode=disable`**, optionally creates a Kubernetes Secret containing a provided GCP service account key, and injects a `cloud-sql-proxy` sidecar plus volume mount/resources into the Deployment. Exposes the created SA key secret as `cloudSqlSaKeySecret`, exports the new `CloudSqlAuthProxy` type, and adds a test covering sidecar/secret creation and URL rewriting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 74deaf2f99246b27f2360bc773c6299c0a5102f5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->