### PR TITLE
fix(ci): install gh/jq for analyze job, approve @pulumi/kubernetes builds

### DIFF
--- a/.github/workflows/pnpm.yml
+++ b/.github/workflows/pnpm.yml
@@ -40,6 +40,12 @@ jobs:
         with:
           repository: ${{ inputs.repository }}
           ref: ${{ inputs.ref }}
+      - uses: jmmaloney4/sector7/.github/actions/nix-setup@main
+        with:
+          runs-on: ${{ inputs.runs-on }}
+          cache: ${{ !contains(inputs.runs-on, 'self-hosted') }}
+      - name: Install gh and jq
+        run: nix profile install nixpkgs#gh nixpkgs#jq
       - name: Analyze packages (target=${{ inputs.target }})
         id: analyze
         uses: jmmaloney4/sector7/.github/actions/analyze-pnpm-packages@main

--- a/package.json
+++ b/package.json
@@ -1,28 +1,29 @@
 {
-  "name": "@jmmaloney4/sector7",
-  "private": true,
-  "version": "0.10.0",
-  "description": "Sector7 monorepo",
-  "license": "MPL-2.0",
-  "workspaces": [
-    "packages/*"
-  ],
-  "scripts": {
-    "build": "pnpm --filter './packages/*' -r --if-present run build",
-    "test": "pnpm --filter './packages/*' -r --if-present run test",
-    "clean": "pnpm --filter './packages/*' -r --if-present run clean"
-  },
-  "devDependencies": {
-    "typescript": "6.0.3",
-    "rimraf": "6.1.3",
-    "@types/node": "24.12.4",
-    "vitest": "4.1.6"
-  },
-  "pnpm": {
-    "onlyBuiltDependencies": [
-      "@pulumi/command",
-      "esbuild",
-      "protobufjs"
-    ]
-  }
+	"name": "@jmmaloney4/sector7",
+	"private": true,
+	"version": "0.10.0",
+	"description": "Sector7 monorepo",
+	"license": "MPL-2.0",
+	"workspaces": [
+		"packages/*"
+	],
+	"scripts": {
+		"build": "pnpm --filter './packages/*' -r --if-present run build",
+		"test": "pnpm --filter './packages/*' -r --if-present run test",
+		"clean": "pnpm --filter './packages/*' -r --if-present run clean"
+	},
+	"devDependencies": {
+		"typescript": "6.0.3",
+		"rimraf": "6.1.3",
+		"@types/node": "24.12.4",
+		"vitest": "4.1.6"
+	},
+	"pnpm": {
+		"onlyBuiltDependencies": [
+			"@pulumi/command",
+			"@pulumi/kubernetes",
+			"esbuild",
+			"protobufjs"
+		]
+	}
 }


### PR DESCRIPTION
## Problem

Two pre-existing failures in `_dogfood-pnpm.yml`:

1. **analyze pnpm packages** — `Error: gh is required but not available`. The composite action needs `gh` + `jq` but the ARC runners do not ship them and the analyze job had no nix setup.

2. **verify pnpm-lock.yaml** — `ERR_PNPM_IGNORED_BUILDS: Ignored build scripts: @pulumi/command, @pulumi/kubernetes, esbuild, protobufjs`. Root `package.json` had `onlyBuiltDependencies` missing `@pulumi/kubernetes`.

## Fix

1. Add `nix-setup` + `nix profile install nixpkgs#gh nixpkgs#jq` to the analyze job before the composite action runs.

2. Add `@pulumi/kubernetes` to `onlyBuiltDependencies` in root `package.json`.

## Verification

- `nix develop .#ci-pnpm --command pnpm install` — no ERR_PNPM_IGNORED_BUILDS
- `nix flake check --no-build -L` passes

## Risks

Low. The nix profile install adds ~30s to the analyze job. An alternative would be a dedicated CI devshell with `gh` + `jq` but that is overkill for one job.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only changes: adds Nix-based installation of `gh`/`jq` for the analyze job and updates pnpm build-allowlist to unblock installs; main risk is longer CI time or runner-specific Nix issues.
> 
> **Overview**
> Fixes pnpm CI failures by ensuring the `analyze` workflow job bootstraps Nix and installs `gh`/`jq` before running `analyze-pnpm-packages`.
> 
> Updates root `package.json` pnpm config to allow build scripts for `@pulumi/kubernetes` (via `onlyBuiltDependencies`), preventing `ERR_PNPM_IGNORED_BUILDS` during lockfile verification/installs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 692f264e1d290658c19c0803c43a75d43f4479b1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->