### PR TITLE
refactor(ci): use ci-pnpm devshell for gh/jq instead of nix profile install

### DIFF
--- a/.github/workflows/pnpm.yml
+++ b/.github/workflows/pnpm.yml
@@ -44,10 +44,8 @@ jobs:
         with:
           runs-on: ${{ inputs.runs-on }}
           cache: ${{ !contains(inputs.runs-on, 'self-hosted') }}
-      - name: Install gh and jq
-        run: |
-          nix profile install nixpkgs#gh nixpkgs#jq
-          echo "$(readlink -f ~/.nix-profile)/bin" >> "$GITHUB_PATH"
+      - name: Add ci-pnpm tools to PATH
+        run: nix develop .#ci-pnpm --command bash -c 'echo "$PATH" >> "$GITHUB_PATH"'
       - name: Analyze packages (target=${{ inputs.target }})
         id: analyze
         uses: jmmaloney4/sector7/.github/actions/analyze-pnpm-packages@main

--- a/flake.lock
+++ b/flake.lock
@@ -236,11 +236,11 @@
         "uv2nix": "uv2nix"
       },
       "locked": {
-        "lastModified": 1779296196,
-        "narHash": "sha256-x7fH89qfLgB8pikR5fr5936WQBPcdTej33M710vJHU8=",
+        "lastModified": 1779311864,
+        "narHash": "sha256-h1LIp/yOgct3ySQJ1xE9hv9SYRP8+JhLfVZy94Nc6yI=",
         "owner": "jmmaloney4",
         "repo": "jackpkgs",
-        "rev": "c86a8e029f09ed0e45a5925af9f717d46eab2690",
+        "rev": "663314364106943e9f5a3ae1b82f24932fb97811",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Problem

The `analyze` job in pnpm.yml installs `gh` and `jq` via `nix profile install` and then hacks `GITHUB_PATH` to make them available. This is ad-hoc — the `ci-pnpm` devshell in jackpkgs was designed for this entire workflow and now includes both tools (jackpkgs#288).

## Fix

Replace the `nix profile install nixpkgs#gh nixpkgs#jq` + `GITHUB_PATH` step with a single step that extracts PATH from the `ci-pnpm` devshell:

```yaml
- name: Add ci-pnpm tools to PATH
  run: nix develop .#ci-pnpm --command bash -c 'echo "$PATH" >> "$GITHUB_PATH"'
```

Also updates `flake.lock` to consume jackpkgs#288 (which adds gh + jq to ci-pnpm).

## Risks

Low. Same tools, same devshell, just a cleaner mechanism. If `nix develop .#ci-pnpm` resolves, the PATH will contain gh and jq.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI refactor that only changes how `gh`/`jq` are provided to the workflow by relying on the `ci-pnpm` devshell; failures would be limited to CI if the devshell no longer includes these tools.
> 
> **Overview**
> The `pnpm` GitHub Actions workflow no longer installs `gh` and `jq` via `nix profile install`; instead it adds the `ci-pnpm` devshell toolchain to `PATH` by running `nix develop .#ci-pnpm` and exporting its `PATH` to `GITHUB_PATH`.
> 
> `flake.lock` is updated to a newer `jackpkgs` revision so the `ci-pnpm` devshell provides the needed CLI tools.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 460028d3c1f7ad62abf21cb2e70179a1f4a57368. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->