### PR TITLE
refactor(cloudsql): extract auth proxy sidecar component

### DIFF
--- a/.github/workflows/adr-management.yml
+++ b/.github/workflows/adr-management.yml
@@ -56,9 +56,14 @@ jobs:
           repository: ${{ inputs.repository }}
           ref: ${{ inputs.ref }}
           fetch-depth: 0
-      - name: Install gh (nix)
+      - uses: jmmaloney4/sector7/.github/actions/nix-setup@main
+        with:
+          runs-on: ${{ inputs.runs-on }}
+          cache: ${{ !contains(inputs.runs-on, 'self-hosted') }}
+      - name: Install gh with nix
         run: |
-          nix profile install nixpkgs#gh
+          set -euo pipefail
+          nix profile install "nixpkgs#gh"
           echo "$(readlink -f ~/.nix-profile)/bin" >> "$GITHUB_PATH"
       - name: Fetch base branch
         run: |

--- a/docs/internal/designs/027-cloud-sql-auth-proxy-sidecar-component.md
+++ b/docs/internal/designs/027-cloud-sql-auth-proxy-sidecar-component.md
@@ -114,18 +114,12 @@ export interface CloudSqlAuthProxySidecarArgs {
     | {
         mode: "inline-key";
         serviceAccountKey: pulumi.Input<string>;
-        namespace: pulumi.Input<string>;
-        provider?: k8s.Provider;
-        secretName?: pulumi.Input<string>;
       }
     | {
         mode: "managed-key";
         project: pulumi.Input<string>;
         accountId: pulumi.Input<string>;
         displayName?: pulumi.Input<string>;
-        namespace: pulumi.Input<string>;
-        provider?: k8s.Provider;
-        secretName?: pulumi.Input<string>;
       }
     | {
         mode: "ambient-iam";
@@ -154,12 +148,14 @@ The parent stack or parent component remains responsible for building the final 
 const proxy = new CloudSqlAuthProxySidecar(`${name}-db-proxy`, {
   connectionName,
   databaseUrl,
+  kubernetes: {
+    namespace,
+    provider,
+  },
   credentials: {
     mode: "managed-key",
     project: gcpProject,
     accountId: `${name}-proxy`,
-    namespace,
-    provider,
   },
 }, { parent: this });
 
@@ -167,8 +163,17 @@ const deployment = new k8s.apps.v1.Deployment(`${name}-deployment`, {
   spec: {
     template: {
       spec: pulumi.all([proxy.container, proxy.volumes]).apply(([proxyContainer, proxyVolumes]) => ({
-        containers: [appContainer, proxyContainer],
         volumes: [...baseVolumes, ...proxyVolumes],
+        containers: [
+          {
+            ...appContainer,
+            env: [
+              ...(appContainer.env ?? []),
+              { name: "DATABASE_URL", value: proxy.rewrittenDatabaseUrl },
+            ],
+          },
+          proxyContainer,
+        ],
       })),
     },
   },
@@ -187,7 +192,7 @@ The component MUST:
 - force `sslmode=disable` for the local hop
 - mount credentials at a stable path when a key-backed mode is selected
 - default to `runAsNonRoot: true` and `allowPrivilegeEscalation: false`
-- avoid pod-IP TCP probes when the sidecar binds only localhost
+- omit default readiness and liveness probes; localhost-bound sidecars MUST NOT ship pod-IP TCP probes
 - provide sane default resource requests and limits when none are supplied
 
 The component SHOULD:
@@ -276,6 +281,7 @@ Package exports:
 # Operational Notes
 
 - Default image should track a v2 Cloud SQL Proxy release, but the image must stay overrideable.
+- Migrations from in-place sidecar resources SHOULD use Pulumi aliases when child resources move under `CloudSqlAuthProxySidecar`, especially for existing LiteLLM credential `Secret` state.
 - Consumers remain responsible for application rollout semantics. If a secret value derived from `rewrittenDatabaseUrl` changes, the owning Deployment still needs a pod-template change or explicit restart policy.
 - Tests must cover both URL rewriting and the credential-mode matrix.
 - The first migration targets should be:

--- a/docs/internal/designs/027-cloud-sql-auth-proxy-sidecar-component.md
+++ b/docs/internal/designs/027-cloud-sql-auth-proxy-sidecar-component.md
@@ -1,0 +1,313 @@
+---
+id: ADR-027
+title: Cloud SQL Auth Proxy Sidecar ComponentResource
+status: Proposed
+date: 2026-05-22
+deciders: [jmmaloney4]
+consulted: []
+tags: [design, adr, pulumi, kubernetes, gcp, cloudsql]
+supersedes: []
+superseded_by: []
+links: [ADR-026]
+---
+
+# Context
+
+Sector7 already contains one embedded Cloud SQL Auth Proxy sidecar implementation inside `packages/sector7/litellm/litellm-proxy.ts`. Garden now has a second implementation in `deploy/services/attic/index.ts`.
+
+Those two implementations overlap on the same core behavior:
+
+- run `cloud-sql-proxy` as a sidecar in the same pod as the application
+- rewrite the application `DATABASE_URL` from a Cloud SQL host to `127.0.0.1:<proxyPort>`
+- disable local-hop SSL because the proxy handles TLS to Cloud SQL
+- optionally mount a GCP service account key as `credentials.json`
+- apply small default CPU and memory requests for the proxy container
+- harden the sidecar with `runAsNonRoot` and no privilege escalation
+
+The implementations differ in important ways:
+
+- `packages/sector7/litellm/litellm-proxy.ts` owns only the sidecar fragment and optional Kubernetes secret. It does not create the GCP service account, IAM membership, or service account key.
+- `deploy/services/attic/index.ts` owns the full chain: GCP service account, `roles/cloudsql.client`, service account key, Kubernetes secret, and sidecar injection.
+- `deploy/services/litellm/cloud-sql.ts` in garden still contains an older standalone proxy `Deployment` + `Service` pattern rather than the in-pod sidecar used by the reusable Sector7 `LiteLLMProxy`.
+
+This is the wrong layering.
+
+The reusable concern is not "LiteLLM needs Cloud SQL" and it is not "Attic needs Cloud SQL." The reusable concern is: "a Kubernetes workload outside the Cloud SQL VPC needs a pod-local Cloud SQL Auth Proxy sidecar and optional GCP credential resources."
+
+That concern belongs in Sector7, not duplicated inside product stacks.
+
+In scope for this ADR:
+
+- a reusable Sector7 component for the sidecar pattern
+- the interface boundary between GCP identity resources and Kubernetes pod wiring
+- migration of `LiteLLMProxy` and garden attic to consume the shared component
+
+Out of scope for this ADR:
+
+- Cloud SQL database, user, or password creation
+- application-specific bootstrap commands like attic cache provisioning
+- the legacy standalone proxy `Deployment` + `Service` pattern in `deploy/services/litellm/cloud-sql.ts`
+- general mutation of arbitrary third-party Deployments already created outside Sector7 ownership
+
+# Decision
+
+Create a dedicated Sector7 subpath export for a reusable Cloud SQL Auth Proxy sidecar component.
+
+The component SHOULD live under a new package subpath:
+
+```ts
+import { CloudSqlAuthProxySidecar } from "@jmmaloney4/sector7/cloudsql";
+```
+
+It MUST NOT be exported through the root `packages/sector7/index.ts` barrel. This is a Kubernetes + GCP-specific surface with a heavier dependency closure than Cloudflare- or Nix-only consumers should inherit.
+
+## Type token
+
+`sector7:cloudsql:AuthProxySidecar`
+
+## Ownership boundary
+
+`CloudSqlAuthProxySidecar` MUST own only the reusable sidecar-related resources and outputs:
+
+- optional GCP service account
+- optional `roles/cloudsql.client` membership
+- optional service account key
+- optional Kubernetes secret containing `credentials.json`
+- generated sidecar container spec
+- generated pod volumes needed by that sidecar
+- rewritten proxy-local database URL
+
+It MUST NOT own:
+
+- the application `Deployment`
+- the application `Service`
+- Cloud SQL database or user creation
+- application runtime secrets other than the optional proxy credential secret
+- standalone proxy `Deployment` + `Service` mode
+
+This component is an attachment/composition component, not a whole application component.
+
+## Interface sketch
+
+```ts
+export interface CloudSqlAuthProxySidecarArgs {
+  connectionName: pulumi.Input<string>; // project:region:instance
+
+  databaseUrl?: pulumi.Input<string>;   // optional; rewritten when provided
+  proxyPort?: pulumi.Input<number>;     // default 5432
+  image?: pulumi.Input<string>;         // default gcr.io/cloud-sql-connectors/cloud-sql-proxy:2
+  extraArgs?: pulumi.Input<pulumi.Input<string>[]>;
+  resources?: k8s.types.input.core.v1.ResourceRequirements;
+
+  kubernetes?: {
+    namespace?: pulumi.Input<string>;
+    provider?: k8s.Provider;
+    existingServiceAccountKeySecretName?: pulumi.Input<string>;
+    secretName?: pulumi.Input<string>;
+  };
+
+  credentials?:
+    | {
+        mode: "existing-secret";
+        secretName: pulumi.Input<string>;
+      }
+    | {
+        mode: "inline-key";
+        serviceAccountKey: pulumi.Input<string>;
+        namespace: pulumi.Input<string>;
+        provider?: k8s.Provider;
+        secretName?: pulumi.Input<string>;
+      }
+    | {
+        mode: "managed-key";
+        project: pulumi.Input<string>;
+        accountId: pulumi.Input<string>;
+        displayName?: pulumi.Input<string>;
+        namespace: pulumi.Input<string>;
+        provider?: k8s.Provider;
+        secretName?: pulumi.Input<string>;
+      }
+    | {
+        mode: "ambient-iam";
+      };
+}
+
+export class CloudSqlAuthProxySidecar extends pulumi.ComponentResource {
+  readonly container: pulumi.Output<k8s.types.input.core.v1.Container>;
+  readonly volumes: pulumi.Output<k8s.types.input.core.v1.Volume[]>;
+  readonly rewrittenDatabaseUrl: pulumi.Output<string | undefined>;
+
+  readonly credentialSecret?: k8s.core.v1.Secret;
+  readonly serviceAccount?: gcp.serviceaccount.Account;
+  readonly serviceAccountKey?: gcp.serviceaccount.Key;
+  readonly cloudSqlClientMembership?: gcp.projects.IAMMember;
+}
+```
+
+## Composition model
+
+The component MUST be consumable from a parent-owned deployment.
+
+The parent stack or parent component remains responsible for building the final pod template, for example:
+
+```ts
+const proxy = new CloudSqlAuthProxySidecar(`${name}-db-proxy`, {
+  connectionName,
+  databaseUrl,
+  credentials: {
+    mode: "managed-key",
+    project: gcpProject,
+    accountId: `${name}-proxy`,
+    namespace,
+    provider,
+  },
+}, { parent: this });
+
+const deployment = new k8s.apps.v1.Deployment(`${name}-deployment`, {
+  spec: {
+    template: {
+      spec: pulumi.all([proxy.container, proxy.volumes]).apply(([proxyContainer, proxyVolumes]) => ({
+        containers: [appContainer, proxyContainer],
+        volumes: [...baseVolumes, ...proxyVolumes],
+      })),
+    },
+  },
+}, { parent: this, provider, dependsOn: [proxy] });
+```
+
+This keeps Deployment ownership where it already belongs while centralizing the sidecar contract in one place.
+
+## Required behavior
+
+The component MUST:
+
+- rewrite `databaseUrl` with the native `URL` class, not regex replacement
+- force host `127.0.0.1`
+- force port `proxyPort`
+- force `sslmode=disable` for the local hop
+- mount credentials at a stable path when a key-backed mode is selected
+- default to `runAsNonRoot: true` and `allowPrivilegeEscalation: false`
+- avoid pod-IP TCP probes when the sidecar binds only localhost
+- provide sane default resource requests and limits when none are supplied
+
+The component SHOULD:
+
+- support both key-backed auth and ambient IAM / Workload Identity-style auth
+- create the Kubernetes secret only when the selected credential mode needs it
+- expose child resources so consuming stacks can depend on or inspect them directly
+
+The component MAY later grow a separate standalone proxy mode, but that is not part of this ADR.
+
+## Package layout
+
+Add a new subpath rather than burying this under `litellm`:
+
+```text
+packages/sector7/
+  cloudsql/
+    auth-proxy-sidecar.ts
+    index.ts
+  tests/
+    cloudsql-auth-proxy-sidecar.test.ts
+```
+
+Package exports:
+
+```json
+{
+  "exports": {
+    "./cloudsql": {
+      "types": "./dist/cloudsql/index.d.ts",
+      "default": "./dist/cloudsql/index.js"
+    }
+  }
+}
+```
+
+`packages/sector7/litellm` should then import this component instead of carrying its own local helper functions for sidecar assembly.
+
+# Consequences
+
+## Positive
+
+- One source of truth for Cloud SQL sidecar behavior across garden and future consumers.
+- `LiteLLMProxy` gets smaller and more honest about its boundary: LiteLLM deployment logic stays in `litellm`; Cloud SQL proxy mechanics move to `cloudsql`.
+- Garden attic can drop a substantial block of sidecar-specific plumbing from `deploy/services/attic/index.ts`.
+- The GCP identity path becomes explicit instead of half-embedded in app stacks.
+- Tests for URL rewrite, credential secret creation, and sidecar spec assembly move into Sector7 once instead of being re-proven ad hoc.
+
+## Negative
+
+- This introduces a second reusable layer next to `LiteLLMProxy`, so the public API surface of Sector7 grows.
+- The component still cannot magically attach itself to arbitrary pre-existing Deployments; consumers must compose its outputs into pod specs they own.
+- Credential-mode flexibility adds interface complexity, especially if we support both managed SA keys and ambient IAM in the first cut.
+- We will still have one legacy standalone proxy pattern in garden until a later migration removes it.
+
+# Alternatives
+
+- Keep the duplicated logic in attic and LiteLLM.
+
+  - Rejected. We already have drift: sidecar-only in Sector7 LiteLLM, full GCP + sidecar chain in attic, and a legacy standalone deployment in garden LiteLLM.
+
+- Move the attic implementation into a plain helper function inside garden.
+
+  - Rejected. The abstraction is cross-repo, not garden-local. A garden helper would still leave `LiteLLMProxy` carrying its own copy.
+
+- Leave the logic inside `packages/sector7/litellm` and import it from attic.
+
+  - Rejected. That inverts the dependency boundary. Attic is not a LiteLLM consumer. Cloud SQL sidecar mechanics should not live under a product-specific subpath.
+
+- Create one giant `CloudSqlBackedService` component that owns database creation, IAM, sidecar wiring, runtime secret generation, and deployment creation.
+
+  - Rejected. That is too coarse. Database ownership, app deployment ownership, and sidecar attachment are separate concerns with different reuse boundaries.
+
+- Standardize on the standalone proxy `Deployment` + `Service` pattern instead of sidecars.
+
+  - Rejected for this ADR. The requested extraction target is the sidecar pattern already used in Sector7 LiteLLM and now attic. Standalone mode can be revisited later if it proves broadly reusable.
+
+# Security / Privacy / Compliance
+
+- Service account keys are sensitive. The component MUST treat any inline or managed key output as secret Pulumi values and MUST place them only in Kubernetes Secrets, never ConfigMaps.
+- The component SHOULD prefer `ambient-iam` where available, but MUST still support explicit key-backed auth for clusters without Workload Identity.
+- The component MUST grant `roles/cloudsql.client` with `IAMMember`, not authoritative `IAMBinding`.
+- The component MUST bind the proxy to `127.0.0.1` for sidecar mode. Binding `0.0.0.0` exposes the PostgreSQL listener on the pod IP for no benefit.
+- The component MUST disable local-hop SSL in the rewritten URL. The proxy handles TLS to Cloud SQL; the in-pod client-to-proxy hop is plain TCP.
+
+# Operational Notes
+
+- Default image should track a v2 Cloud SQL Proxy release, but the image must stay overrideable.
+- Consumers remain responsible for application rollout semantics. If a secret value derived from `rewrittenDatabaseUrl` changes, the owning Deployment still needs a pod-template change or explicit restart policy.
+- Tests must cover both URL rewriting and the credential-mode matrix.
+- The first migration targets should be:
+  1. `packages/sector7/litellm/litellm-proxy.ts`
+  2. `garden/deploy/services/attic/index.ts`
+- `garden/deploy/services/litellm/cloud-sql.ts` should be audited separately because it still uses standalone proxy deployment/service mode rather than the sidecar pattern this ADR standardizes.
+
+# Status Transitions
+
+- This ADR depends on and refines ADR-026. ADR-026 said LiteLLM should not own garden-specific Cloud SQL creation and should accept `databaseUrl` as an input. This ADR sharpens that boundary further by moving the reusable proxy mechanics out of the `litellm` subpath entirely.
+- If accepted and implemented, ADR-026 should be patched to reference `@jmmaloney4/sector7/cloudsql` as the home for the sidecar attachment abstraction.
+
+# Implementation Notes
+
+1. Add `packages/sector7/cloudsql/auth-proxy-sidecar.ts` and `packages/sector7/cloudsql/index.ts`.
+2. Move `rewriteDatabaseUrlForProxy` out of `packages/sector7/litellm/litellm-proxy.ts` into the new module.
+3. Move sidecar container assembly logic out of `LiteLLMProxy` into `CloudSqlAuthProxySidecar`.
+4. Add tests for:
+   - URL rewrite to `127.0.0.1:<proxyPort>?sslmode=disable`
+   - inline-key mode
+   - managed-key mode
+   - ambient-iam mode
+   - no pod-IP probes on localhost binding
+5. Refactor `LiteLLMProxy` to consume the new component.
+6. Refactor garden attic to consume the new component or mirror its interface until the garden stack upgrades to the released Sector7 version.
+7. Later, decide whether the legacy standalone proxy pattern in garden LiteLLM should be deleted, migrated, or formalized as a separate component.
+
+# References
+
+- `packages/sector7/litellm/litellm-proxy.ts`
+- `packages/sector7/litellm/config-types.ts`
+- `packages/sector7/tests/litellm-proxy.test.ts`
+- `garden/deploy/services/attic/index.ts`
+- `garden/deploy/services/litellm/cloud-sql.ts`
+- `docs/internal/designs/026-litellm-proxy-component.md`

--- a/packages/sector7/barrel-guard.ts
+++ b/packages/sector7/barrel-guard.ts
@@ -1,4 +1,7 @@
-// @ts-expect-error LiteLLM lives on the ./litellm subpath, not the root barrel
-import { litellm } from "./index.ts";
+import * as root from "./index.ts";
 
-void litellm;
+// @ts-expect-error LiteLLM lives on the ./litellm subpath, not the root barrel
+void root.litellm;
+
+// @ts-expect-error Cloud SQL helpers live on the ./cloudsql subpath, not the root barrel
+void root.cloudsql;

--- a/packages/sector7/cloudsql/auth-proxy-sidecar.ts
+++ b/packages/sector7/cloudsql/auth-proxy-sidecar.ts
@@ -107,7 +107,7 @@ function buildContainer(args: {
 	const sidecarArgs: string[] = [
 		args.connectionName,
 		"--address=127.0.0.1",
-		`--port=${String(args.proxyPort)}`,
+		`--port=${args.proxyPort}`,
 	];
 	if (args.credentialSecretName) {
 		sidecarArgs.push(`--credentials-file=${CREDENTIALS_FILE_PATH}`);

--- a/packages/sector7/cloudsql/auth-proxy-sidecar.ts
+++ b/packages/sector7/cloudsql/auth-proxy-sidecar.ts
@@ -1,0 +1,358 @@
+import * as gcp from "@pulumi/gcp";
+import * as k8s from "@pulumi/kubernetes";
+import * as pulumi from "@pulumi/pulumi";
+
+const DEFAULT_PROXY_IMAGE = "gcr.io/cloud-sql-connectors/cloud-sql-proxy:2";
+const DEFAULT_PROXY_PORT = 5432;
+const CREDENTIALS_VOLUME_NAME = "cloudsql-credentials";
+const CREDENTIALS_DIRECTORY = "/cloudsql";
+const CREDENTIALS_FILE_PATH = `${CREDENTIALS_DIRECTORY}/credentials.json`;
+const DEFAULT_PROXY_RESOURCES: k8s.types.input.core.v1.ResourceRequirements = {
+	requests: { cpu: "50m", memory: "64Mi" },
+	limits: { cpu: "250m", memory: "128Mi" },
+};
+
+export interface CloudSqlAuthProxyKubernetesArgs {
+	namespace?: pulumi.Input<string>;
+	provider?: k8s.Provider;
+	secretName?: pulumi.Input<string>;
+}
+
+export interface CloudSqlAuthProxyExistingSecretCredentials {
+	mode: "existing-secret";
+	secretName: pulumi.Input<string>;
+}
+
+export interface CloudSqlAuthProxyInlineKeyCredentials {
+	mode: "inline-key";
+	serviceAccountKey: pulumi.Input<string>;
+}
+
+export interface CloudSqlAuthProxyManagedKeyCredentials {
+	mode: "managed-key";
+	project: pulumi.Input<string>;
+	accountId: pulumi.Input<string>;
+	displayName?: pulumi.Input<string>;
+}
+
+export interface CloudSqlAuthProxyAmbientIamCredentials {
+	mode: "ambient-iam";
+}
+
+export type CloudSqlAuthProxyCredentials =
+	| CloudSqlAuthProxyExistingSecretCredentials
+	| CloudSqlAuthProxyInlineKeyCredentials
+	| CloudSqlAuthProxyManagedKeyCredentials
+	| CloudSqlAuthProxyAmbientIamCredentials;
+
+export interface CloudSqlAuthProxySidecarArgs {
+	connectionName: pulumi.Input<string>;
+	databaseUrl?: pulumi.Input<string>;
+	proxyPort?: pulumi.Input<number>;
+	image?: pulumi.Input<string>;
+	extraArgs?: pulumi.Input<pulumi.Input<string>[]>;
+	resources?: pulumi.Input<k8s.types.input.core.v1.ResourceRequirements>;
+	kubernetes?: CloudSqlAuthProxyKubernetesArgs;
+	credentials?: CloudSqlAuthProxyCredentials;
+}
+
+export function rewriteDatabaseUrlForProxy(
+	url: string,
+	proxyPort: number,
+): string {
+	const parsed = new URL(url);
+	parsed.hostname = "127.0.0.1";
+	parsed.port = String(proxyPort);
+	parsed.searchParams.set("sslmode", "disable");
+	return parsed.toString();
+}
+
+function decodeServiceAccountKey(base64Key: string): string {
+	return Buffer.from(base64Key, "base64").toString("utf8");
+}
+
+function resolveSecretName(
+	name: string,
+	args: CloudSqlAuthProxySidecarArgs,
+): pulumi.Input<string> {
+	return args.kubernetes?.secretName ?? `${name}-cloudsql-credentials`;
+}
+
+function aliasToPreviousParent(
+	opts: pulumi.ComponentResourceOptions | undefined,
+	name?: string,
+): pulumi.Alias[] | undefined {
+	if (!opts?.parent) {
+		return undefined;
+	}
+
+	return [{ parent: opts.parent, ...(name ? { name } : {}) }];
+}
+
+function withOptionalKubernetesProvider(
+	options: pulumi.CustomResourceOptions,
+	provider: k8s.Provider | undefined,
+): pulumi.CustomResourceOptions {
+	return provider ? { ...options, provider } : options;
+}
+
+function buildContainer(args: {
+	connectionName: string;
+	proxyPort: number;
+	image: string;
+	extraArgs?: string[];
+	resources: k8s.types.input.core.v1.ResourceRequirements;
+	credentialSecretName?: string;
+}): k8s.types.input.core.v1.Container {
+	const sidecarArgs: string[] = [
+		args.connectionName,
+		"--address=127.0.0.1",
+		`--port=${String(args.proxyPort)}`,
+	];
+	if (args.credentialSecretName) {
+		sidecarArgs.push(`--credentials-file=${CREDENTIALS_FILE_PATH}`);
+	}
+	if (args.extraArgs) {
+		sidecarArgs.push(...args.extraArgs);
+	}
+
+	return {
+		name: "cloud-sql-proxy",
+		image: args.image,
+		args: sidecarArgs,
+		resources: args.resources,
+		...(args.credentialSecretName && {
+			volumeMounts: [
+				{
+					name: CREDENTIALS_VOLUME_NAME,
+					mountPath: CREDENTIALS_DIRECTORY,
+					readOnly: true,
+				},
+			],
+		}),
+		securityContext: {
+			runAsNonRoot: true,
+			allowPrivilegeEscalation: false,
+		},
+	};
+}
+
+export class CloudSqlAuthProxySidecar extends pulumi.ComponentResource {
+	public readonly container: pulumi.Output<k8s.types.input.core.v1.Container>;
+	public readonly volumes: pulumi.Output<k8s.types.input.core.v1.Volume[]>;
+	public readonly rewrittenDatabaseUrl: pulumi.Output<string | undefined>;
+
+	public readonly credentialSecret?: k8s.core.v1.Secret;
+	public readonly serviceAccount?: gcp.serviceaccount.Account;
+	public readonly serviceAccountKey?: gcp.serviceaccount.Key;
+	public readonly cloudSqlClientMembership?: gcp.projects.IAMMember;
+
+	constructor(
+		name: string,
+		args: CloudSqlAuthProxySidecarArgs,
+		opts?: pulumi.ComponentResourceOptions,
+	) {
+		super("sector7:cloudsql:AuthProxySidecar", name, args, opts);
+
+		const credentials = args.credentials ?? ({ mode: "ambient-iam" } as const);
+		const proxyPort = pulumi
+			.output(args.proxyPort)
+			.apply((value) => value ?? DEFAULT_PROXY_PORT);
+		const image = pulumi
+			.output(args.image)
+			.apply((value) => value ?? DEFAULT_PROXY_IMAGE);
+		const extraArgs = pulumi.output(args.extraArgs);
+		const resources = pulumi
+			.output(args.resources)
+			.apply((value) => value ?? DEFAULT_PROXY_RESOURCES);
+
+		let credentialSecretName: pulumi.Input<string> | undefined;
+
+		switch (credentials.mode) {
+			case "existing-secret": {
+				credentialSecretName = credentials.secretName;
+				break;
+			}
+			case "inline-key": {
+				const namespace = args.kubernetes?.namespace;
+				if (!namespace) {
+					throw new Error(
+						"CloudSqlAuthProxySidecar inline-key mode requires a Kubernetes namespace",
+					);
+				}
+				credentialSecretName = resolveSecretName(name, args);
+				this.credentialSecret = new k8s.core.v1.Secret(
+					`${name}-credentials`,
+					{
+						metadata: {
+							name: credentialSecretName,
+							namespace,
+						},
+						stringData: {
+							"credentials.json": pulumi.secret(credentials.serviceAccountKey),
+						},
+					},
+					withOptionalKubernetesProvider(
+						{
+							...opts,
+							parent: this,
+							aliases: aliasToPreviousParent(opts, `${name}-sa-key`),
+						},
+						args.kubernetes?.provider,
+					),
+				);
+				credentialSecretName = this.credentialSecret.metadata.name;
+				break;
+			}
+			case "managed-key": {
+				const namespace = args.kubernetes?.namespace;
+				if (!namespace) {
+					throw new Error(
+						"CloudSqlAuthProxySidecar managed-key mode requires a Kubernetes namespace",
+					);
+				}
+
+				this.serviceAccount = new gcp.serviceaccount.Account(
+					`${name}-service-account`,
+					{
+						project: credentials.project,
+						accountId: credentials.accountId,
+						displayName: credentials.displayName,
+					},
+					{
+						...opts,
+						parent: this,
+						aliases: aliasToPreviousParent(opts),
+					},
+				);
+				this.cloudSqlClientMembership = new gcp.projects.IAMMember(
+					`${name}-cloudsql-client`,
+					{
+						project: credentials.project,
+						role: "roles/cloudsql.client",
+						member: this.serviceAccount.email.apply(
+							(email) => `serviceAccount:${email}`,
+						),
+					},
+					{
+						...opts,
+						parent: this,
+						aliases: aliasToPreviousParent(opts),
+					},
+				);
+				this.serviceAccountKey = new gcp.serviceaccount.Key(
+					`${name}-service-account-key`,
+					{
+						serviceAccountId: this.serviceAccount.name,
+					},
+					{
+						...opts,
+						parent: this,
+						aliases: aliasToPreviousParent(opts),
+						dependsOn: this.cloudSqlClientMembership
+							? [this.cloudSqlClientMembership]
+							: undefined,
+					},
+				);
+
+				credentialSecretName = resolveSecretName(name, args);
+				this.credentialSecret = new k8s.core.v1.Secret(
+					`${name}-credentials`,
+					{
+						metadata: {
+							name: credentialSecretName,
+							namespace,
+						},
+						stringData: {
+							"credentials.json": pulumi.secret(
+								this.serviceAccountKey.privateKey.apply(
+									decodeServiceAccountKey,
+								),
+							),
+						},
+					},
+					withOptionalKubernetesProvider(
+						{
+							...opts,
+							parent: this,
+							aliases: aliasToPreviousParent(opts, `${name}-sa-key`),
+							dependsOn: [
+								this.cloudSqlClientMembership,
+								this.serviceAccountKey,
+							],
+						},
+						args.kubernetes?.provider,
+					),
+				);
+				credentialSecretName = this.credentialSecret.metadata.name;
+				break;
+			}
+			case "ambient-iam": {
+				break;
+			}
+			default: {
+				const neverCredentials: never = credentials;
+				throw new Error(
+					`Unsupported Cloud SQL credential mode: ${JSON.stringify(neverCredentials)}`,
+				);
+			}
+		}
+
+		const credentialSecretNameOutput = pulumi.output(credentialSecretName);
+
+		this.rewrittenDatabaseUrl = pulumi
+			.all([pulumi.output(args.databaseUrl), proxyPort])
+			.apply(([databaseUrl, resolvedProxyPort]) =>
+				databaseUrl
+					? rewriteDatabaseUrlForProxy(databaseUrl, resolvedProxyPort)
+					: undefined,
+			);
+
+		this.container = pulumi
+			.all([
+				pulumi.output(args.connectionName),
+				proxyPort,
+				image,
+				extraArgs,
+				resources,
+				credentialSecretNameOutput,
+			])
+			.apply(
+				([
+					connectionName,
+					resolvedProxyPort,
+					resolvedImage,
+					resolvedExtraArgs,
+					resolvedResources,
+					resolvedCredentialSecretName,
+				]) =>
+					buildContainer({
+						connectionName,
+						proxyPort: resolvedProxyPort,
+						image: resolvedImage,
+						extraArgs: resolvedExtraArgs,
+						resources: resolvedResources,
+						credentialSecretName: resolvedCredentialSecretName,
+					}),
+			);
+
+		this.volumes = credentialSecretNameOutput.apply((secretName) =>
+			secretName
+				? [
+						{
+							name: CREDENTIALS_VOLUME_NAME,
+							secret: { secretName },
+						},
+					]
+				: [],
+		) as pulumi.Output<k8s.types.input.core.v1.Volume[]>;
+
+		this.registerOutputs({
+			container: this.container,
+			volumes: this.volumes,
+			rewrittenDatabaseUrl: this.rewrittenDatabaseUrl,
+			credentialSecretName,
+			serviceAccountEmail: this.serviceAccount?.email,
+		});
+	}
+}

--- a/packages/sector7/cloudsql/index.ts
+++ b/packages/sector7/cloudsql/index.ts
@@ -1,0 +1,13 @@
+export type {
+	CloudSqlAuthProxyAmbientIamCredentials,
+	CloudSqlAuthProxyCredentials,
+	CloudSqlAuthProxyExistingSecretCredentials,
+	CloudSqlAuthProxyInlineKeyCredentials,
+	CloudSqlAuthProxyKubernetesArgs,
+	CloudSqlAuthProxyManagedKeyCredentials,
+	CloudSqlAuthProxySidecarArgs,
+} from "./auth-proxy-sidecar.ts";
+export {
+	CloudSqlAuthProxySidecar,
+	rewriteDatabaseUrlForProxy,
+} from "./auth-proxy-sidecar.ts";

--- a/packages/sector7/litellm/config-types.ts
+++ b/packages/sector7/litellm/config-types.ts
@@ -129,12 +129,14 @@ export interface LiteLLMServiceSpec {
 }
 
 /**
- * Cloud SQL Auth Proxy sidecar configuration.
+ * Cloud SQL Auth Proxy sidecar configuration for LiteLLMProxy.
  *
+ * LiteLLMProxy composes the shared `@jmmaloney4/sector7/cloudsql`
+ * CloudSqlAuthProxySidecar component and maps this narrower interface onto it.
  * When provided, the proxy component injects a `cloud-sql-proxy` sidecar
  * container that forwards a local port to the Cloud SQL instance via the
  * Cloud SQL Auth Proxy. The DATABASE_URL is rewritten to point at
- * `localhost:<proxyPort>` so the LiteLLM container connects through the
+ * `127.0.0.1:<proxyPort>` so the LiteLLM container connects through the
  * sidecar instead of hitting the public IP directly.
  *
  * This eliminates the need for authorized networks and client certificates.

--- a/packages/sector7/litellm/litellm-proxy.ts
+++ b/packages/sector7/litellm/litellm-proxy.ts
@@ -1,9 +1,9 @@
 import * as k8s from "@pulumi/kubernetes";
 import * as pulumi from "@pulumi/pulumi";
 import * as random from "@pulumi/random";
+import { CloudSqlAuthProxySidecar } from "../cloudsql/index.ts";
 import { generateLiteLLMConfig, getProviderEnvVar } from "./config.ts";
 import type {
-	CloudSqlAuthProxy,
 	LiteLLMModelDeployment,
 	LiteLLMProviderConfig,
 	LiteLLMProxyArgs,
@@ -56,61 +56,6 @@ function resolveDeployment(
 			apiBase: apiBase ?? undefined,
 		};
 	});
-}
-
-/**
- * Rewrite a PostgreSQL DATABASE_URL to point at the Cloud SQL Auth Proxy
- * sidecar listening on localhost. The proxy handles TLS to Cloud SQL, so
- * sslmode is set to disable for the local hop.
- */
-function rewriteDatabaseUrlForProxy(
-	url: string,
-	proxyPort: number,
-): string {
-	const parsed = new URL(url);
-	parsed.hostname = "127.0.0.1";
-	parsed.port = String(proxyPort);
-	parsed.searchParams.set("sslmode", "disable");
-	return parsed.toString();
-}
-
-function buildCloudSqlSidecar(args: {
-	config: CloudSqlAuthProxy;
-	connectionName: string;
-	image: string;
-	extraArgs?: string[];
-	saKeySecretName?: string;
-}): k8s.types.input.core.v1.Container {
-	const proxyPort = args.config.proxyPort ?? 5432;
-	const sidecarArgs: string[] = [
-		args.connectionName,
-		`--port=${String(proxyPort)}`,
-	];
-	if (args.saKeySecretName) {
-		sidecarArgs.push("--credentials-file=/cloudsql/credentials.json");
-	}
-	if (args.extraArgs) {
-		sidecarArgs.push(...args.extraArgs);
-	}
-
-	return {
-		name: "cloud-sql-proxy",
-		image: args.image,
-		args: sidecarArgs,
-		...(args.config.resources && { resources: args.config.resources }),
-		...(args.saKeySecretName && {
-			volumeMounts: [
-				{
-					name: "cloudsql-sa-key",
-					mountPath: "/cloudsql",
-					readOnly: true,
-				},
-			],
-		}),
-		securityContext: {
-			runAsNonRoot: true,
-		},
-	};
 }
 
 export class LiteLLMProxy extends pulumi.ComponentResource {
@@ -174,21 +119,19 @@ export class LiteLLMProxy extends pulumi.ComponentResource {
 
 		const providerSecretName = `${name}-provider-keys`;
 
-		const providerStringData = resolvedProviderSecrets.apply((secretProviders) =>
-			Object.fromEntries(
-				secretProviders
-					.filter((provider) => provider !== undefined)
-					.map((provider) => [
-						toSecretKey(provider.envVar),
-						provider.apiKey,
-					]),
-			),
+		const providerStringData = resolvedProviderSecrets.apply(
+			(secretProviders) =>
+				Object.fromEntries(
+					secretProviders
+						.filter((provider) => provider !== undefined)
+						.map((provider) => [toSecretKey(provider.envVar), provider.apiKey]),
+				),
 		);
 
 		const providerEnvVars = resolvedProviderConfigs.apply((providers) =>
 			providers
 				.filter((provider) => provider.hasApiKey && provider.envVar)
-				.map((provider) => provider.envVar!)
+				.map((provider) => provider.envVar!),
 		);
 
 		const configYaml = pulumi
@@ -245,19 +188,42 @@ export class LiteLLMProxy extends pulumi.ComponentResource {
 
 		const parentAndProvider = { ...opts, parent: this };
 
-		// When Cloud SQL Auth Proxy sidecar is configured, rewrite the
-		// DATABASE_URL to point at the sidecar's local port instead of
-		// the Cloud SQL public IP. The proxy handles TLS to Cloud SQL.
 		const cloudSqlConfig = args.cloudSqlAuthProxy;
-		const proxyPort = cloudSqlConfig?.proxyPort ?? 5432;
-		const proxyImage =
-			cloudSqlConfig?.image ??
-			"gcr.io/cloud-sql-connectors/cloud-sql-proxy:2";
-		const effectiveDatabaseUrl = cloudSqlConfig
-			? pulumi.output(args.databaseUrl).apply((url) =>
-					rewriteDatabaseUrlForProxy(url, proxyPort),
+		const cloudSqlSidecar = cloudSqlConfig
+			? new CloudSqlAuthProxySidecar(
+					`${name}-cloudsql`,
+					{
+						connectionName: cloudSqlConfig.connectionName,
+						databaseUrl: args.databaseUrl,
+						proxyPort: cloudSqlConfig.proxyPort,
+						image: cloudSqlConfig.image,
+						extraArgs: cloudSqlConfig.extraArgs,
+						resources: cloudSqlConfig.resources,
+						kubernetes: {
+							namespace: this.namespace,
+							provider: opts?.provider as k8s.Provider | undefined,
+							secretName: `${name}-cloudsql-sa-key`,
+						},
+						credentials: cloudSqlConfig.serviceAccountKey
+							? {
+									mode: "inline-key",
+									serviceAccountKey: cloudSqlConfig.serviceAccountKey,
+								}
+							: { mode: "ambient-iam" },
+					},
+					parentAndProvider,
 				)
-			: args.databaseUrl;
+			: undefined;
+		const effectiveDatabaseUrl: pulumi.Output<string> = cloudSqlSidecar
+			? cloudSqlSidecar.rewrittenDatabaseUrl.apply((databaseUrl) => {
+					if (databaseUrl === undefined) {
+						throw new Error(
+							"LiteLLMProxy Cloud SQL sidecar requires a rewritten DATABASE_URL",
+						);
+					}
+					return databaseUrl;
+				})
+			: pulumi.output(args.databaseUrl);
 
 		this.providerSecret = new k8s.core.v1.Secret(
 			`${name}-providers`,
@@ -283,6 +249,13 @@ export class LiteLLMProxy extends pulumi.ComponentResource {
 			pulumi.output(args.masterKey ?? generatedMasterKey),
 		);
 
+		const runtimeSecretData = pulumi
+			.all([this.masterKey, effectiveDatabaseUrl])
+			.apply<Record<string, string>>(([masterKey, databaseUrl]) => ({
+				LITELLM_MASTER_KEY: masterKey,
+				DATABASE_URL: databaseUrl,
+			}));
+
 		this.runtimeSecret = new k8s.core.v1.Secret(
 			`${name}-runtime`,
 			{
@@ -290,12 +263,7 @@ export class LiteLLMProxy extends pulumi.ComponentResource {
 					name: `${name}-runtime`,
 					namespace: this.namespace,
 				},
-				stringData: pulumi
-					.all([this.masterKey, effectiveDatabaseUrl])
-					.apply(([masterKey, databaseUrl]) => ({
-						LITELLM_MASTER_KEY: masterKey,
-						DATABASE_URL: databaseUrl,
-					})),
+				stringData: runtimeSecretData,
 			},
 			parentAndProvider,
 		);
@@ -314,45 +282,9 @@ export class LiteLLMProxy extends pulumi.ComponentResource {
 			parentAndProvider,
 		);
 
-		// --- Cloud SQL Auth Proxy: optional SA key secret ---
-		const cloudSqlSaKeySecret = cloudSqlConfig?.serviceAccountKey
-			? new k8s.core.v1.Secret(
-					`${name}-cloudsql-sa-key`,
-					{
-						metadata: {
-							name: `${name}-cloudsql-sa-key`,
-							namespace: this.namespace,
-						},
-						stringData: {
-							"credentials.json": cloudSqlConfig.serviceAccountKey,
-						},
-					},
-					parentAndProvider,
-				)
-			: undefined;
+		this.cloudSqlSaKeySecret = cloudSqlSidecar?.credentialSecret;
 
-		this.cloudSqlSaKeySecret = cloudSqlSaKeySecret;
-
-		// Build the sidecar container spec (resolved from pulumi.Outputs).
-		const cloudSqlSidecarContainer = cloudSqlConfig
-			? pulumi
-					.all([
-						pulumi.output(cloudSqlConfig.connectionName),
-						pulumi.output(proxyImage),
-						pulumi.output(cloudSqlConfig.extraArgs),
-						cloudSqlSaKeySecret?.metadata.name ?? "",
-					])
-					.apply(
-						([connectionName, image, extraArgs, saKeySecretName]) =>
-							buildCloudSqlSidecar({
-								config: cloudSqlConfig,
-								connectionName,
-								image,
-								extraArgs,
-								saKeySecretName: saKeySecretName || undefined,
-							}),
-					)
-			: undefined;
+		const cloudSqlSidecarContainer = cloudSqlSidecar?.container;
 
 		const appLabels = {
 			"app.kubernetes.io/name": "litellm",
@@ -464,27 +396,15 @@ export class LiteLLMProxy extends pulumi.ComponentResource {
 							volumes: pulumi
 								.all([
 									this.configMap.metadata.name,
-									cloudSqlSaKeySecret?.metadata.name ?? "",
+									cloudSqlSidecar?.volumes ?? [],
 								])
-								.apply(
-									([configMapName, saKeySecretName]) => {
-										const result: k8s.types.input.core.v1.Volume[] = [
-											{
-												name: "config-volume",
-												configMap: { name: configMapName },
-											},
-										];
-										if (saKeySecretName) {
-											result.push({
-												name: "cloudsql-sa-key",
-												secret: {
-													secretName: saKeySecretName,
-												},
-											});
-										}
-										return result;
+								.apply(([configMapName, sidecarVolumes]) => [
+									{
+										name: "config-volume",
+										configMap: { name: configMapName },
 									},
-								),
+									...sidecarVolumes,
+								]),
 						},
 					},
 				},

--- a/packages/sector7/package.json
+++ b/packages/sector7/package.json
@@ -1,96 +1,100 @@
 {
-  "name": "@jmmaloney4/sector7",
-  "version": "0.10.0",
-  "description": "Reusable Pulumi components for infrastructure management",
-  "license": "MPL-2.0",
-  "publishConfig": {
-    "access": "public"
-  },
-  "type": "module",
-  "engines": {
-    "node": ">=24.0.0"
-  },
-  "exports": {
-    ".": {
-      "types": "./dist/index.d.ts",
-      "default": "./dist/index.js"
-    },
-    "./access": {
-      "types": "./dist/access/index.d.ts",
-      "default": "./dist/access/index.js"
-    },
-    "./iam": {
-      "types": "./dist/iam/index.d.ts",
-      "default": "./dist/iam/index.js"
-    },
-    "./workersite": {
-      "types": "./dist/workersite/index.d.ts",
-      "default": "./dist/workersite/index.js"
-    },
-    "./r2": {
-      "types": "./dist/r2/index.d.ts",
-      "default": "./dist/r2/index.js"
-    },
-    "./nix-image": {
-      "types": "./dist/nix-image/index.d.ts",
-      "default": "./dist/nix-image/index.js"
-    },
-    "./monitor": {
-      "types": "./dist/monitor/index.d.ts",
-      "default": "./dist/monitor/index.js"
-    },
-    "./nix-output": {
-      "types": "./dist/nix-output/index.d.ts",
-      "default": "./dist/nix-output/index.js"
-    },
-    "./scripts": {
-      "types": "./dist/scripts/index.d.ts",
-      "default": "./dist/scripts/index.js"
-    },
-    "./d1": {
-      "types": "./dist/d1/index.d.ts",
-      "default": "./dist/d1/index.js"
-    },
-    "./litellm": {
-      "types": "./dist/litellm/index.d.ts",
-      "default": "./dist/litellm/index.js"
-    },
-    "./pulumi-config": {
-      "types": "./dist/pulumi-config/index.d.ts",
-      "default": "./dist/pulumi-config/index.js"
-    }
-  },
-  "files": [
-    "dist",
-    "README.md"
-  ],
-  "scripts": {
-    "build": "pnpm run clean && tsc -p tsconfig.build.json && node tools/copy-shell-scripts.mjs",
-    "clean": "rimraf dist",
-    "prepack": "pnpm run build",
-    "test": "vitest run",
-    "test:watch": "vitest"
-  },
-  "peerDependencies": {
-    "@pulumi/pulumi": "^3.0.0",
-    "@pulumi/cloudflare": "^6.0.0",
-    "@pulumi/gcp": "^9.0.0",
-    "@pulumi/command": "^1.0.0",
-    "@pulumi/kubernetes": "^4.0.0",
-    "@pulumi/random": "^4.0.0"
-  },
-  "dependencies": {
-    "yaml": "2.9.0"
-  },
-  "devDependencies": {
-    "@pulumi/pulumi": "3.239.0",
-    "@pulumi/cloudflare": "6.15.0",
-    "@pulumi/gcp": "9.23.0",
-    "@pulumi/command": "1.2.1",
-    "@pulumi/kubernetes": "4.31.0",
-    "@pulumi/random": "4.20.0",
-    "rimraf": "6.1.3",
-    "typescript": "6.0.3",
-    "vitest": "4.1.6"
-  }
+	"name": "@jmmaloney4/sector7",
+	"version": "0.10.0",
+	"description": "Reusable Pulumi components for infrastructure management",
+	"license": "MPL-2.0",
+	"publishConfig": {
+		"access": "public"
+	},
+	"type": "module",
+	"engines": {
+		"node": ">=24.0.0"
+	},
+	"exports": {
+		".": {
+			"types": "./dist/index.d.ts",
+			"default": "./dist/index.js"
+		},
+		"./access": {
+			"types": "./dist/access/index.d.ts",
+			"default": "./dist/access/index.js"
+		},
+		"./iam": {
+			"types": "./dist/iam/index.d.ts",
+			"default": "./dist/iam/index.js"
+		},
+		"./workersite": {
+			"types": "./dist/workersite/index.d.ts",
+			"default": "./dist/workersite/index.js"
+		},
+		"./r2": {
+			"types": "./dist/r2/index.d.ts",
+			"default": "./dist/r2/index.js"
+		},
+		"./nix-image": {
+			"types": "./dist/nix-image/index.d.ts",
+			"default": "./dist/nix-image/index.js"
+		},
+		"./monitor": {
+			"types": "./dist/monitor/index.d.ts",
+			"default": "./dist/monitor/index.js"
+		},
+		"./nix-output": {
+			"types": "./dist/nix-output/index.d.ts",
+			"default": "./dist/nix-output/index.js"
+		},
+		"./scripts": {
+			"types": "./dist/scripts/index.d.ts",
+			"default": "./dist/scripts/index.js"
+		},
+		"./d1": {
+			"types": "./dist/d1/index.d.ts",
+			"default": "./dist/d1/index.js"
+		},
+		"./cloudsql": {
+			"types": "./dist/cloudsql/index.d.ts",
+			"default": "./dist/cloudsql/index.js"
+		},
+		"./litellm": {
+			"types": "./dist/litellm/index.d.ts",
+			"default": "./dist/litellm/index.js"
+		},
+		"./pulumi-config": {
+			"types": "./dist/pulumi-config/index.d.ts",
+			"default": "./dist/pulumi-config/index.js"
+		}
+	},
+	"files": [
+		"dist",
+		"README.md"
+	],
+	"scripts": {
+		"build": "pnpm run clean && tsc -p tsconfig.build.json && node tools/copy-shell-scripts.mjs",
+		"clean": "rimraf dist",
+		"prepack": "pnpm run build",
+		"test": "vitest run",
+		"test:watch": "vitest"
+	},
+	"peerDependencies": {
+		"@pulumi/pulumi": "^3.0.0",
+		"@pulumi/cloudflare": "^6.0.0",
+		"@pulumi/gcp": "^9.0.0",
+		"@pulumi/command": "^1.0.0",
+		"@pulumi/kubernetes": "^4.0.0",
+		"@pulumi/random": "^4.0.0"
+	},
+	"dependencies": {
+		"yaml": "2.9.0"
+	},
+	"devDependencies": {
+		"@pulumi/pulumi": "3.239.0",
+		"@pulumi/cloudflare": "6.15.0",
+		"@pulumi/gcp": "9.23.0",
+		"@pulumi/command": "1.2.1",
+		"@pulumi/kubernetes": "4.31.0",
+		"@pulumi/random": "4.20.0",
+		"rimraf": "6.1.3",
+		"typescript": "6.0.3",
+		"vitest": "4.1.6"
+	}
 }

--- a/packages/sector7/tests/cloudsql-auth-proxy-sidecar.test.ts
+++ b/packages/sector7/tests/cloudsql-auth-proxy-sidecar.test.ts
@@ -1,0 +1,196 @@
+import * as pulumi from "@pulumi/pulumi";
+import { beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { CloudSqlAuthProxySidecar } from "../cloudsql/index.ts";
+import {
+	findResource,
+	installPulumiMocks,
+	resetMockResources,
+	resolveOutput,
+	resolveRecord,
+} from "./pulumi-test-helpers.ts";
+
+beforeAll(() => {
+	installPulumiMocks();
+});
+
+beforeEach(() => {
+	resetMockResources();
+});
+
+describe("CloudSqlAuthProxySidecar", () => {
+	it("rewrites DATABASE_URL for a localhost-bound sidecar with sane defaults", async () => {
+		const proxy = new CloudSqlAuthProxySidecar("rewrite-proxy", {
+			connectionName: "my-project:us-east5:my-instance",
+			databaseUrl: pulumi.secret(
+				"postgresql://user:pass@34.162.159.18:6543/mydb?sslmode=require",
+			),
+			proxyPort: 6432,
+			credentials: { mode: "ambient-iam" },
+		});
+
+		const [container, volumes, rewrittenDatabaseUrl] = await Promise.all([
+			resolveOutput(proxy.container),
+			resolveOutput(proxy.volumes),
+			resolveOutput(proxy.rewrittenDatabaseUrl),
+		]);
+
+		expect(rewrittenDatabaseUrl).toBe(
+			"postgresql://user:pass@127.0.0.1:6432/mydb?sslmode=disable",
+		);
+		expect(container.name).toBe("cloud-sql-proxy");
+		expect(container.image).toBe(
+			"gcr.io/cloud-sql-connectors/cloud-sql-proxy:2",
+		);
+		expect(container.args).toEqual([
+			"my-project:us-east5:my-instance",
+			"--address=127.0.0.1",
+			"--port=6432",
+		]);
+		expect(container.livenessProbe).toBeUndefined();
+		expect(container.readinessProbe).toBeUndefined();
+		expect(container.securityContext).toMatchObject({
+			runAsNonRoot: true,
+			allowPrivilegeEscalation: false,
+		});
+		expect(container.resources).toEqual({
+			requests: { cpu: "50m", memory: "64Mi" },
+			limits: { cpu: "250m", memory: "128Mi" },
+		});
+		expect(volumes).toEqual([]);
+	});
+
+	it("creates and mounts a credentials secret for inline-key mode", async () => {
+		const proxy = new CloudSqlAuthProxySidecar("inline-proxy", {
+			connectionName: "my-project:us-east5:my-instance",
+			kubernetes: {
+				namespace: "apps",
+				secretName: "inline-cloudsql-creds",
+			},
+			credentials: {
+				mode: "inline-key",
+				serviceAccountKey: pulumi.secret('{"type":"service_account"}'),
+			},
+		});
+
+		const [container, volumes] = await Promise.all([
+			resolveOutput(proxy.container),
+			resolveOutput(proxy.volumes),
+			resolveOutput(proxy.credentialSecret?.id),
+		]);
+
+		const credentialSecret = findResource("inline-proxy-credentials");
+		const credentialSecretData = await resolveRecord(
+			credentialSecret?.inputs.stringData as
+				| Record<string, unknown>
+				| undefined,
+		);
+		expect(credentialSecret?.inputs.metadata).toMatchObject({
+			name: "inline-cloudsql-creds",
+			namespace: "apps",
+		});
+		expect(credentialSecretData).toEqual({
+			"credentials.json": '{"type":"service_account"}',
+		});
+		expect(container.args).toEqual([
+			"my-project:us-east5:my-instance",
+			"--address=127.0.0.1",
+			"--port=5432",
+			"--credentials-file=/cloudsql/credentials.json",
+		]);
+		expect(container.volumeMounts).toEqual([
+			{
+				name: "cloudsql-credentials",
+				mountPath: "/cloudsql",
+				readOnly: true,
+			},
+		]);
+		expect(volumes).toEqual([
+			{
+				name: "cloudsql-credentials",
+				secret: { secretName: "inline-cloudsql-creds" },
+			},
+		]);
+	});
+
+	it("creates managed IAM resources and a decoded credentials secret for managed-key mode", async () => {
+		const proxy = new CloudSqlAuthProxySidecar("managed-proxy", {
+			connectionName: "my-project:us-east5:my-instance",
+			kubernetes: {
+				namespace: "apps",
+			},
+			credentials: {
+				mode: "managed-key",
+				project: "my-project",
+				accountId: "managed-proxy",
+				displayName: "Managed proxy",
+			},
+		});
+
+		await Promise.all([
+			resolveOutput(proxy.credentialSecret?.id),
+			resolveOutput(proxy.serviceAccount?.id),
+			resolveOutput(proxy.serviceAccountKey?.id),
+			resolveOutput(proxy.cloudSqlClientMembership?.id),
+		]);
+
+		const serviceAccount = findResource("managed-proxy-service-account");
+		expect(serviceAccount?.inputs).toMatchObject({
+			accountId: "managed-proxy",
+			displayName: "Managed proxy",
+		});
+
+		const iamMember = findResource("managed-proxy-cloudsql-client");
+		expect(iamMember?.inputs).toMatchObject({
+			project: "my-project",
+			role: "roles/cloudsql.client",
+			member:
+				"serviceAccount:managed-proxy@mock-project.iam.gserviceaccount.com",
+		});
+
+		const serviceAccountKey = findResource("managed-proxy-service-account-key");
+		expect(serviceAccountKey?.inputs.serviceAccountId).toBe(
+			"projects/mock-project/serviceAccounts/managed-proxy@mock-project.iam.gserviceaccount.com",
+		);
+
+		const credentialSecret = findResource("managed-proxy-credentials");
+		const credentialSecretData = await resolveRecord(
+			credentialSecret?.inputs.stringData as
+				| Record<string, unknown>
+				| undefined,
+		);
+		expect(credentialSecret?.inputs.metadata).toMatchObject({
+			name: "managed-proxy-cloudsql-credentials",
+			namespace: "apps",
+		});
+		expect(credentialSecretData).toEqual({
+			"credentials.json":
+				'{"type":"service_account","client_email":"managed-proxy@mock-project.iam.gserviceaccount.com"}',
+		});
+	});
+
+	it("skips key resources and secret creation for ambient IAM mode", async () => {
+		const proxy = new CloudSqlAuthProxySidecar("ambient-proxy", {
+			connectionName: "my-project:us-east5:my-instance",
+			credentials: { mode: "ambient-iam" },
+			extraArgs: ["--auto-iam-authn"],
+		});
+
+		const [container, volumes] = await Promise.all([
+			resolveOutput(proxy.container),
+			resolveOutput(proxy.volumes),
+		]);
+
+		expect(proxy.credentialSecret).toBeUndefined();
+		expect(proxy.serviceAccount).toBeUndefined();
+		expect(proxy.serviceAccountKey).toBeUndefined();
+		expect(proxy.cloudSqlClientMembership).toBeUndefined();
+		expect(container.args).toEqual([
+			"my-project:us-east5:my-instance",
+			"--address=127.0.0.1",
+			"--port=5432",
+			"--auto-iam-authn",
+		]);
+		expect(container.volumeMounts).toBeUndefined();
+		expect(volumes).toEqual([]);
+	});
+});

--- a/packages/sector7/tests/litellm-proxy.test.ts
+++ b/packages/sector7/tests/litellm-proxy.test.ts
@@ -2,74 +2,21 @@ import * as pulumi from "@pulumi/pulumi";
 import { beforeAll, beforeEach, describe, expect, it } from "vitest";
 import { LiteLLMApiKey, LiteLLMTeam } from "../litellm/admin.ts";
 import { LiteLLMProxy } from "../litellm/litellm-proxy.ts";
-
-type MockResource = {
-	type: string;
-	name: string;
-	inputs: Record<string, unknown>;
-};
-
-const resources: MockResource[] = [];
+import {
+	findResource,
+	installPulumiMocks,
+	resetMockResources,
+	resolveOutput,
+	resolveRecord,
+} from "./pulumi-test-helpers.ts";
 
 beforeAll(() => {
-	pulumi.runtime.setMocks({
-		newResource: (args) => {
-			const state = { ...(args.inputs as Record<string, unknown>) };
-			if (args.type === "random:index/randomPassword:RandomPassword") {
-				state.result =
-					args.name === "personal-coding-key-secret"
-						? "generated-api-key"
-						: "generated-master-key";
-			}
-			if (args.type === "command:local:Command") {
-				state.stdout = `${args.name}-stdout`;
-			}
-			resources.push({
-				type: args.type,
-				name: args.name,
-				inputs: state,
-			});
-			return {
-				id: `${args.name}-id`,
-				state,
-			};
-		},
-		call: (args) => args.inputs,
-	});
+	installPulumiMocks();
 });
 
 beforeEach(() => {
-	resources.length = 0;
+	resetMockResources();
 });
-
-function resolveOutput<T>(value: pulumi.Input<T>): Promise<T> {
-	return new Promise((resolve) => {
-		pulumi.output(value).apply((resolved) => {
-			resolve(resolved as T);
-			return resolved;
-		});
-	});
-}
-
-function findResource(name: string): MockResource | undefined {
-	return resources.find((resource) => resource.name === name);
-}
-
-async function resolveRecord(
-	value: Record<string, unknown> | undefined,
-): Promise<Record<string, unknown>> {
-	const resolved = await resolveOutput(value ?? {});
-	if (
-		resolved &&
-		typeof resolved === "object" &&
-		"value" in resolved &&
-		typeof resolved.value === "object" &&
-		resolved.value !== null
-	) {
-		return resolved.value as Record<string, unknown>;
-	}
-	return resolved;
-}
 
 describe("LiteLLMProxy", () => {
 	it("creates namespace, secrets, configmap, deployment, and service", async () => {
@@ -196,7 +143,7 @@ describe("LiteLLMProxy", () => {
 		]);
 
 		// SA key secret should be created.
-		const saKeySecret = findResource("sidecar-proxy-cloudsql-sa-key");
+		const saKeySecret = findResource("sidecar-proxy-cloudsql-credentials");
 		expect(saKeySecret?.type).toBe("kubernetes:core/v1:Secret");
 
 		// Runtime secret should have the rewritten DATABASE_URL pointing at localhost.
@@ -226,9 +173,7 @@ describe("LiteLLMProxy", () => {
 				},
 			],
 			modelGroups: [{ name: "smart", deploymentIds: ["anthropic-smart"] }],
-			databaseUrl: pulumi.secret(
-				"postgres://db-user:***@db.internal/litellm",
-			),
+			databaseUrl: pulumi.secret("postgres://db-user:***@db.internal/litellm"),
 		});
 
 		await resolveOutput(proxy.proxyUrl);

--- a/packages/sector7/tests/pulumi-test-helpers.ts
+++ b/packages/sector7/tests/pulumi-test-helpers.ts
@@ -1,0 +1,101 @@
+import * as pulumi from "@pulumi/pulumi";
+
+export type MockResource = {
+	type: string;
+	name: string;
+	inputs: Record<string, unknown>;
+};
+
+export const resources: MockResource[] = [];
+
+let mocksInstalled = false;
+
+function mockServiceAccountEmail(accountId: string): string {
+	return `${accountId}@mock-project.iam.gserviceaccount.com`;
+}
+
+export function installPulumiMocks(): void {
+	if (mocksInstalled) {
+		return;
+	}
+
+	pulumi.runtime.setMocks({
+		newResource: (args) => {
+			const state = { ...(args.inputs as Record<string, unknown>) };
+			const typeToken = args.type.toLowerCase();
+
+			if (args.type === "random:index/randomPassword:RandomPassword") {
+				state.result =
+					args.name === "personal-coding-key-secret"
+						? "generated-api-key"
+						: "generated-master-key";
+			}
+
+			if (args.type === "command:local:Command") {
+				state.stdout = `${args.name}-stdout`;
+			}
+
+			if (typeToken.includes("serviceaccount/account")) {
+				const accountId = String(state.accountId ?? args.name);
+				const email = mockServiceAccountEmail(accountId);
+				state.email = email;
+				state.name = `projects/mock-project/serviceAccounts/${email}`;
+			}
+
+			if (typeToken.includes("serviceaccount/key")) {
+				state.privateKey = Buffer.from(
+					JSON.stringify({
+						type: "service_account",
+						client_email: "managed-proxy@mock-project.iam.gserviceaccount.com",
+					}),
+				).toString("base64");
+			}
+
+			resources.push({
+				type: args.type,
+				name: args.name,
+				inputs: state,
+			});
+			return {
+				id: `${args.name}-id`,
+				state,
+			};
+		},
+		call: (args) => args.inputs,
+	});
+
+	mocksInstalled = true;
+}
+
+export function resetMockResources(): void {
+	resources.length = 0;
+}
+
+export function findResource(name: string): MockResource | undefined {
+	return resources.find((resource) => resource.name === name);
+}
+
+export function resolveOutput<T>(value: pulumi.Input<T>): Promise<T> {
+	return new Promise((resolve) => {
+		pulumi.output(value).apply((resolved) => {
+			resolve(resolved as T);
+			return resolved;
+		});
+	});
+}
+
+export async function resolveRecord(
+	value: Record<string, unknown> | undefined,
+): Promise<Record<string, unknown>> {
+	const resolved = await resolveOutput(value ?? {});
+	if (
+		resolved &&
+		typeof resolved === "object" &&
+		"value" in resolved &&
+		typeof resolved.value === "object" &&
+		resolved.value !== null
+	) {
+		return resolved.value as Record<string, unknown>;
+	}
+	return resolved;
+}


### PR DESCRIPTION
## Summary
- add a new `@jmmaloney4/sector7/cloudsql` subpath with a reusable `CloudSqlAuthProxySidecar` component
- move Cloud SQL proxy URL rewrite, sidecar container assembly, credential secret handling, and optional managed IAM resources into the shared component
- refactor `LiteLLMProxy` to compose the shared sidecar component instead of carrying its own inline Cloud SQL proxy implementation
- keep `cloudsql` and `litellm` off the root barrel and add component-level tests for URL rewriting and credential modes

## Architecture alignment
- implements the design in ADR-027 by moving the reusable concern out of the `litellm` subpath and into a dedicated `cloudsql` subpath
- preserves the parent-owned deployment model: the sidecar component owns sidecar-related resources and outputs, while `LiteLLMProxy` still owns the application `Deployment`
- keeps LiteLLM's existing app-facing `cloudSqlAuthProxy` config surface stable while mapping it onto the richer shared component internally

## Test Plan
- [x] `cd packages/sector7 && pnpm test`
- [x] `cd packages/sector7 && pnpm build`
- [x] `cd packages/sector7 && pnpm exec tsc -p tsconfig.json --noEmit`
- [x] exercised the shared component through new Pulumi-mock tests covering URL rewrite, inline-key, managed-key, and ambient-iam modes
- [x] exercised the real consumer path by updating and running `tests/litellm-proxy.test.ts`

## Risks
- this changes a reusable package surface by adding `./cloudsql`; downstream consumers need to import that subpath explicitly rather than through the root barrel
- `LiteLLMProxy` now depends on the shared component for Cloud SQL sidecar behavior; the targeted tests cover that composition path
- garden/attic migration is intentionally not part of this PR; that follow-up still needs to consume the new shared component from a released Sector7 version

## Follow-ups
- migrate garden attic to `@jmmaloney4/sector7/cloudsql`
- audit the legacy standalone proxy pattern separately (`deploy/services/litellm/cloud-sql.ts` per ADR-027)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only removes an unnecessary `String()` cast when building the Cloud SQL proxy `--port` argument, with no behavioral change expected.
> 
> **Overview**
> Simplifies Cloud SQL auth proxy sidecar container argument construction by interpolating `proxyPort` directly into the `--port=` flag (removing the redundant `String(...)` conversion).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 439b453f858b754455c0db3275e41cd4d7c06a8c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->