### PR TITLE
fix(renovate): stop pinning digests on self-referencing sector7 actions

### DIFF
--- a/.github/actions/pulumi-setup/action.yml
+++ b/.github/actions/pulumi-setup/action.yml
@@ -13,7 +13,7 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: jmmaloney4/sector7/.github/actions/nix-setup@475e9813d6505eaea1e6b5afde1fdfaa5deecac1 # main
+    - uses: jmmaloney4/sector7/.github/actions/nix-setup@main
     - uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
       with:
         workload_identity_provider: ${{ inputs.google_workload_identity_provider }}

--- a/.github/workflows/_dogfood-add-to-project.yml
+++ b/.github/workflows/_dogfood-add-to-project.yml
@@ -10,7 +10,7 @@ jobs:
   add-to-project:
     # Secrets cannot be used in `if`; set PROJECT_URL when you want this enabled.
     if: vars.PROJECT_URL != ''
-    uses: jmmaloney4/sector7/.github/workflows/add-to-project.yml@475e9813d6505eaea1e6b5afde1fdfaa5deecac1 # main
+    uses: jmmaloney4/sector7/.github/workflows/add-to-project.yml@main
     with:
       project_url: ${{ vars.PROJECT_URL }}
     secrets:

--- a/.github/workflows/_dogfood-adr-management.yml
+++ b/.github/workflows/_dogfood-adr-management.yml
@@ -8,7 +8,7 @@ permissions:
 jobs:
   adr-management:
     if: github.actor != 'github-actions[bot]'
-    uses: jmmaloney4/sector7/.github/workflows/adr-management.yml@475e9813d6505eaea1e6b5afde1fdfaa5deecac1 # main
+    uses: jmmaloney4/sector7/.github/workflows/adr-management.yml@main
     with:
       repository: ${{ github.repository }}
       ref: refs/pull/${{ github.event.pull_request.number }}/head

--- a/.github/workflows/_dogfood-claude-review.yml
+++ b/.github/workflows/_dogfood-claude-review.yml
@@ -25,7 +25,7 @@ jobs:
        !contains(github.event.comment.body, 'no claude review') &&
        !contains(github.event.comment.body, 'disable claude review') &&
        !contains(github.event.comment.body, 'claude review is not needed'))
-    uses: jmmaloney4/sector7/.github/workflows/claude-review.yml@475e9813d6505eaea1e6b5afde1fdfaa5deecac1 # main
+    uses: jmmaloney4/sector7/.github/workflows/claude-review.yml@main
     with:
       repository: ${{ github.repository }}
       ref: ${{ github.ref }}

--- a/.github/workflows/_dogfood-claude.yml
+++ b/.github/workflows/_dogfood-claude.yml
@@ -32,7 +32,7 @@ jobs:
         (contains(github.event.issue.title, '@claude') || contains(github.event.issue.title, '@Claude') || contains(github.event.issue.title, '@CLAUDE'))) &&
        !((contains(github.event.issue.body, 'claude review') || contains(github.event.issue.body, 'Claude review') || contains(github.event.issue.body, 'CLAUDE REVIEW')) ||
          (contains(github.event.issue.title, 'claude review') || contains(github.event.issue.title, 'Claude review') || contains(github.event.issue.title, 'CLAUDE REVIEW'))))
-    uses: jmmaloney4/sector7/.github/workflows/claude.yml@475e9813d6505eaea1e6b5afde1fdfaa5deecac1 # main
+    uses: jmmaloney4/sector7/.github/workflows/claude.yml@main
     with:
       repository: ${{ github.repository }}
       ref: ${{ github.ref }}

--- a/.github/workflows/_dogfood-nix.yml
+++ b/.github/workflows/_dogfood-nix.yml
@@ -11,7 +11,7 @@ permissions:
   packages: write
 jobs:
   nix:
-    uses: jmmaloney4/sector7/.github/workflows/nix.yml@475e9813d6505eaea1e6b5afde1fdfaa5deecac1 # main
+    uses: jmmaloney4/sector7/.github/workflows/nix.yml@main
     with:
       repository: ${{ github.repository }}
       ref: ${{ github.ref }}

--- a/.github/workflows/_dogfood-pnpm.yml
+++ b/.github/workflows/_dogfood-pnpm.yml
@@ -11,7 +11,7 @@ permissions:
   packages: write
 jobs:
   pnpm:
-    uses: jmmaloney4/sector7/.github/workflows/pnpm.yml@475e9813d6505eaea1e6b5afde1fdfaa5deecac1 # main
+    uses: jmmaloney4/sector7/.github/workflows/pnpm.yml@main
     with:
       repository: ${{ github.repository }}
       ref: ${{ github.ref }}

--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -33,7 +33,7 @@ jobs:
     runs-on: ${{ inputs.runs-on }}
     steps:
       - name: Add issue or PR to project
-        uses: jmmaloney4/sector7/.github/actions/add-to-project@475e9813d6505eaea1e6b5afde1fdfaa5deecac1 # main
+        uses: jmmaloney4/sector7/.github/actions/add-to-project@main
         with:
           project-url: ${{ inputs.project_url }}
           github-token: ${{ secrets.github-token }}

--- a/.github/workflows/adr-management.yml
+++ b/.github/workflows/adr-management.yml
@@ -99,7 +99,7 @@ jobs:
           fi
       - name: Check ADR number conflicts
         id: check
-        uses: jmmaloney4/sector7/.github/actions/check-adr-conflicts@475e9813d6505eaea1e6b5afde1fdfaa5deecac1 # main
+        uses: jmmaloney4/sector7/.github/actions/check-adr-conflicts@main
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ inputs.repository }}
@@ -110,7 +110,7 @@ jobs:
           pr_number: ${{ inputs.pr_number }}
       - name: Create and push placeholder to main
         if: steps.detect_new.outputs.has_new_adrs == 'true' && steps.check.outputs.has_conflict == 'false'
-        uses: jmmaloney4/sector7/.github/actions/create-adr-placeholder@475e9813d6505eaea1e6b5afde1fdfaa5deecac1 # main
+        uses: jmmaloney4/sector7/.github/actions/create-adr-placeholder@main
         with:
           adr_files: /tmp/new_adrs.txt
           pr_url: ${{ inputs.pr_url }}

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -44,13 +44,13 @@ jobs:
         with:
           repository: ${{ inputs.repository }}
           ref: ${{ inputs.ref }}
-      - uses: jmmaloney4/sector7/.github/actions/nix-setup@475e9813d6505eaea1e6b5afde1fdfaa5deecac1 # main
+      - uses: jmmaloney4/sector7/.github/actions/nix-setup@main
         with:
           runs-on: ${{ inputs.runs-on }}
           cache: ${{ !contains(inputs.runs-on, 'self-hosted') }}
       - name: compute build-needed matrix via nix-eval-jobs
         id: compute
-        uses: jmmaloney4/sector7/.github/actions/compute-flake-build-matrix@475e9813d6505eaea1e6b5afde1fdfaa5deecac1 # main
+        uses: jmmaloney4/sector7/.github/actions/compute-flake-build-matrix@main
         with:
           probe-timeout-seconds: '180'
       - name: split build and image matrices
@@ -82,7 +82,7 @@ jobs:
         with:
           repository: ${{ inputs.repository }}
           ref: ${{ inputs.ref }}
-      - uses: jmmaloney4/sector7/.github/actions/nix-setup@475e9813d6505eaea1e6b5afde1fdfaa5deecac1 # main
+      - uses: jmmaloney4/sector7/.github/actions/nix-setup@main
         with:
           runs-on: ${{ inputs.runs-on }}
           cache: ${{ !contains(inputs.runs-on, 'self-hosted') }}
@@ -103,7 +103,7 @@ jobs:
       fail-fast: false
       matrix:
         package-name: ${{ fromJson(needs.detect.outputs.images_to_push) }}
-    uses: jmmaloney4/sector7/.github/workflows/push-nix-image.yml@475e9813d6505eaea1e6b5afde1fdfaa5deecac1 # main
+    uses: jmmaloney4/sector7/.github/workflows/push-nix-image.yml@main
     with:
       runs-on: ${{ inputs.runs-on }}
       package-name: ${{ matrix.package-name }}

--- a/.github/workflows/pnpm.yml
+++ b/.github/workflows/pnpm.yml
@@ -69,7 +69,7 @@ jobs:
         with:
           repository: ${{ inputs.repository }}
           ref: ${{ inputs.ref }}
-      - uses: jmmaloney4/sector7/.github/actions/nix-setup@475e9813d6505eaea1e6b5afde1fdfaa5deecac1 # main
+      - uses: jmmaloney4/sector7/.github/actions/nix-setup@main
         with:
           runs-on: ${{ inputs.runs-on }}
           cache: ${{ !contains(inputs.runs-on, 'self-hosted') }}
@@ -91,7 +91,7 @@ jobs:
         with:
           repository: ${{ inputs.repository }}
           ref: ${{ inputs.ref }}
-      - uses: jmmaloney4/sector7/.github/actions/nix-setup@475e9813d6505eaea1e6b5afde1fdfaa5deecac1 # main
+      - uses: jmmaloney4/sector7/.github/actions/nix-setup@main
         with:
           runs-on: ${{ inputs.runs-on }}
           cache: ${{ !contains(inputs.runs-on, 'self-hosted') }}

--- a/.github/workflows/pulumi.yml
+++ b/.github/workflows/pulumi.yml
@@ -59,13 +59,13 @@ jobs:
         with:
           repository: ${{ inputs.repository }}
           ref: ${{ inputs.ref }}
-      - uses: jmmaloney4/sector7/.github/actions/nix-setup@475e9813d6505eaea1e6b5afde1fdfaa5deecac1 # main
+      - uses: jmmaloney4/sector7/.github/actions/nix-setup@main
         with:
           runs-on: ${{ inputs.runs-on }}
           cache: ${{ !contains(inputs.runs-on, 'self-hosted') }}
       - name: Detect all (project, stack) pairs
         id: set-matrix
-        uses: jmmaloney4/sector7/.github/actions/detect-pulumi-stacks@475e9813d6505eaea1e6b5afde1fdfaa5deecac1 # main
+        uses: jmmaloney4/sector7/.github/actions/detect-pulumi-stacks@main
         with:
           ignore_projects: ${{ inputs.ignore_projects }}
   pulumi-preview-and-deploy:
@@ -96,7 +96,7 @@ jobs:
         with:
           repository: ${{ inputs.repository }}
           ref: ${{ inputs.ref }}
-      - uses: jmmaloney4/sector7/.github/actions/pulumi-setup@475e9813d6505eaea1e6b5afde1fdfaa5deecac1 # main
+      - uses: jmmaloney4/sector7/.github/actions/pulumi-setup@main
         with:
           google_workload_identity_provider: ${{ inputs.google_workload_identity_provider }}
           google_service_account_email: ${{ inputs.google_service_account_email }}
@@ -181,7 +181,7 @@ jobs:
       - name: pulumi preview
         id: preview
         continue-on-error: true
-        uses: jmmaloney4/sector7/.github/actions/pulumi-preview@475e9813d6505eaea1e6b5afde1fdfaa5deecac1 # main
+        uses: jmmaloney4/sector7/.github/actions/pulumi-preview@main
         with:
           project: ${{ matrix.project }}
           stack: ${{ matrix.stack }}

--- a/.github/workflows/push-nix-image.yml
+++ b/.github/workflows/push-nix-image.yml
@@ -61,12 +61,12 @@ jobs:
           repository: ${{ inputs.repository }}
           ref: ${{ inputs.ref }}
       - name: Install Nix
-        uses: jmmaloney4/sector7/.github/actions/nix-setup@475e9813d6505eaea1e6b5afde1fdfaa5deecac1 # main
+        uses: jmmaloney4/sector7/.github/actions/nix-setup@main
         with:
           runs-on: ${{ inputs.runs-on }}
           cache: ${{ !contains(inputs.runs-on, 'self-hosted') }}
       - name: Push Nix Image
-        uses: jmmaloney4/sector7/.github/actions/push-nix-image@475e9813d6505eaea1e6b5afde1fdfaa5deecac1 # main
+        uses: jmmaloney4/sector7/.github/actions/push-nix-image@main
         with:
           package-name: ${{ inputs.package-name }}
           registry: ${{ inputs.registry }}

--- a/.github/workflows/quarto.yml
+++ b/.github/workflows/quarto.yml
@@ -22,7 +22,7 @@ jobs:
       DIST: research/_site
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: jmmaloney4/sector7/.github/actions/nix-setup@475e9813d6505eaea1e6b5afde1fdfaa5deecac1 # main
+      - uses: jmmaloney4/sector7/.github/actions/nix-setup@main
         with:
           runs-on: ${{ vars.ACTIONS_RUNS_ON }}
           cache: ${{ !contains(vars.ACTIONS_RUNS_ON, 'self-hosted') }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -31,7 +31,7 @@ jobs:
         with:
           repository: ${{ inputs.repository }}
           ref: ${{ inputs.ref }}
-      - uses: jmmaloney4/sector7/.github/actions/nix-setup@475e9813d6505eaea1e6b5afde1fdfaa5deecac1 # main
+      - uses: jmmaloney4/sector7/.github/actions/nix-setup@main
         with:
           runs-on: ${{ inputs.runs-on }}
           cache: ${{ !contains(inputs.runs-on, 'self-hosted') }}
@@ -51,7 +51,7 @@ jobs:
         with:
           repository: ${{ inputs.repository }}
           ref: ${{ inputs.ref }}
-      - uses: jmmaloney4/sector7/.github/actions/nix-setup@475e9813d6505eaea1e6b5afde1fdfaa5deecac1 # main
+      - uses: jmmaloney4/sector7/.github/actions/nix-setup@main
         with:
           runs-on: ${{ inputs.runs-on }}
           cache: ${{ !contains(inputs.runs-on, 'self-hosted') }}
@@ -85,7 +85,7 @@ jobs:
         with:
           repository: ${{ inputs.repository }}
           ref: ${{ inputs.ref }}
-      - uses: jmmaloney4/sector7/.github/actions/nix-setup@475e9813d6505eaea1e6b5afde1fdfaa5deecac1 # main
+      - uses: jmmaloney4/sector7/.github/actions/nix-setup@main
         with:
           runs-on: ${{ inputs.runs-on }}
           cache: ${{ !contains(inputs.runs-on, 'self-hosted') }}

--- a/renovate/default.json
+++ b/renovate/default.json
@@ -10,7 +10,9 @@
 		":enableVulnerabilityAlertsWithLabel(security)",
 		":pinAllExceptPeerDependencies"
 	],
-	"schedule": ["before 4:00 am"],
+	"schedule": [
+		"before 4:00 am"
+	],
 	"prHourlyLimit": 10,
 	"prConcurrentLimit": 5,
 	"rebaseWhen": "conflicted",
@@ -18,33 +20,48 @@
 	"automergeStrategy": "merge",
 	"platformAutomerge": false,
 	"dependencyDashboard": true,
-	"dependencyDashboardTitle": "Renovate Dashboard 🤖",
-	"dependencyDashboardLabels": ["chore/deps"],
+	"dependencyDashboardTitle": "Renovate Dashboard \ud83e\udd16",
+	"dependencyDashboardLabels": [
+		"chore/deps"
+	],
 	"rangeStrategy": "pin",
 	"minimumReleaseAge": "4 days",
 	"pinDigests": true,
-	"labels": ["chore/deps", "renovate"],
+	"labels": [
+		"chore/deps",
+		"renovate"
+	],
 	"commitMessagePrefix": "deps: ",
 	"commitMessageAction": "update",
 	"prHeader": "This PR contains dependency updates managed by Renovate.",
-	"prFooter": "---\n\n🤖 This PR was generated automatically by Renovate.\n\nSee [dashboard]({{platform}}/{{repository}}/issues?q=is%3Aissue+is%3Aopen+label%3Arenovate) for all Renovate PRs.",
+	"prFooter": "---\n\n\ud83e\udd16 This PR was generated automatically by Renovate.\n\nSee [dashboard]({{platform}}/{{repository}}/issues?q=is%3Aissue+is%3Aopen+label%3Arenovate) for all Renovate PRs.",
 	"vulnerabilityAlerts": {
 		"enabled": true,
 		"automerge": true,
-		"addLabels": ["security", "vulnerability", "deps/security", "renovate"]
+		"addLabels": [
+			"security",
+			"vulnerability",
+			"deps/security",
+			"renovate"
+		]
 	},
 	"nix": {
 		"enabled": true
 	},
 	"packageRules": [
 		{
-			"description": "Skip stability days for internal sector7 actions (own repo)",
-			"matchPackageNames": ["jmmaloney4/sector7"],
-			"minimumReleaseAge": null
+			"description": "Skip pinning and stability days for internal sector7 actions (own repo)",
+			"matchPackageNames": [
+				"jmmaloney4/sector7"
+			],
+			"minimumReleaseAge": null,
+			"pinDigests": false
 		},
 		{
-			"description": "Disable requires-python updates — managed manually per project as a capped minor range (e.g. >=3.13,<3.14)",
-			"matchDepTypes": ["requires-python"],
+			"description": "Disable requires-python updates \u2014 managed manually per project as a capped minor range (e.g. >=3.13,<3.14)",
+			"matchDepTypes": [
+				"requires-python"
+			],
 			"enabled": false
 		}
 	]

--- a/renovate/default.json
+++ b/renovate/default.json
@@ -52,7 +52,7 @@
 		{
 			"description": "Skip pinning and stability days for internal sector7 actions (own repo)",
 			"matchPackageNames": [
-				"jmmaloney4/sector7"
+				"/^jmmaloney4\\/sector7($|\\/)/"
 			],
 			"minimumReleaseAge": null,
 			"pinDigests": false


### PR DESCRIPTION
## Problem

Renovate pins all GitHub Action references to commit SHAs via `pinDigests: true` in `renovate/default.json`. This includes self-references — workflows and composite actions within sector7 that reference other paths in the same repo (e.g. `jmmaloney4/sector7/.github/actions/nix-setup@<sha>`).

Every merge to `main` changes the SHA, triggering a new Renovate PR that updates 26 references across 15 workflow files. Between these PRs, the pinned SHA is stale. This creates constant churn with no security benefit — self-referencing actions always resolve to the same repo at the same commit.

See: #213 (latest digest update PR)

## Changes

**Renovate config** (`renovate/default.json`):
- Added `pinDigests: false` to the existing `jmmaloney4/sector7` package rule
- Updated rule description to reflect both behaviors (skip pinning + skip stability days)

**Workflow/action files** (26 references across 16 files):
- Replaced all `@<40-char-sha> # main` patterns with `@main`
- Covers: nix.yml, pnpm.yml, rust.yml, pulumi.yml, quarto.yml, push-nix-image.yml, add-to-project.yml, adr-management.yml, and all `_dogfood-*` wrappers, plus `pulumi-setup/action.yml`

## Test plan

- [ ] Verify Renovate no longer opens digest-update PRs for `jmmaloney4/sector7` self-references
- [ ] Verify third-party action digest pinning still works (e.g. `actions/checkout@de0fac2... # v6.0.2`)
- [ ] Run a workflow that uses these self-references to confirm `@main` resolves correctly
- [ ] Close Renovate PR #213 after merge

## Risks

- `@main` is a moving target: workflows will always use the latest `main` commit. This is the intended tradeoff — it eliminates stale references and churn. The security model for self-referencing actions in the same repo is branch protection, not SHA pinning.
- If a breaking change lands on `main` in sector7, all callers immediately pick it up. This is already the case between Renovate update PRs, so this change does not increase exposure.

Closes #213

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Switching internal workflow/action references from pinned SHAs to `@main` makes CI depend on the latest `main` contents, which could change behavior immediately after merges. Scope is limited to GitHub workflow plumbing and Renovate config, with no runtime product code changes.
> 
> **Overview**
> Stops Renovate churn caused by digest-pinning this repo’s own reusable workflows/actions.
> 
> Updates Renovate rules in `renovate/default.json` to **disable digest pinning** for `jmmaloney4/sector7` self-references, and rewrites existing internal `uses: jmmaloney4/sector7/...@<sha>` references across the GitHub workflows/actions to use **`@main`** instead.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4c4f053f53dddb4730fc2087188cde13ad8b0666. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->