### PR TITLE
fix(ci): use @main tag for analyze-pnpm-packages self-reference

### DIFF
--- a/.github/workflows/pnpm.yml
+++ b/.github/workflows/pnpm.yml
@@ -42,7 +42,7 @@ jobs:
           ref: ${{ inputs.ref }}
       - name: Analyze packages (target=${{ inputs.target }})
         id: analyze
-        uses: jmmaloney4/sector7/.github/actions/analyze-pnpm-packages@2f47d5c
+        uses: jmmaloney4/sector7/.github/actions/analyze-pnpm-packages@main
         with:
           dry_run: ${{ inputs.dry_run }}
           target: ${{ inputs.target }}


### PR DESCRIPTION
## Problem

`pnpm.yml` references `jmmaloney4/sector7/.github/actions/analyze-pnpm-packages@2f47d5c` — a short SHA. GitHub Actions rejects short SHAs:

```
Unable to resolve action `jmmaloney4/sector7@2f47d5c`, the provided ref `2f47d5c` is the shortened version of a commit SHA, which is not supported.
```

This causes `pnpm / analyze pnpm packages` to fail on every run.

## Fix

Change `@2f47d5c` to `@main`, consistent with the other self-references in the same file (`nix-setup@main`).

The recent Renovate config changes (`aaebe73`, `4c4f053`) prevent Renovate from pinning digests on sector7 self-references going forward, but this stale pin predates that config.

## Risks

None. One-character-class change on a workflow ref.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only changes the GitHub Actions ref for a self-referenced action from a short SHA (which fails to resolve) to `@main`, affecting CI execution but not runtime code.
> 
> **Overview**
> Fixes the `pnpm.yml` workflow by updating the `analyze-pnpm-packages` self-reference from a shortened commit SHA to `@main`, avoiding GitHub Actions ref resolution failures.
> 
> This restores the ability for the `analyze pnpm packages` job to run and produce the publish matrix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dab98e8ca35452f77b1db3bb110c9971599cc062. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->