### PR TITLE
feat(monitor): add optional read API to UptimeMonitor (ADR-028)

### DIFF
--- a/packages/sector7/monitor/monitor-script.ts
+++ b/packages/sector7/monitor/monitor-script.ts
@@ -59,7 +59,7 @@ export interface MonitorTarget {
  */
 export function generateMonitorScript(
   monitors: MonitorTarget[],
-  options: { enableReadApi?: boolean } = {}
+  options: { enableReadApi?: boolean; readApiAuth?: { type: "service-token" } } = {}
 ): string {
 	const monitorsJson = JSON.stringify(
 		monitors.map((m) => ({

--- a/packages/sector7/monitor/monitor-script.ts
+++ b/packages/sector7/monitor/monitor-script.ts
@@ -237,29 +237,36 @@ async function checkAndAlert(result, env, ctx) {
 }
 
 async function sendWebhook(env, payload) {
-\tconst webhookUrl = env.WEBHOOK_URL;
-\tif (!webhookUrl) return;
+	const webhookUrl = env.WEBHOOK_URL;
+	if (!webhookUrl) return;
 
-\ttry {
-\t\tawait fetch(webhookUrl, {
-\t\t\tmethod: "POST",
-\t\t\theaders: { "Content-Type": "application/json" },
-\t\t\tbody: JSON.stringify(payload),
-\t\t});
-\t} catch (e) {
-\t\tconsole.error("Failed to send webhook:", e);
-\t}
+	try {
+		await fetch(webhookUrl, {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify(payload),
+		});
+	} catch (e) {
+		console.error("Failed to send webhook:", e);
+	}
 }
 
 ${options.enableReadApi ? `
-async function handleStats(env, request) {
-  // TODO: real D1 query + Service Token auth
-  return Response.json({
-    points: [],
-    period: "7d",
-    generated_at: new Date().toISOString()
-  });
-}
+export default {
+  scheduled: ...,
+  async fetch(request, env) {
+    const url = new URL(request.url);
+    if (url.pathname === "/stats") {
+      // Basic Service Token check (placeholder)
+      const clientId = request.headers.get("CF-Access-Client-Id");
+      if (!clientId) {
+        return new Response("Unauthorized", { status: 401 });
+      }
+      return handleStats(env, request);
+    }
+    return new Response("Not found", { status: 404 });
+  },
+};
 ` : ""}
 
 `.trim();

--- a/packages/sector7/monitor/monitor-script.ts
+++ b/packages/sector7/monitor/monitor-script.ts
@@ -58,8 +58,8 @@ export interface MonitorTarget {
  * - Webhook fires only on state transitions, not on every probe.
  */
 export function generateMonitorScript(
-  monitors: MonitorTarget[],
-  options: { enableReadApi?: boolean; readApiAuth?: { type: "service-token" } } = {}
+	monitors: MonitorTarget[],
+	options: { enableReadApi?: boolean; readApiAuth?: { type: "service-token" } } = {},
 ): string {
 	const monitorsJson = JSON.stringify(
 		monitors.map((m) => ({
@@ -75,6 +75,40 @@ export function generateMonitorScript(
 		"\t",
 	);
 
+	// Build the fetch handler block — only included when enableReadApi is true.
+	// This is a placeholder: real D1 aggregation queries and full Service Token
+	// validation are follow-up work (per ADR-028).
+	const fetchHandler = options.enableReadApi
+		? `
+	async fetch(request, env) {
+		const url = new URL(request.url);
+		if (url.pathname === "/stats") {
+			const clientId = request.headers.get("CF-Access-Client-Id");
+			if (!clientId) {
+				return new Response("Unauthorized", { status: 401 });
+			}
+			return handleStats(env, request);
+		}
+		return new Response("Not found", { status: 404 });
+	},`
+		: "";
+
+	// handleStats stub — returns a placeholder response.
+	// Full D1 query aggregation to be implemented in follow-up.
+	const handleStatsFn = options.enableReadApi
+		? `
+async function handleStats(env, request) {
+	return new Response(JSON.stringify({
+		status: "ok",
+		message: "Stats endpoint placeholder — D1 queries pending (ADR-028 follow-up)",
+		generated_at: new Date().toISOString(),
+	}), {
+		headers: { "Content-Type": "application/json" },
+	});
+}
+`
+		: "";
+
 	return `
 /**
  * UptimeMonitor - Synthetic HTTP probe with D1 storage and webhook alerting
@@ -87,7 +121,7 @@ const MONITORS = ${monitorsJson};
 const ALERT_THRESHOLD = 3;
 const RECOVERY_THRESHOLD = 1;
 
-export default {
+export default {${fetchHandler}
 	async scheduled(controller, env, ctx) {
 		const results = [];
 
@@ -250,24 +284,5 @@ async function sendWebhook(env, payload) {
 		console.error("Failed to send webhook:", e);
 	}
 }
-
-${options.enableReadApi ? `
-export default {
-  scheduled: ...,
-  async fetch(request, env) {
-    const url = new URL(request.url);
-    if (url.pathname === "/stats") {
-      // Basic Service Token check (placeholder)
-      const clientId = request.headers.get("CF-Access-Client-Id");
-      if (!clientId) {
-        return new Response("Unauthorized", { status: 401 });
-      }
-      return handleStats(env, request);
-    }
-    return new Response("Not found", { status: 404 });
-  },
-};
-` : ""}
-
-`.trim();
+${handleStatsFn}`.trim();
 }

--- a/packages/sector7/monitor/monitor-script.ts
+++ b/packages/sector7/monitor/monitor-script.ts
@@ -57,7 +57,10 @@ export interface MonitorTarget {
  * - A monitor transitions back to "healthy" after RECOVERY_THRESHOLD consecutive successes.
  * - Webhook fires only on state transitions, not on every probe.
  */
-export function generateMonitorScript(monitors: MonitorTarget[]): string {
+export function generateMonitorScript(
+  monitors: MonitorTarget[],
+  options: { enableReadApi?: boolean } = {}
+): string {
 	const monitorsJson = JSON.stringify(
 		monitors.map((m) => ({
 			id: m.id,
@@ -234,18 +237,30 @@ async function checkAndAlert(result, env, ctx) {
 }
 
 async function sendWebhook(env, payload) {
-	const webhookUrl = env.WEBHOOK_URL;
-	if (!webhookUrl) return;
+\tconst webhookUrl = env.WEBHOOK_URL;
+\tif (!webhookUrl) return;
 
-	try {
-		await fetch(webhookUrl, {
-			method: "POST",
-			headers: { "Content-Type": "application/json" },
-			body: JSON.stringify(payload),
-		});
-	} catch (e) {
-		console.error("Failed to send webhook:", e);
-	}
+\ttry {
+\t\tawait fetch(webhookUrl, {
+\t\t\tmethod: "POST",
+\t\t\theaders: { "Content-Type": "application/json" },
+\t\t\tbody: JSON.stringify(payload),
+\t\t});
+\t} catch (e) {
+\t\tconsole.error("Failed to send webhook:", e);
+\t}
 }
+
+${options.enableReadApi ? `
+async function handleStats(env, request) {
+  // TODO: real D1 query + Service Token auth
+  return Response.json({
+    points: [],
+    period: "7d",
+    generated_at: new Date().toISOString()
+  });
+}
+` : ""}
+
 `.trim();
 }

--- a/packages/sector7/monitor/monitor-script.ts
+++ b/packages/sector7/monitor/monitor-script.ts
@@ -59,7 +59,11 @@ export interface MonitorTarget {
  */
 export function generateMonitorScript(
 	monitors: MonitorTarget[],
-	options: { enableReadApi?: boolean; readApiAuth?: { type: "service-token" } } = {},
+	options: {
+		enableReadApi?: boolean;
+		/** Auth config — reserved for ADR-028 follow-up (full JWT validation). */
+		readApiAuth?: { type: "service-token" };
+	} = {},
 ): string {
 	const monitorsJson = JSON.stringify(
 		monitors.map((m) => ({

--- a/packages/sector7/monitor/uptime-monitor.ts
+++ b/packages/sector7/monitor/uptime-monitor.ts
@@ -118,7 +118,10 @@ export interface UptimeMonitorArgs {
 	/**
 	 * Enable a read API (`GET /stats`) on the Worker.
 	 * When true, the Worker will accept requests and return aggregated uptime data.
-	 * Protected by Cloudflare Access Service Tokens.
+	 *
+	 * **Note:** The current implementation uses a placeholder auth check
+	 * (header presence only). Full Cloudflare Access Service Token validation
+	 * (JWT assertion verification) is a follow-up per ADR-028.
 	 *
 	 * @default false
 	 */

--- a/packages/sector7/monitor/uptime-monitor.ts
+++ b/packages/sector7/monitor/uptime-monitor.ts
@@ -305,7 +305,9 @@ export class UptimeMonitor extends pulumi.ComponentResource {
 		}
 
 		// 3. Generate Worker script
-		const scriptContent = generateMonitorScript(args.monitors);
+		const scriptContent = generateMonitorScript(args.monitors, {
+			enableReadApi: args.enableReadApi ?? false,
+		});
 
 		// 4. Create Worker with D1 and KV bindings
 		const baseBindings: Array<cloudflare.types.input.WorkersScriptBinding> = [

--- a/packages/sector7/monitor/uptime-monitor.ts
+++ b/packages/sector7/monitor/uptime-monitor.ts
@@ -123,6 +123,14 @@ export interface UptimeMonitorArgs {
 	 * @default false
 	 */
 	enableReadApi?: pulumi.Input<boolean>;
+
+	/**
+	 * Authentication configuration for the read API.
+	 * Currently only supports Service Tokens.
+	 */
+	readApiAuth?: {
+		type: "service-token";
+	};
 }
 
 const DEFAULT_D1_SCHEMA = [

--- a/packages/sector7/monitor/uptime-monitor.ts
+++ b/packages/sector7/monitor/uptime-monitor.ts
@@ -114,6 +114,15 @@ export interface UptimeMonitorArgs {
 	 * `pulumi.secret("...")` or `pulumi.config.requireSecret("cloudflare:apiToken")`.
 	 */
 	apiToken: pulumi.Input<string>;
+
+	/**
+	 * Enable a read API (`GET /stats`) on the Worker.
+	 * When true, the Worker will accept requests and return aggregated uptime data.
+	 * Protected by Cloudflare Access Service Tokens.
+	 *
+	 * @default false
+	 */
+	enableReadApi?: pulumi.Input<boolean>;
 }
 
 const DEFAULT_D1_SCHEMA = [

--- a/packages/sector7/monitor/uptime-monitor.ts
+++ b/packages/sector7/monitor/uptime-monitor.ts
@@ -313,9 +313,16 @@ export class UptimeMonitor extends pulumi.ComponentResource {
 		}
 
 		// 3. Generate Worker script
-		const scriptContent = generateMonitorScript(args.monitors, {
-			enableReadApi: args.enableReadApi ?? false,
-		});
+		// Resolve pulumi.Input<boolean> via .apply() so Output values are
+		// unwrapped before being passed to the synchronous script generator.
+		const scriptContent = pulumi
+			.output(args.enableReadApi ?? false)
+			.apply((enabled: boolean) =>
+				generateMonitorScript(args.monitors, {
+					enableReadApi: enabled,
+					readApiAuth: args.readApiAuth,
+				}),
+			);
 
 		// 4. Create Worker with D1 and KV bindings
 		const baseBindings: Array<cloudflare.types.input.WorkersScriptBinding> = [

--- a/packages/sector7/tests/monitor-script.test.ts
+++ b/packages/sector7/tests/monitor-script.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import { generateMonitorScript } from "../monitor/monitor-script.ts";
+
+const BASIC_MONITORS = [{ id: "api", url: "https://api.example.com/healthz" }];
+
+describe("generateMonitorScript", () => {
+	it("generates a script with scheduled handler only by default", () => {
+		const script = generateMonitorScript(BASIC_MONITORS);
+		expect(script).toContain("export default {");
+		expect(script).toContain("async scheduled(controller, env, ctx)");
+		expect(script).not.toContain("async fetch(request, env)");
+		expect(script).not.toContain("handleStats");
+	});
+
+	it("adds fetch handler and handleStats when enableReadApi is true", () => {
+		const script = generateMonitorScript(BASIC_MONITORS, {
+			enableReadApi: true,
+			readApiAuth: { type: "service-token" },
+		});
+		expect(script).toContain("async fetch(request, env)");
+		expect(script).toContain('pathname === "/stats"');
+		expect(script).toContain("CF-Access-Client-Id");
+		expect(script).toContain("handleStats");
+	});
+
+	it("produces exactly one export default when read API is enabled", () => {
+		const script = generateMonitorScript(BASIC_MONITORS, {
+			enableReadApi: true,
+		});
+		const exportDefaults = script.match(/export default \{/g);
+		expect(exportDefaults).toHaveLength(1);
+	});
+
+	it("produces exactly one export default when read API is disabled", () => {
+		const script = generateMonitorScript(BASIC_MONITORS, {
+			enableReadApi: false,
+		});
+		const exportDefaults = script.match(/export default \{/g);
+		expect(exportDefaults).toHaveLength(1);
+	});
+
+	it("includes handleStats placeholder response when enabled", () => {
+		const script = generateMonitorScript(BASIC_MONITORS, {
+			enableReadApi: true,
+		});
+		expect(script).toContain("Stats endpoint placeholder");
+		expect(script).toContain("generated_at");
+	});
+
+	it("embeds monitor config as JSON", () => {
+		const script = generateMonitorScript([
+			{ id: "grafana", url: "https://grafana.example.com/healthz" },
+			{ id: "api", url: "https://api.example.com/healthz", expectedCodes: [200, 204] },
+		]);
+		expect(script).toContain("grafana");
+		expect(script).toContain("https://grafana.example.com/healthz");
+		expect(script).toContain("https://api.example.com/healthz");
+	});
+});

--- a/packages/sector7/tests/uptime-monitor.test.ts
+++ b/packages/sector7/tests/uptime-monitor.test.ts
@@ -260,4 +260,40 @@ describe("UptimeMonitor", () => {
 		expect(content).toContain("api");
 		expect(content).toContain("homepage");
 	});
+
+	it("includes fetch handler in Worker script when enableReadApi is true", async () => {
+		const monitor = new UptimeMonitor("readapi", {
+			...DEFAULT_ARGS,
+			name: "readapi-uptime",
+			monitors: [{ id: "api", url: "https://api.example.com/healthz" }],
+			enableReadApi: true,
+			readApiAuth: { type: "service-token" },
+		});
+
+		await resolveOutput(monitor.worker.id);
+
+		const worker = findResource("readapi-worker");
+		const content = worker?.inputs.content as string;
+		expect(content).toContain("async fetch(request, env)");
+		expect(content).toContain('pathname === "/stats"');
+		expect(content).toContain("handleStats");
+		// Must have exactly one export default
+		const exportDefaults = content.match(/export default \{/g);
+		expect(exportDefaults).toHaveLength(1);
+	});
+
+	it("omits fetch handler when enableReadApi is false or unset", async () => {
+		const monitor = new UptimeMonitor("noreadapi", {
+			...DEFAULT_ARGS,
+			name: "noreadapi-uptime",
+			monitors: [{ id: "api", url: "https://api.example.com/healthz" }],
+		});
+
+		await resolveOutput(monitor.worker.id);
+
+		const worker = findResource("noreadapi-worker");
+		const content = worker?.inputs.content as string;
+		expect(content).not.toContain("async fetch(request, env)");
+		expect(content).not.toContain("handleStats");
+	});
 });


### PR DESCRIPTION
Adds support for an optional read API on the UptimeMonitor Cloudflare Worker component.

- New enableReadApi option
- Basic fetch handler stub
- ADR-028 included

Follow-up: real D1 queries + Service Token validation

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Exposes a new HTTP surface on the Worker with weak auth (header presence only) until ADR-028 follow-up; default remains disabled.
> 
> **Overview**
> Adds an **opt-in read API** on the generated uptime Worker (ADR-028): `UptimeMonitor` gains `enableReadApi` (default off) and optional `readApiAuth` for service-token style access.
> 
> When enabled, `generateMonitorScript` injects a **`fetch` handler** for `GET /stats` that requires a `CF-Access-Client-Id` header (presence only, not full JWT validation) and a **`handleStats` stub** returning placeholder JSON instead of real D1 aggregates. Script generation is wired through Pulumi via `.apply()` on `enableReadApi`.
> 
> New **unit tests** cover script shape (single `export default`, fetch/stats inclusion) and component-level Worker content when the flag is on or off.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a7cd09c535ecf0fc833bef434bf5f1357eeccb95. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->