### PR TITLE
fix(ci): resolve ADR-022 collision and install gh for adr-management

### DIFF
--- a/.github/workflows/adr-management.yml
+++ b/.github/workflows/adr-management.yml
@@ -56,6 +56,10 @@ jobs:
           repository: ${{ inputs.repository }}
           ref: ${{ inputs.ref }}
           fetch-depth: 0
+      - name: Install gh (nix)
+        run: |
+          nix profile install nixpkgs#gh
+          echo "$(readlink -f ~/.nix-profile)/bin" >> "$GITHUB_PATH"
       - name: Fetch base branch
         run: |
           set -euo pipefail

--- a/.github/workflows/pnpm.yml
+++ b/.github/workflows/pnpm.yml
@@ -45,7 +45,9 @@ jobs:
           runs-on: ${{ inputs.runs-on }}
           cache: ${{ !contains(inputs.runs-on, 'self-hosted') }}
       - name: Install gh and jq
-        run: nix profile install nixpkgs#gh nixpkgs#jq
+        run: |
+          nix profile install nixpkgs#gh nixpkgs#jq
+          echo "$(readlink -f ~/.nix-profile)/bin" >> "$GITHUB_PATH"
       - name: Analyze packages (target=${{ inputs.target }})
         id: analyze
         uses: jmmaloney4/sector7/.github/actions/analyze-pnpm-packages@main

--- a/docs/internal/designs/024-litellm-team-scoped-capability-routing.md
+++ b/docs/internal/designs/024-litellm-team-scoped-capability-routing.md
@@ -9,13 +9,13 @@ tags: [design, adr, pulumi, kubernetes, litellm]
 supersedes: []
 superseded_by: []
 links:
-  - '[ADR-022](./022-litellm-proxy-component.md)'
+  - '[ADR-026](./026-litellm-proxy-component.md)'
   - https://github.com/jmmaloney4/sector7/issues/197
 ---
 
 # Context
 
-ADR-022 established Sector7's `LiteLLMProxy` component and the low-level split between provider credentials, deployments, model groups, router policy, and governance policy.
+ADR-026 established Sector7's `LiteLLMProxy` component and the low-level split between provider credentials, deployments, model groups, router policy, and governance policy.
 
 That is a good base, but the next consumer use case exposes a gap in the public API.
 
@@ -156,10 +156,12 @@ These resources SHOULD use the existing Pulumi command-provider pattern already 
 Example: `personal-coding`, `research-coding`.
 
 Pros:
+
 - no library refactor required
 - easy to understand in one small deployment
 
 Cons:
+
 - caller-visible API leaks internal billing structure
 - aliases become unstable when account structure changes
 - every consumer repeats the same awkward naming policy
@@ -169,10 +171,12 @@ Decision: rejected.
 ## Alternative B: build the high-level builder only in a consumer repo
 
 Pros:
+
 - fast for one consumer
 - fewer immediate upstream changes
 
 Cons:
+
 - duplicates logic outside Sector7
 - keeps team/key lifecycle split across repos
 - locks the reusable library at the wrong abstraction level
@@ -182,9 +186,11 @@ Decision: rejected.
 ## Alternative C: replace the low-level API entirely with a high-level one
 
 Pros:
+
 - one clean opinionated surface
 
 Cons:
+
 - throws away useful escape hatches
 - too risky while LiteLLM integration is still evolving
 - makes advanced or unusual topologies harder to express
@@ -207,8 +213,8 @@ Decision: rejected.
 
 # Status Transitions
 
-- This ADR amends ADR-022 in practice by defining the next abstraction layer above the original low-level proxy component.
-- ADR-022 remains the foundational deployment ADR. This ADR narrows how the public LiteLLM API should evolve.
+- This ADR amends ADR-026 in practice by defining the next abstraction layer above the original low-level proxy component.
+- ADR-026 remains the foundational deployment ADR. This ADR narrows how the public LiteLLM API should evolve.
 
 # Implementation Notes
 
@@ -220,5 +226,5 @@ Decision: rejected.
 
 # References
 
-- [ADR-022: LiteLLM Proxy ComponentResource](./022-litellm-proxy-component.md)
+- [ADR-026: LiteLLM Proxy ComponentResource](./026-litellm-proxy-component.md)
 - Sector7 issue tracking the refactor: https://github.com/jmmaloney4/sector7/issues/197

--- a/docs/internal/designs/026-litellm-proxy-component.md
+++ b/docs/internal/designs/026-litellm-proxy-component.md
@@ -1,5 +1,5 @@
 ---
-id: ADR-022
+id: ADR-026
 title: LiteLLM Proxy ComponentResource
 status: Proposed
 date: 2026-05-14


### PR DESCRIPTION
## Problem

Two issues in the adr-management workflow:

1. **ADR 022 collision** — `022-github-app-auth-add-to-project.md` and `022-litellm-proxy-component.md` share the same number, triggering the conflict detector.

2. **`gh` not found** — The ARC NixOS runners do not ship the `gh` CLI. Both `check-adr-conflicts/main.sh` and the "Post ADR check status comment" step call `gh`, causing exit code 127.

## Fix

1. Renumber `022-litellm-proxy-component.md` to `026-litellm-proxy-component.md` (next free slot). Update all cross-references in `024-litellm-team-scoped-capability-routing.md`.

2. Add `nix profile install nixpkgs#gh` step before any `gh` usage in `adr-management.yml`.

## Verification

- No ADR number collisions remain (`ADR-022` only used by github-app-auth)
- All cross-references updated
- treefmt passes

## Risks

Low. The nix profile install adds ~15s to the workflow.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to GitHub Actions workflow setup (installing `gh`/PATH) and ADR documentation renumbering/cross-references, with no runtime code impact.
> 
> **Overview**
> Fixes CI/automation issues around ADR handling on Nix-based runners by installing the `gh` CLI in the `adr-management` workflow and ensuring the installed binaries are added to `GITHUB_PATH` (mirroring the existing `pnpm` workflow).
> 
> Resolves an ADR number collision by renumbering the LiteLLM proxy design doc from `ADR-022` to `ADR-026` and updating `ADR-024` links/references accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 457c74a94f695ae828c3316593ac69847a41fc36. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->