### PR TITLE
fix(deps): migrate onlyBuiltDependencies to allowBuilds for pnpm 11

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,13 +17,5 @@
 		"rimraf": "6.1.3",
 		"@types/node": "24.12.4",
 		"vitest": "4.1.6"
-	},
-	"pnpm": {
-		"onlyBuiltDependencies": [
-			"@pulumi/command",
-			"@pulumi/kubernetes",
-			"esbuild",
-			"protobufjs"
-		]
 	}
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,7 @@
 packages:
   - 'packages/*'
+allowBuilds:
+  '@pulumi/command': true
+  '@pulumi/kubernetes': true
+  esbuild: true
+  protobufjs: true


### PR DESCRIPTION
## Problem

`pnpm install --frozen-lockfile` fails with `ERR_PNPM_IGNORED_BUILDS` for `@pulumi/command`, `@pulumi/kubernetes`, `esbuild`, and `protobufjs`.

Root cause: pnpm 11 deprecated `onlyBuiltDependencies` in favor of `allowBuilds`. The old setting is silently ignored, so all build scripts are blocked.

## Fix

Replace `onlyBuiltDependencies` array with `allowBuilds` map in `package.json`, matching the pattern already used in `garden/pnpm-workspace.yaml`.

## Verification

```
$ nix develop .#ci-pnpm --command pnpm install --frozen-lockfile
Scope: all 2 workspace projects
Already up to date
Done in 238ms using pnpm v11.1.1
```

No `ERR_PNPM_IGNORED_BUILDS`.

## Risks

None. Mechanical migration to the new pnpm 11 setting format.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change that updates pnpm workspace settings for dependency build scripts; no runtime or application logic changes.
> 
> **Overview**
> Updates pnpm configuration to restore allowed postinstall/build scripts under pnpm 11 by **removing** the deprecated `pnpm.onlyBuiltDependencies` list from `package.json` and **adding** an `allowBuilds` map to `pnpm-workspace.yaml` for `@pulumi/command`, `@pulumi/kubernetes`, `esbuild`, and `protobufjs`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0bc0064079a85b4a38ace27d5283c0be0b74d6e9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->