### PR TITLE
fix(test): resolve renovate/nix.json relative to test file, not process.cwd()

### DIFF
--- a/packages/sector7/tests/renovate-nix-regex.test.ts
+++ b/packages/sector7/tests/renovate-nix-regex.test.ts
@@ -3,7 +3,7 @@ import { resolve } from "node:path";
 import { describe, expect, it } from "vitest";
 
 const nixConfig = JSON.parse(
-	readFileSync(resolve(process.cwd(), "../../renovate/nix.json"), "utf8"),
+	readFileSync(resolve(import.meta.dirname, "../../../renovate/nix.json"), "utf8"),
 ) as {
 	customManagers: Array<{
 		description: string;


### PR DESCRIPTION
## Problem

`checks.aarch64-darwin.vitest` fails in Nix builds:

```
Error: ENOENT: no such file or directory, open '/nix/var/nix/builds/renovate/nix.json'
 ❯ packages/sector7/tests/renovate-nix-regex.test.ts:6:2
```

The test used `process.cwd()` to locate `renovate/nix.json`. This works in local dev (where CWD is the repo root) but fails in the Nix build sandbox, where CWD is a temporary build directory.

## Fix

Replace `resolve(process.cwd(), "../../renovate/nix.json")` with `resolve(import.meta.dirname, "../../../renovate/nix.json")`, which resolves relative to the test file itself rather than the runtime working directory.

Node >= 24 is required (already the case — `engines.node: ">=24.0.0"`), so `import.meta.dirname` is available.

## Test plan

- [x] `nix build .#checks.aarch64-darwin.vitest -L` — all 138 tests pass (was 1 failed, 131 passed)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts a test fixture file path to be independent of `process.cwd()`, reducing flakiness in sandboxed/Nix environments.
> 
> **Overview**
> Fixes `renovate-nix-regex.test.ts` to load `renovate/nix.json` relative to the test file (`import.meta.dirname`) instead of `process.cwd()`, so the Vitest check passes when run from non-repo-root working directories (e.g., Nix sandboxes).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8db5e41833fa22b8c2fcf4717a7879d622410db3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->