### PR TITLE
fix(ci): update flake.lock for ci-pnpm devshell

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -236,11 +236,11 @@
         "uv2nix": "uv2nix"
       },
       "locked": {
-        "lastModified": 1779239420,
-        "narHash": "sha256-t+Kdf+IoNw7WP3blpchfr+hTct3x6z3lp2Nvqg/Y7Ok=",
+        "lastModified": 1779296196,
+        "narHash": "sha256-x7fH89qfLgB8pikR5fr5936WQBPcdTej33M710vJHU8=",
         "owner": "jmmaloney4",
         "repo": "jackpkgs",
-        "rev": "2df7c0d2a66c70b9da5a9eeec0dce6e28a083b38",
+        "rev": "c86a8e029f09ed0e45a5925af9f717d46eab2690",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Problem

The `_dogfood-pnpm.yml` workflow fails because `nix develop .#ci-pnpm` cannot find the `ci-pnpm` devshell:

```
error: flake does not provide attribute 'devShells.x86_64-linux.ci-pnpm'
```

## Fix

Update `flake.lock` to consume jackpkgs `c86a8e0`, which adds the `ci-pnpm` devshell via [jmmaloney4/jackpkgs#285](https://github.com/jmmaloney4/jackpkgs/pull/285).

The new devshell provides `node` + `pnpm` only, using `mkShellNoCC` with `CI=true`, following ADR-013 conventions.

## Verification

- `nix develop .#ci-pnpm --command pnpm install --frozen-lockfile` succeeds locally
- `nix flake check --no-build -L` passes
- `ci-pnpm` provides: node v24.14.1, pnpm 11.1.1, CI=1

## Risks

None. This is a lockfile-only update that consumes a new devshell attribute — no existing code changed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk lockfile-only change; main risk is CI/environment drift from pulling a newer `jackpkgs` revision.
> 
> **Overview**
> Updates `flake.lock` to pin `jackpkgs` to a newer revision (`c86a8e0...`), updating its `narHash`/`lastModified` accordingly.
> 
> This is intended to make `nix develop .#ci-pnpm` available for the pnpm GitHub workflow (e.g., `.github/workflows/pnpm.yml`) without changing any project code.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 18c45da71831ec5302e37a1f1af7af63a50dfee0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->