### PR TITLE
feat(ci): add explicit Attic cache inputs

### DIFF
--- a/.github/actions/analyze-pnpm-packages/action.yml
+++ b/.github/actions/analyze-pnpm-packages/action.yml
@@ -1,11 +1,8 @@
 name: Analyze pnpm packages
 description: >
-  Unified monorepo release analyzer. Reads version from root package.json,
-  checks whether a v${version} GitHub Release with all expected tarballs already
-  exists, and emits a JSON matrix of packages to publish if needed.
+  Unified monorepo release analyzer. Reads version from root package.json, checks whether a v${version} GitHub Release with all expected tarballs already exists, and emits a JSON matrix of packages to publish if needed.
 
-  Only the 'release' target is supported. Registry targets (ghcr, npm, gcp)
-  have been removed.
+  Only the 'release' target is supported. Registry targets (ghcr, npm, gcp) have been removed.
 
 inputs:
   dry_run:
@@ -22,11 +19,10 @@ inputs:
     default: "."
   github_repository:
     description: >
-      Owner/repository for GitHub Release checks. Defaults to the workflow's
-      github.repository (set automatically by GitHub Actions).
+      Owner/repository for GitHub Release checks. Defaults to the workflow's github.repository (set automatically by GitHub Actions).
+
     required: false
     default: "${{ github.repository }}"
-
 outputs:
   matrix:
     description: JSON matrix of packages to publish
@@ -34,7 +30,6 @@ outputs:
   has_packages:
     description: Whether there are packages to publish (true/false)
     value: ${{ steps.analyze.outputs.has_packages }}
-
 runs:
   using: composite
   steps:

--- a/.github/actions/analyze-pnpm-packages/main.sh
+++ b/.github/actions/analyze-pnpm-packages/main.sh
@@ -30,7 +30,7 @@ if [[ ! -f "${ROOT}/package.json" ]]; then
 fi
 
 VERSION="$(jq -r '.version // empty' "${ROOT}/package.json")"
-if [[ -z "$VERSION" || "$VERSION" == "null" ]]; then
+if [[ -z $VERSION || $VERSION == "null" ]]; then
   echo "Error: version field missing or empty in ${ROOT}/package.json" >&2
   exit 1
 fi
@@ -38,7 +38,7 @@ fi
 TAG="v${VERSION}"
 
 echo "# 📦 Unified release analysis" >>"$SUMMARY_FILE"
-if [[ "${DRY_RUN}" == "true" ]]; then
+if [[ ${DRY_RUN} == "true" ]]; then
   echo "> **DRY RUN MODE** - No packages will be published" >>"$SUMMARY_FILE"
 fi
 echo "" >>"$SUMMARY_FILE"
@@ -48,16 +48,16 @@ echo "- **Target:** \`${TARGET}\`" >>"$SUMMARY_FILE"
 
 # ── Validate all package versions match the root version ────────────
 
-if [[ "${DRY_RUN}" == "true" ]]; then
+if [[ ${DRY_RUN} == "true" ]]; then
   echo "- **Version check:** skipped in dry run" >>"$SUMMARY_FILE"
 else
   if [[ -d "${ROOT}/packages" ]]; then
     VERSION_MISMATCH=0
     for pkg_json in "${ROOT}"/packages/*/package.json; do
-      [[ -f "$pkg_json" ]] || continue
+      [[ -f $pkg_json ]] || continue
       pkg_name="$(jq -r '.name' "$pkg_json")"
       pkg_ver="$(jq -r '.version // empty' "$pkg_json")"
-      if [[ "$pkg_ver" != "$VERSION" ]]; then
+      if [[ $pkg_ver != "$VERSION" ]]; then
         echo "❌ Version mismatch: ${pkg_name} is ${pkg_ver}, expected ${VERSION}" >&2
         VERSION_MISMATCH=1
       fi
@@ -75,7 +75,7 @@ fi
 PKG_PATHS=()
 if [[ -d "${ROOT}/packages" ]]; then
   for pkg_json in "${ROOT}/packages"/*/package.json; do
-    [[ -f "$pkg_json" ]] && PKG_PATHS+=("${pkg_json%/package.json}")
+    [[ -f $pkg_json ]] && PKG_PATHS+=("${pkg_json%/package.json}")
   done
 fi
 
@@ -93,45 +93,45 @@ fi
 
 ALREADY_PUBLISHED="false"
 case "$TARGET" in
-  release)
-    if [[ -n "$GITHUB_REPO" ]]; then
-      if gh release view "$TAG" --repo "$GITHUB_REPO" >/dev/null 2>&1; then
-        # Release exists — verify all expected assets are present.
-        # Partial releases (tag created but upload failed) must be retried.
-        # Fetch asset list once to avoid N API calls per package.
-        EXISTING_ASSETS="$(gh release view "$TAG" --repo "$GITHUB_REPO" --json assets -q ".assets[].name" 2>/dev/null || true)"
-        MISSING_ASSETS=()
-        for pkg_path in "${PKG_PATHS[@]}"; do
-          name="$(jq -r '.name' "${pkg_path}/package.json")"
-          pkg_version="$(jq -r '.version // empty' "${pkg_path}/package.json")"
-          stem="${name#@}"
-          stem="${stem//\//-}"
-          asset_name="${stem}-${pkg_version}.tgz"
-          # grep -F for literal match (asset names contain dots)
-          if ! echo "$EXISTING_ASSETS" | grep -Fqx "$asset_name"; then
-            MISSING_ASSETS+=("$asset_name")
-          fi
-        done
-        if [[ ${#MISSING_ASSETS[@]} -eq 0 ]]; then
-          ALREADY_PUBLISHED="true"
-          echo "- **Status:** already published (tag \`${TAG}\` exists with all assets)" >>"$SUMMARY_FILE"
-        else
-          echo "- **Status:** incomplete release (missing: ${MISSING_ASSETS[*]}), will republish" >>"$SUMMARY_FILE"
-          for asset in "${MISSING_ASSETS[@]}"; do
-            echo "  ⚠️ Missing asset: $asset" >&2
-          done
+release)
+  if [[ -n $GITHUB_REPO ]]; then
+    if gh release view "$TAG" --repo "$GITHUB_REPO" >/dev/null 2>&1; then
+      # Release exists — verify all expected assets are present.
+      # Partial releases (tag created but upload failed) must be retried.
+      # Fetch asset list once to avoid N API calls per package.
+      EXISTING_ASSETS="$(gh release view "$TAG" --repo "$GITHUB_REPO" --json assets -q ".assets[].name" 2>/dev/null || true)"
+      MISSING_ASSETS=()
+      for pkg_path in "${PKG_PATHS[@]}"; do
+        name="$(jq -r '.name' "${pkg_path}/package.json")"
+        pkg_version="$(jq -r '.version // empty' "${pkg_path}/package.json")"
+        stem="${name#@}"
+        stem="${stem//\//-}"
+        asset_name="${stem}-${pkg_version}.tgz"
+        # grep -F for literal match (asset names contain dots)
+        if ! echo "$EXISTING_ASSETS" | grep -Fqx "$asset_name"; then
+          MISSING_ASSETS+=("$asset_name")
         fi
+      done
+      if [[ ${#MISSING_ASSETS[@]} -eq 0 ]]; then
+        ALREADY_PUBLISHED="true"
+        echo "- **Status:** already published (tag \`${TAG}\` exists with all assets)" >>"$SUMMARY_FILE"
       else
-        echo "- **Status:** new release needed" >>"$SUMMARY_FILE"
+        echo "- **Status:** incomplete release (missing: ${MISSING_ASSETS[*]}), will republish" >>"$SUMMARY_FILE"
+        for asset in "${MISSING_ASSETS[@]}"; do
+          echo "  ⚠️ Missing asset: $asset" >&2
+        done
       fi
     else
-      echo "- **Status:** unknown (no GITHUB_REPO set, assuming not published)" >>"$SUMMARY_FILE"
+      echo "- **Status:** new release needed" >>"$SUMMARY_FILE"
     fi
-    ;;
-  *)
-    echo "Error: unknown or deprecated target '${TARGET}'. Only 'release' is supported." >&2
-    exit 1
-    ;;
+  else
+    echo "- **Status:** unknown (no GITHUB_REPO set, assuming not published)" >>"$SUMMARY_FILE"
+  fi
+  ;;
+*)
+  echo "Error: unknown or deprecated target '${TARGET}'. Only 'release' is supported." >&2
+  exit 1
+  ;;
 esac
 
 # ── Build matrix entries ────────────────────────────────────────────
@@ -168,7 +168,7 @@ done
 # ── Decide action ───────────────────────────────────────────────────
 
 ACTION="publish"
-if [[ "$ALREADY_PUBLISHED" == "true" || "$DRY_RUN" == "true" ]]; then
+if [[ $ALREADY_PUBLISHED == "true" || $DRY_RUN == "true" ]]; then
   ACTION="skip"
 fi
 
@@ -176,7 +176,7 @@ echo "" >>"$SUMMARY_FILE"
 echo "| Package | Version | Action |" >>"$SUMMARY_FILE"
 echo "|---|---|---|" >>"$SUMMARY_FILE"
 
-if [[ "$ACTION" == "skip" ]]; then
+if [[ $ACTION == "skip" ]]; then
   for entry in "${MATRIX_ENTRIES[@]}"; do
     name="$(echo "$entry" | jq -r '.name')"
     echo "| ${name} | ${VERSION} | ⏭️ skip |" >>"$SUMMARY_FILE"

--- a/.github/actions/compute-flake-build-matrix/action.yml
+++ b/.github/actions/compute-flake-build-matrix/action.yml
@@ -5,6 +5,14 @@ inputs:
     description: Timeout (in seconds) for nix-eval-jobs cache probe
     required: false
     default: '180'
+  extra-substituters:
+    description: Optional newline-delimited extra substituter URLs to pass to nix-eval-jobs cache probing
+    required: false
+    default: ''
+  extra-trusted-public-keys:
+    description: Optional newline-delimited extra trusted public keys to pass to nix-eval-jobs cache probing
+    required: false
+    default: ''
 outputs:
   matrix_include:
     description: JSON array for strategy.matrix.include
@@ -19,5 +27,7 @@ runs:
       shell: bash
       env:
         PROBE_TIMEOUT_SECONDS: ${{ inputs.probe-timeout-seconds }}
+        INPUT_EXTRA_SUBSTITUTERS: ${{ inputs.extra-substituters }}
+        INPUT_EXTRA_TRUSTED_PUBLIC_KEYS: ${{ inputs.extra-trusted-public-keys }}
       run: |
         bash "${{ github.action_path }}/main.sh"

--- a/.github/actions/compute-flake-build-matrix/main.sh
+++ b/.github/actions/compute-flake-build-matrix/main.sh
@@ -22,18 +22,31 @@ nix_eval_args=(
   --option extra-trusted-public-keys "nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs="
 )
 
+append_option_values() {
+  local existing_values="$1"
+  local extra_values="$2"
+  local merged="$existing_values"
+  local value=""
+
+  if [ -z "$extra_values" ]; then
+    printf '%s\n' "$merged"
+    return 0
+  fi
+
+  while IFS= read -r value; do
+    [ -n "$value" ] || continue
+    merged+=" $value"
+  done < <(printf '%s\n' "$extra_values" | tr -s '[:space:]' '\n')
+
+  printf '%s\n' "$merged"
+}
+
 if [ -n "$EXTRA_SUBSTITUTERS" ]; then
-  while IFS= read -r substituter; do
-    [ -n "$substituter" ] || continue
-    nix_eval_args+=(--option extra-substituters "$substituter")
-  done <<<"$EXTRA_SUBSTITUTERS"
+  nix_eval_args[1]="$(append_option_values "${nix_eval_args[1]}" "$EXTRA_SUBSTITUTERS")"
 fi
 
 if [ -n "$EXTRA_TRUSTED_PUBLIC_KEYS" ]; then
-  while IFS= read -r public_key; do
-    [ -n "$public_key" ] || continue
-    nix_eval_args+=(--option extra-trusted-public-keys "$public_key")
-  done <<<"$EXTRA_TRUSTED_PUBLIC_KEYS"
+  nix_eval_args[3]="$(append_option_values "${nix_eval_args[3]}" "$EXTRA_TRUSTED_PUBLIC_KEYS")"
 fi
 
 nix run github:nix-community/nix-eval-jobs "${nix_eval_args[@]}" --   --flake .   --check-cache-status   --meta   --workers 1   --select "(${select_expr}) \"${system}\"" >"$tmp_all"

--- a/.github/actions/compute-flake-build-matrix/main.sh
+++ b/.github/actions/compute-flake-build-matrix/main.sh
@@ -52,7 +52,7 @@ nix_eval_args=(
   --option extra-trusted-public-keys "$extra_trusted_public_keys_value"
 )
 
-nix run github:nix-community/nix-eval-jobs/v2.34.1 "${nix_eval_args[@]}" --   --flake .   --check-cache-status   --meta   --workers 1   --select "(${select_expr}) \"${system}\"" >"$tmp_all"
+nix run github:nix-community/nix-eval-jobs/v2.34.1 "${nix_eval_args[@]}" -- --flake . --check-cache-status --meta --workers 1 --select "(${select_expr}) \"${system}\"" >"$tmp_all"
 
 # Transform nix-eval-jobs output to matrix format
 echo "Processing nix-eval-jobs output..." >&2

--- a/.github/actions/compute-flake-build-matrix/main.sh
+++ b/.github/actions/compute-flake-build-matrix/main.sh
@@ -10,37 +10,40 @@ fi
 
 # Set probe timeout from input or default
 PROBE_TIMEOUT_SECONDS="${PROBE_TIMEOUT_SECONDS:-180}"
+EXTRA_SUBSTITUTERS="${INPUT_EXTRA_SUBSTITUTERS:-}"
+EXTRA_TRUSTED_PUBLIC_KEYS="${INPUT_EXTRA_TRUSTED_PUBLIC_KEYS:-}"
 
 tmp_all="$(mktemp)"
 select_expr="$(<"${GITHUB_ACTION_PATH}/select.nix")"
 echo "Running nix-eval-jobs to detect flake outputs..." >&2
-nix run github:nix-community/nix-eval-jobs --option extra-substituters "https://nix-community.cachix.org" --option extra-trusted-public-keys "nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs=" -- \
-  --flake . \
-  --check-cache-status \
-  --meta \
-  --workers 1 \
-  --select "(${select_expr}) \"${system}\"" >"$tmp_all"
+
+nix_eval_args=(
+  --option extra-substituters "https://nix-community.cachix.org"
+  --option extra-trusted-public-keys "nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs="
+)
+
+if [ -n "$EXTRA_SUBSTITUTERS" ]; then
+  while IFS= read -r substituter; do
+    [ -n "$substituter" ] || continue
+    nix_eval_args+=(--option extra-substituters "$substituter")
+  done <<<"$EXTRA_SUBSTITUTERS"
+fi
+
+if [ -n "$EXTRA_TRUSTED_PUBLIC_KEYS" ]; then
+  while IFS= read -r public_key; do
+    [ -n "$public_key" ] || continue
+    nix_eval_args+=(--option extra-trusted-public-keys "$public_key")
+  done <<<"$EXTRA_TRUSTED_PUBLIC_KEYS"
+fi
+
+nix run github:nix-community/nix-eval-jobs "${nix_eval_args[@]}" --   --flake .   --check-cache-status   --meta   --workers 1   --select "(${select_expr}) \"${system}\"" >"$tmp_all"
 
 # Transform nix-eval-jobs output to matrix format
 echo "Processing nix-eval-jobs output..." >&2
 all_outputs=$(nix -L run nixpkgs#jq -- -s -c --arg system "$system" '
-    # Filter out non-objects and ensure attr exists (handles error messages or malformed lines)
     map(select(type == "object" and .attr != null))
-    # Parse each JSON object and extract matrix fields.
-    # After select.nix narrows to packages/checks for the current system, nix-eval-jobs emits
-    # 2-part attrs (e.g. "packages.foo") rather than 3-part ("packages.x86_64-linux.foo").
-    # Handle both shapes; reconstruct a full flake_attr for the 2-part case using $system.
     | map(
         (.attr | split(".")) as $parts
-        # select.nix pre-filters to the current system, so nix-eval-jobs always emits
-        # 2-part attrs of the form "<category>.<name>" where <name> may itself contain
-        # dots (e.g. "packages.python3.requests"). The old $long heuristic
-        # (length >= 3 → treat as 3-part) is therefore wrong for dotted names and has
-        # been removed. Assumption: select.nix is always used; callers that bypass it
-        # and rely on 3-part attrs are not supported by this script.
-        #
-        # Risk: a 1-part attr (no dot) would produce an empty $name.
-        # Mitigation: retain the "// \"default\"" fallback below.
         | ($parts[1:] | join(".")) as $name
         | {
           attr: .attr,
@@ -61,11 +64,7 @@ echo "All detected outputs: $all_outputs"
 # Build include array from only uncached, buildable outputs OR container images (which must be pushed regardless of cache)
 include_array=$(nix -L run nixpkgs#jq -- -c '
   map(select(.ci_skip != true and (.cached == false or .is_image == true)))
-  # Filter out categories we dont want to build (packages, checks, OR images)
-  # IMPORTANT: Use parentheses around (.category | test(...)) to ensure OR applies to boolean result,
-  # otherwise pipe precedence passes string context to .is_image causing "Cannot index string" error.
   | map(select((.category | test("^(packages|checks)$")) or .is_image == true))
-  # Extract only fields needed for the matrix
   | map({category, system, name, flake_attr} + (if .is_image then {is_image: .is_image} else {} end))
 ' <<<"$all_outputs")
 
@@ -96,7 +95,6 @@ if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
   {
     echo "### Detected flake outputs"
     if [ -n "$all_outputs" ] && [ "$all_outputs" != "null" ] && [ "$all_outputs" != "[]" ]; then
-      # Render a markdown table listing all outputs and whether they are cached
       nix -L run nixpkgs#jq -- -rc '
         ["| Category | System | Name | Attr | Store Path | Status |",
          "|---|---|---|---|---|---|"]

--- a/.github/actions/compute-flake-build-matrix/main.sh
+++ b/.github/actions/compute-flake-build-matrix/main.sh
@@ -52,7 +52,7 @@ nix_eval_args=(
   --option extra-trusted-public-keys "$extra_trusted_public_keys_value"
 )
 
-nix run github:nix-community/nix-eval-jobs "${nix_eval_args[@]}" --   --flake .   --check-cache-status   --meta   --workers 1   --select "(${select_expr}) \"${system}\"" >"$tmp_all"
+nix run github:nix-community/nix-eval-jobs/v2.34.1 "${nix_eval_args[@]}" --   --flake .   --check-cache-status   --meta   --workers 1   --select "(${select_expr}) \"${system}\"" >"$tmp_all"
 
 # Transform nix-eval-jobs output to matrix format
 echo "Processing nix-eval-jobs output..." >&2

--- a/.github/actions/compute-flake-build-matrix/main.sh
+++ b/.github/actions/compute-flake-build-matrix/main.sh
@@ -17,10 +17,8 @@ tmp_all="$(mktemp)"
 select_expr="$(<"${GITHUB_ACTION_PATH}/select.nix")"
 echo "Running nix-eval-jobs to detect flake outputs..." >&2
 
-nix_eval_args=(
-  --option extra-substituters "https://nix-community.cachix.org"
-  --option extra-trusted-public-keys "nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs="
-)
+extra_substituters_value="https://nix-community.cachix.org"
+extra_trusted_public_keys_value="nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs="
 
 append_option_values() {
   local existing_values="$1"
@@ -42,12 +40,17 @@ append_option_values() {
 }
 
 if [ -n "$EXTRA_SUBSTITUTERS" ]; then
-  nix_eval_args[1]="$(append_option_values "${nix_eval_args[1]}" "$EXTRA_SUBSTITUTERS")"
+  extra_substituters_value="$(append_option_values "$extra_substituters_value" "$EXTRA_SUBSTITUTERS")"
 fi
 
 if [ -n "$EXTRA_TRUSTED_PUBLIC_KEYS" ]; then
-  nix_eval_args[3]="$(append_option_values "${nix_eval_args[3]}" "$EXTRA_TRUSTED_PUBLIC_KEYS")"
+  extra_trusted_public_keys_value="$(append_option_values "$extra_trusted_public_keys_value" "$EXTRA_TRUSTED_PUBLIC_KEYS")"
 fi
+
+nix_eval_args=(
+  --option extra-substituters "$extra_substituters_value"
+  --option extra-trusted-public-keys "$extra_trusted_public_keys_value"
+)
 
 nix run github:nix-community/nix-eval-jobs "${nix_eval_args[@]}" --   --flake .   --check-cache-status   --meta   --workers 1   --select "(${select_expr}) \"${system}\"" >"$tmp_all"
 

--- a/.github/actions/nix-setup/action.yml
+++ b/.github/actions/nix-setup/action.yml
@@ -36,4 +36,4 @@ runs:
       env:
         INPUT_EXTRA_SUBSTITUTERS: ${{ inputs.extra-substituters }}
         INPUT_EXTRA_TRUSTED_PUBLIC_KEYS: ${{ inputs.extra-trusted-public-keys }}
-      run: $GITHUB_ACTION_PATH/configure-binary-cache.sh
+      run: bash "${{ github.action_path }}/configure-binary-cache.sh"

--- a/.github/actions/nix-setup/action.yml
+++ b/.github/actions/nix-setup/action.yml
@@ -1,5 +1,5 @@
 name: Nix Setup
-description: Install Nix and enable flakehub cache for GitHub Actions
+description: Install Nix and optionally configure additional binary caches for GitHub Actions
 inputs:
   runs-on:
     description: Runner label to determine if runs-on/actions@v2 should be used
@@ -9,6 +9,14 @@ inputs:
     description: Enable FlakeHub cache (set to 'false' for self-hosted runners with cache already configured)
     required: false
     default: 'true'
+  extra-substituters:
+    description: Optional newline-delimited extra substituter URLs to append to the runner Nix config
+    required: false
+    default: ''
+  extra-trusted-public-keys:
+    description: Optional newline-delimited extra trusted public keys to append to the runner Nix config
+    required: false
+    default: ''
 runs:
   using: composite
   steps:
@@ -23,3 +31,9 @@ runs:
       # TODO: Fix this
       # with:
       # use-gha-cache: enabled
+    - if: ${{ inputs.extra-substituters != '' || inputs.extra-trusted-public-keys != '' }}
+      shell: bash
+      env:
+        INPUT_EXTRA_SUBSTITUTERS: ${{ inputs.extra-substituters }}
+        INPUT_EXTRA_TRUSTED_PUBLIC_KEYS: ${{ inputs.extra-trusted-public-keys }}
+      run: $GITHUB_ACTION_PATH/configure-binary-cache.sh

--- a/.github/actions/nix-setup/configure-binary-cache.sh
+++ b/.github/actions/nix-setup/configure-binary-cache.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+substituters="${INPUT_EXTRA_SUBSTITUTERS:-}"
+trusted_keys="${INPUT_EXTRA_TRUSTED_PUBLIC_KEYS:-}"
+
+if [ -z "$substituters" ] && [ -z "$trusted_keys" ]; then
+  echo "No extra binary cache configuration requested."
+  exit 0
+fi
+
+mkdir -p "$HOME/.config/nix"
+config_path="$HOME/.config/nix/nix.conf"
+tmp_path="$(mktemp)"
+trap 'rm -f "$tmp_path"' EXIT
+cp "$config_path" "$tmp_path" 2>/dev/null || :
+
+append_unique_lines() {
+  local prefix="$1"
+  local lines="$2"
+  [ -n "$lines" ] || return 0
+
+  while IFS= read -r line; do
+    [ -n "$line" ] || continue
+    if grep -Fqx "$prefix = $line" "$tmp_path" 2>/dev/null; then
+      continue
+    fi
+    printf '%s = %s\n' "$prefix" "$line" >>"$tmp_path"
+  done <<<"$lines"
+}
+
+append_unique_lines "extra-substituters" "$substituters"
+append_unique_lines "extra-trusted-public-keys" "$trusted_keys"
+
+mv "$tmp_path" "$config_path"
+echo "Configured extra Nix binary caches in $config_path"

--- a/.github/actions/nix-setup/configure-binary-cache.sh
+++ b/.github/actions/nix-setup/configure-binary-cache.sh
@@ -11,7 +11,7 @@ fi
 
 mkdir -p "$HOME/.config/nix"
 config_path="$HOME/.config/nix/nix.conf"
-tmp_path="$(mktemp)"
+tmp_path="$(mktemp -t nix-config-XXXXXX)"
 trap 'rm -f "$tmp_path"' EXIT
 cp "$config_path" "$tmp_path" 2>/dev/null || :
 
@@ -55,7 +55,7 @@ append_config_values() {
   fi
 
   local clean_tmp
-  clean_tmp="$(mktemp)"
+  clean_tmp="$(mktemp -t nix-config-clean-XXXXXX)"
   if [ -f "$tmp_path" ]; then
     grep -Ev "^[[:space:]]*${key}[[:space:]]*=" "$tmp_path" >"$clean_tmp" || :
   fi

--- a/.github/actions/nix-setup/configure-binary-cache.sh
+++ b/.github/actions/nix-setup/configure-binary-cache.sh
@@ -15,22 +15,56 @@ tmp_path="$(mktemp)"
 trap 'rm -f "$tmp_path"' EXIT
 cp "$config_path" "$tmp_path" 2>/dev/null || :
 
-append_unique_lines() {
-  local prefix="$1"
-  local lines="$2"
-  [ -n "$lines" ] || return 0
+contains_element() {
+  local needle="$1"
+  shift
 
-  while IFS= read -r line; do
-    [ -n "$line" ] || continue
-    if grep -Fqx "$prefix = $line" "$tmp_path" 2>/dev/null; then
-      continue
+  local item
+  for item in "$@"; do
+    if [ "$item" = "$needle" ]; then
+      return 0
     fi
-    printf '%s = %s\n' "$prefix" "$line" >>"$tmp_path"
-  done <<<"$lines"
+  done
+
+  return 1
 }
 
-append_unique_lines "extra-substituters" "$substituters"
-append_unique_lines "extra-trusted-public-keys" "$trusted_keys"
+append_config_values() {
+  local key="$1"
+  local new_values="$2"
+  [ -n "$new_values" ] || return 0
+
+  local existing_value=""
+  if [ -f "$tmp_path" ]; then
+    existing_value="$({
+      grep -E "^[[:space:]]*${key}[[:space:]]*=" "$tmp_path" || :
+    } | tail -n 1 | cut -d '=' -f 2-)"
+  fi
+
+  local merged=()
+  local item=""
+  while IFS= read -r item; do
+    [ -n "$item" ] || continue
+    if ! contains_element "$item" "${merged[@]}"; then
+      merged+=("$item")
+    fi
+  done < <(printf '%s\n%s\n' "$existing_value" "$new_values" | tr -s '[:space:]' '\n')
+
+  if [ ${#merged[@]} -eq 0 ]; then
+    return 0
+  fi
+
+  local clean_tmp
+  clean_tmp="$(mktemp)"
+  if [ -f "$tmp_path" ]; then
+    grep -Ev "^[[:space:]]*${key}[[:space:]]*=" "$tmp_path" >"$clean_tmp" || :
+  fi
+  printf '%s = %s\n' "$key" "${merged[*]}" >>"$clean_tmp"
+  mv "$clean_tmp" "$tmp_path"
+}
+
+append_config_values "extra-substituters" "$substituters"
+append_config_values "extra-trusted-public-keys" "$trusted_keys"
 
 mv "$tmp_path" "$config_path"
 echo "Configured extra Nix binary caches in $config_path"

--- a/.github/actions/nix-setup/configure-binary-cache.sh
+++ b/.github/actions/nix-setup/configure-binary-cache.sh
@@ -45,7 +45,7 @@ append_config_values() {
   local item=""
   while IFS= read -r item; do
     [ -n "$item" ] || continue
-    if ! contains_element "$item" "${merged[@]}"; then
+    if ! contains_element "$item" ${merged[@]+"${merged[@]}"}; then
       merged+=("$item")
     fi
   done < <(printf '%s\n%s\n' "$existing_value" "$new_values" | tr -s '[:space:]' '\n')

--- a/.github/actions/push-attic-cache/action.yml
+++ b/.github/actions/push-attic-cache/action.yml
@@ -27,4 +27,4 @@ runs:
         INPUT_ATTIC_CACHE_NAME: ${{ inputs.attic-cache-name }}
         INPUT_ATTIC_TOKEN: ${{ inputs.attic-token }}
         INPUT_SERVER_NAME: ${{ inputs.server-name }}
-      run: $GITHUB_ACTION_PATH/main.sh
+      run: bash "${{ github.action_path }}/main.sh"

--- a/.github/actions/push-attic-cache/action.yml
+++ b/.github/actions/push-attic-cache/action.yml
@@ -1,0 +1,30 @@
+name: Push Attic Cache
+description: Log into an Attic server and push one flake output path into a binary cache
+inputs:
+  flake-attr:
+    description: Flake attribute to realize and push (for example .#packages.x86_64-linux.foo)
+    required: true
+  attic-endpoint:
+    description: Attic server endpoint (root URL, without cache name)
+    required: true
+  attic-cache-name:
+    description: Attic cache name to push into
+    required: true
+  attic-token:
+    description: Token with push permission for the target Attic cache
+    required: true
+  server-name:
+    description: Local Attic server alias used for attic login
+    required: false
+    default: ci
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      env:
+        INPUT_FLAKE_ATTR: ${{ inputs.flake-attr }}
+        INPUT_ATTIC_ENDPOINT: ${{ inputs.attic-endpoint }}
+        INPUT_ATTIC_CACHE_NAME: ${{ inputs.attic-cache-name }}
+        INPUT_ATTIC_TOKEN: ${{ inputs.attic-token }}
+        INPUT_SERVER_NAME: ${{ inputs.server-name }}
+      run: $GITHUB_ACTION_PATH/main.sh

--- a/.github/actions/push-attic-cache/main.sh
+++ b/.github/actions/push-attic-cache/main.sh
@@ -7,6 +7,11 @@ attic_cache_name="${INPUT_ATTIC_CACHE_NAME}"
 attic_token="${INPUT_ATTIC_TOKEN}"
 server_name="${INPUT_SERVER_NAME:-ci}"
 
+if [ -z "$attic_token" ]; then
+  echo "Attic token is empty (likely a fork PR). Skipping Attic cache push."
+  exit 0
+fi
+
 xdg_config_home_tmp="$(mktemp -d -t attic-config-XXXXXX)"
 export XDG_CONFIG_HOME="$xdg_config_home_tmp"
 trap 'rm -rf "$xdg_config_home_tmp"' EXIT

--- a/.github/actions/push-attic-cache/main.sh
+++ b/.github/actions/push-attic-cache/main.sh
@@ -7,9 +7,9 @@ attic_cache_name="${INPUT_ATTIC_CACHE_NAME}"
 attic_token="${INPUT_ATTIC_TOKEN}"
 server_name="${INPUT_SERVER_NAME:-ci}"
 
-xdg_config_home_tmp="$(mktemp -d)"
+xdg_config_home_tmp="$(mktemp -d -t attic-config-XXXXXX)"
 export XDG_CONFIG_HOME="$xdg_config_home_tmp"
-trap 'rm -rf "$XDG_CONFIG_HOME"' EXIT
+trap 'rm -rf "$xdg_config_home_tmp"' EXIT
 
 if [ -d "$HOME/.config/nix" ]; then
   mkdir -p "$XDG_CONFIG_HOME"
@@ -19,10 +19,9 @@ fi
 run_attic() {
   if command -v attic >/dev/null 2>&1; then
     attic "$@"
-    return 0
+  else
+    nix run nixpkgs#attic-client -- "$@"
   fi
-
-  nix run nixpkgs#attic-client -- "$@"
 }
 
 run_attic login "$server_name" "$attic_endpoint" "$attic_token"

--- a/.github/actions/push-attic-cache/main.sh
+++ b/.github/actions/push-attic-cache/main.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+flake_attr="${INPUT_FLAKE_ATTR}"
+attic_endpoint="${INPUT_ATTIC_ENDPOINT}"
+attic_cache_name="${INPUT_ATTIC_CACHE_NAME}"
+attic_token="${INPUT_ATTIC_TOKEN}"
+server_name="${INPUT_SERVER_NAME:-ci}"
+
+export PATH="$HOME/.nix-profile/bin:$PATH"
+if ! command -v attic >/dev/null 2>&1; then
+  nix profile install nixpkgs#attic-client
+  export PATH="$HOME/.nix-profile/bin:$PATH"
+fi
+
+mkdir -p "$HOME/.config/attic"
+attic login "$server_name" "$attic_endpoint" "$attic_token"
+
+echo "Realizing flake output for Attic push: $flake_attr"
+nix build "$flake_attr" --no-link --print-out-paths -L | attic push --stdin "$server_name:$attic_cache_name"

--- a/.github/actions/push-attic-cache/main.sh
+++ b/.github/actions/push-attic-cache/main.sh
@@ -7,6 +7,15 @@ attic_cache_name="${INPUT_ATTIC_CACHE_NAME}"
 attic_token="${INPUT_ATTIC_TOKEN}"
 server_name="${INPUT_SERVER_NAME:-ci}"
 
+xdg_config_home_tmp="$(mktemp -d)"
+export XDG_CONFIG_HOME="$xdg_config_home_tmp"
+trap 'rm -rf "$XDG_CONFIG_HOME"' EXIT
+
+if [ -d "$HOME/.config/nix" ]; then
+  mkdir -p "$XDG_CONFIG_HOME"
+  cp -R "$HOME/.config/nix" "$XDG_CONFIG_HOME/"
+fi
+
 run_attic() {
   if command -v attic >/dev/null 2>&1; then
     attic "$@"
@@ -16,7 +25,6 @@ run_attic() {
   nix run nixpkgs#attic-client -- "$@"
 }
 
-mkdir -p "$HOME/.config/attic"
 run_attic login "$server_name" "$attic_endpoint" "$attic_token"
 
 echo "Realizing flake output for Attic push: $flake_attr"

--- a/.github/actions/push-attic-cache/main.sh
+++ b/.github/actions/push-attic-cache/main.sh
@@ -7,14 +7,17 @@ attic_cache_name="${INPUT_ATTIC_CACHE_NAME}"
 attic_token="${INPUT_ATTIC_TOKEN}"
 server_name="${INPUT_SERVER_NAME:-ci}"
 
-export PATH="$HOME/.nix-profile/bin:$PATH"
-if ! command -v attic >/dev/null 2>&1; then
-  nix profile install nixpkgs#attic-client
-  export PATH="$HOME/.nix-profile/bin:$PATH"
-fi
+run_attic() {
+  if command -v attic >/dev/null 2>&1; then
+    attic "$@"
+    return 0
+  fi
+
+  nix run nixpkgs#attic-client -- "$@"
+}
 
 mkdir -p "$HOME/.config/attic"
-attic login "$server_name" "$attic_endpoint" "$attic_token"
+run_attic login "$server_name" "$attic_endpoint" "$attic_token"
 
 echo "Realizing flake output for Attic push: $flake_attr"
-nix build "$flake_attr" --no-link --print-out-paths -L | attic push --stdin "$server_name:$attic_cache_name"
+nix build "$flake_attr" --no-link --print-out-paths -L | run_attic push --stdin "$server_name:$attic_cache_name"

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "github>jmmaloney4/.github//renovate/default.json5"
+  ],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "description": "Track pinned nix run github: refs in shell scripts",
+      "fileMatch": ["\\.sh$"],
+      "matchStrings": [
+        "nix (?:-\\w+ )*run github:(?<depName>[^#/]+)/(?<packageName>[^#/]+)/(?<currentValue>v?\\d+(?:\\.\\d+)*)"
+      ],
+      "datasourceTemplate": "github-tags"
+    }
+  ]
+}

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -9,7 +9,7 @@
       "description": "Track pinned nix run github: refs in shell scripts",
       "fileMatch": ["\\.sh$"],
       "matchStrings": [
-        "nix (?:-\\w+ )*run github:(?<depName>[^#/]+)/(?<packageName>[^#/]+)/(?<currentValue>v?\\d+(?:\\.\\d+)*)"
+        "nix (?:-\\w+ )*run github:(?<depName>[^#/]+/[^#/]+)/(?<currentValue>v?\\d+(?:\\.\\d+)*)"
       ],
       "datasourceTemplate": "github-tags"
     }

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,17 +1,15 @@
 {
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "github>jmmaloney4/.github//renovate/default.json5"
-  ],
-  "customManagers": [
-    {
-      "customType": "regex",
-      "description": "Track pinned nix run github: refs in shell scripts",
-      "fileMatch": ["\\.sh$"],
-      "matchStrings": [
-        "nix (?:-\\w+ )*run github:(?<depName>[^#/]+/[^#/]+)/(?<currentValue>v?\\d+(?:\\.\\d+)*)"
-      ],
-      "datasourceTemplate": "github-tags"
-    }
-  ]
+	"$schema": "https://docs.renovatebot.com/renovate-schema.json",
+	"extends": ["github>jmmaloney4/.github//renovate/default.json5"],
+	"customManagers": [
+		{
+			"customType": "regex",
+			"description": "Track pinned nix run github: refs in shell scripts",
+			"fileMatch": ["\\.sh$"],
+			"matchStrings": [
+				"nix (?:-\\w+ )*run github:(?<depName>[^#/]+/[^#/]+)/(?<currentValue>v?\\d+(?:\\.\\d+)*)"
+			],
+			"datasourceTemplate": "github-tags"
+		}
+	]
 }

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -5,7 +5,7 @@
 		{
 			"customType": "regex",
 			"description": "Track pinned nix run github: refs in shell scripts",
-			"fileMatch": ["\\.sh$"],
+			"managerFilePatterns": ["/\\.sh$/"],
 			"matchStrings": [
 				"nix (?:-\\w+ )*run github:(?<depName>[^#/]+/[^#/]+)/(?<currentValue>v?\\d+(?:\\.\\d+)*)"
 			],

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -20,9 +20,32 @@ on:
         required: false
         default: 'cavinsresearch'
         type: string
+      binary-cache-url:
+        description: 'Optional full binary cache URL to add as a substituter (for example https://cache.example.com/cache)'
+        required: false
+        default: ''
+        type: string
+      binary-cache-public-key:
+        description: 'Optional trusted public key for the binary cache'
+        required: false
+        default: ''
+        type: string
+      binary-cache-endpoint:
+        description: 'Optional Attic server endpoint (root URL) used for cache pushes'
+        required: false
+        default: ''
+        type: string
+      binary-cache-name:
+        description: 'Optional Attic cache name used for cache pushes'
+        required: false
+        default: ''
+        type: string
     secrets:
       REGISTRY_PASSWORD:
         description: 'Registry password/token (usually GITHUB_TOKEN)'
+        required: false
+      BINARY_CACHE_TOKEN:
+        description: 'Optional Attic token used to push built store paths into the binary cache'
         required: false
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -47,12 +70,16 @@ jobs:
       - uses: jmmaloney4/sector7/.github/actions/nix-setup@main
         with:
           runs-on: ${{ inputs.runs-on }}
-          cache: ${{ !contains(inputs.runs-on, 'self-hosted') }}
+          cache: ${{ !contains(inputs.runs-on, 'self-hosted') && inputs.binary-cache-url == '' }}
+          extra-substituters: ${{ inputs.binary-cache-url }}
+          extra-trusted-public-keys: ${{ inputs.binary-cache-public-key }}
       - name: compute build-needed matrix via nix-eval-jobs
         id: compute
         uses: jmmaloney4/sector7/.github/actions/compute-flake-build-matrix@main
         with:
           probe-timeout-seconds: '180'
+          extra-substituters: ${{ inputs.binary-cache-url }}
+          extra-trusted-public-keys: ${{ inputs.binary-cache-public-key }}
       - name: split build and image matrices
         id: split
         shell: 'nix shell nixpkgs#jq -c bash {0}'
@@ -85,19 +112,29 @@ jobs:
       - uses: jmmaloney4/sector7/.github/actions/nix-setup@main
         with:
           runs-on: ${{ inputs.runs-on }}
-          cache: ${{ !contains(inputs.runs-on, 'self-hosted') }}
+          cache: ${{ !contains(inputs.runs-on, 'self-hosted') && inputs.binary-cache-url == '' }}
+          extra-substituters: ${{ inputs.binary-cache-url }}
+          extra-trusted-public-keys: ${{ inputs.binary-cache-public-key }}
       - name: "🚀 build with nix-fast-build"
         shell: 'nix -L shell nixpkgs#nix-fast-build -c bash {0}'
         run: |-
           set -euo pipefail
           attr='${{ matrix.flake_attr }}'
           echo "Building via nix-fast-build: $attr"
-          # Build only missing (uncached) derivations, with CI-friendly logs and no out-link
           nix-fast-build --skip-cached --no-nom --no-link -j 1 --flake "$attr"
+      - name: Push built store paths to binary cache
+        if: ${{ inputs.binary-cache-endpoint != '' && inputs.binary-cache-name != '' && env.BINARY_CACHE_TOKEN != '' }}
+        env:
+          BINARY_CACHE_TOKEN: ${{ secrets.BINARY_CACHE_TOKEN }}
+        uses: jmmaloney4/sector7/.github/actions/push-attic-cache@main
+        with:
+          flake-attr: ${{ matrix.flake_attr }}
+          attic-endpoint: ${{ inputs.binary-cache-endpoint }}
+          attic-cache-name: ${{ inputs.binary-cache-name }}
+          attic-token: ${{ env.BINARY_CACHE_TOKEN }}
   build-and-push-images:
     name: "🐳 build+push ${{ matrix.package-name }}"
     needs: [detect]
-    # Only run if there are actually images to push
     if: ${{ needs.detect.outputs.images_to_push != '[]' }}
     strategy:
       fail-fast: false
@@ -110,7 +147,11 @@ jobs:
       namespace: ${{ inputs.image-namespace }}
       repository: ${{ inputs.repository }}
       ref: ${{ inputs.ref }}
-      # Tag with PR number if PR, otherwise SHA + branch/latest
       tags: ${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.number) || format('sha-{0},{1}{2}', github.sha, github.ref_name, github.ref_name == 'main' && ',latest' || '') }}
+      binary-cache-url: ${{ inputs.binary-cache-url }}
+      binary-cache-public-key: ${{ inputs.binary-cache-public-key }}
+      binary-cache-endpoint: ${{ inputs.binary-cache-endpoint }}
+      binary-cache-name: ${{ inputs.binary-cache-name }}
     secrets:
       REGISTRY_PASSWORD: ${{ secrets.REGISTRY_PASSWORD || secrets.GITHUB_TOKEN }}
+      BINARY_CACHE_TOKEN: ${{ secrets.BINARY_CACHE_TOKEN }}

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -99,6 +99,8 @@ jobs:
     needs: [detect]
     runs-on: ${{ startsWith(inputs.runs-on, '[') && fromJson(inputs.runs-on) || inputs.runs-on }}
     if: ${{ needs.detect.outputs.build_has_work == 'true' }}
+    env:
+      BINARY_CACHE_TOKEN: ${{ secrets.BINARY_CACHE_TOKEN }}
     strategy:
       fail-fast: false
       max-parallel: 1
@@ -124,8 +126,6 @@ jobs:
           nix-fast-build --skip-cached --no-nom --no-link -j 1 --flake "$attr"
       - name: Push built store paths to binary cache
         if: ${{ inputs.binary-cache-endpoint != '' && inputs.binary-cache-name != '' && env.BINARY_CACHE_TOKEN != '' }}
-        env:
-          BINARY_CACHE_TOKEN: ${{ secrets.BINARY_CACHE_TOKEN }}
         uses: jmmaloney4/sector7/.github/actions/push-attic-cache@main
         with:
           flake-attr: ${{ matrix.flake_attr }}

--- a/.github/workflows/push-nix-image.yml
+++ b/.github/workflows/push-nix-image.yml
@@ -40,6 +40,26 @@ on:
         description: 'Git ref to checkout'
         required: true
         type: string
+      binary-cache-url:
+        description: 'Optional full binary cache URL to add as a substituter'
+        required: false
+        type: string
+        default: ''
+      binary-cache-public-key:
+        description: 'Optional trusted public key for the binary cache'
+        required: false
+        type: string
+        default: ''
+      binary-cache-endpoint:
+        description: 'Optional Attic server endpoint (root URL) for cache pushes'
+        required: false
+        type: string
+        default: ''
+      binary-cache-name:
+        description: 'Optional Attic cache name for cache pushes'
+        required: false
+        type: string
+        default: ''
     secrets:
       REGISTRY_USERNAME:
         description: 'Registry username (defaults to github.actor)'
@@ -47,6 +67,9 @@ on:
       REGISTRY_PASSWORD:
         description: 'Registry password/token (usually GITHUB_TOKEN)'
         required: true
+      BINARY_CACHE_TOKEN:
+        description: 'Optional Attic token used to push built store paths into the binary cache'
+        required: false
 jobs:
   push-image:
     runs-on: ${{ startsWith(inputs.runs-on, '[') && fromJson(inputs.runs-on) || inputs.runs-on }}
@@ -64,7 +87,9 @@ jobs:
         uses: jmmaloney4/sector7/.github/actions/nix-setup@main
         with:
           runs-on: ${{ inputs.runs-on }}
-          cache: ${{ !contains(inputs.runs-on, 'self-hosted') }}
+          cache: ${{ !contains(inputs.runs-on, 'self-hosted') && inputs.binary-cache-url == '' }}
+          extra-substituters: ${{ inputs.binary-cache-url }}
+          extra-trusted-public-keys: ${{ inputs.binary-cache-public-key }}
       - name: Push Nix Image
         uses: jmmaloney4/sector7/.github/actions/push-nix-image@main
         with:
@@ -76,3 +101,13 @@ jobs:
           system: ${{ inputs.system }}
           registry-username: ${{ secrets.REGISTRY_USERNAME || github.actor }}
           registry-password: ${{ secrets.REGISTRY_PASSWORD }}
+      - name: Push image derivation to binary cache
+        if: ${{ inputs.binary-cache-endpoint != '' && inputs.binary-cache-name != '' && env.BINARY_CACHE_TOKEN != '' }}
+        env:
+          BINARY_CACHE_TOKEN: ${{ secrets.BINARY_CACHE_TOKEN }}
+        uses: jmmaloney4/sector7/.github/actions/push-attic-cache@main
+        with:
+          flake-attr: ${{ format('.#packages.{0}.{1}', inputs.system, inputs.package-name) }}
+          attic-endpoint: ${{ inputs.binary-cache-endpoint }}
+          attic-cache-name: ${{ inputs.binary-cache-name }}
+          attic-token: ${{ env.BINARY_CACHE_TOKEN }}

--- a/.github/workflows/push-nix-image.yml
+++ b/.github/workflows/push-nix-image.yml
@@ -73,6 +73,8 @@ on:
 jobs:
   push-image:
     runs-on: ${{ startsWith(inputs.runs-on, '[') && fromJson(inputs.runs-on) || inputs.runs-on }}
+    env:
+      BINARY_CACHE_TOKEN: ${{ secrets.BINARY_CACHE_TOKEN }}
     permissions:
       contents: read
       packages: write
@@ -103,8 +105,6 @@ jobs:
           registry-password: ${{ secrets.REGISTRY_PASSWORD }}
       - name: Push image derivation to binary cache
         if: ${{ inputs.binary-cache-endpoint != '' && inputs.binary-cache-name != '' && env.BINARY_CACHE_TOKEN != '' }}
-        env:
-          BINARY_CACHE_TOKEN: ${{ secrets.BINARY_CACHE_TOKEN }}
         uses: jmmaloney4/sector7/.github/actions/push-attic-cache@main
         with:
           flake-attr: ${{ format('.#packages.{0}.{1}', inputs.system, inputs.package-name) }}

--- a/README.md
+++ b/README.md
@@ -53,6 +53,28 @@ jobs:
       ref: ${{ github.ref }}
 ```
 
+#### Optional Attic binary cache inputs
+
+When a caller has a private or self-hosted Attic cache, pass the cache explicitly instead of teaching Sector7 about your runner topology:
+
+```yaml
+jobs:
+  nix:
+    uses: jmmaloney4/sector7/.github/workflows/nix.yml@main
+    with:
+      runs-on: '["self-hosted","room-of-requirement"]'
+      repository: ${{ github.repository }}
+      ref: ${{ github.ref }}
+      binary-cache-url: ${{ vars.ATTIC_CACHE_URL }}
+      binary-cache-public-key: ${{ vars.ATTIC_CACHE_PUBLIC_KEY }}
+      binary-cache-endpoint: ${{ vars.ATTIC_SERVER_URL }}
+      binary-cache-name: ${{ vars.ATTIC_CACHE_NAME }}
+    secrets:
+      BINARY_CACHE_TOKEN: ${{ secrets.ATTIC_CACHE_TOKEN }}
+```
+
+`binary-cache-url` is the full Nix substituter URL (for example `https://attic.example.com/cache`). `binary-cache-endpoint` is the Attic server root URL used for `attic login` before pushes.
+
 ### Pulumi Components
 
 Install the Pulumi package:

--- a/docs/internal/designs/028-uptime-monitor-read-api.md
+++ b/docs/internal/designs/028-uptime-monitor-read-api.md
@@ -1,11 +1,12 @@
 ---
 id: ADR-028
-title: "Uptime Monitor Read Api"
+title: Uptime Monitor Read Api
 status: proposed
 date: 2026-05-24
 ---
 
 # ADR 028: Uptime Monitor Read Api
+
 *Date:* 2026-05-24
 *Status:* proposed
 

--- a/docs/public/workflows.md
+++ b/docs/public/workflows.md
@@ -45,6 +45,13 @@ jobs:
   - **runs-on**: Runner label (e.g., `ubuntu-latest` or your self-hosted label). For multiple labels, pass a JSON array string like `["self-hosted","linux","x64"]`.
   - **repository**: Repository to build (`owner/repo`), typically `${{ github.repository }}`
   - **ref**: Git ref to build, typically `${{ github.ref }}`
+- **Optional inputs**:
+  - **binary-cache-url**: Full substituter URL for an extra binary cache (for example `https://attic.example.com/cache`)
+  - **binary-cache-public-key**: Trusted public key for that binary cache
+  - **binary-cache-endpoint**: Attic server root URL used for `attic login` before cache pushes
+  - **binary-cache-name**: Attic cache name used for cache pushes
+- **Optional secrets**:
+  - **BINARY_CACHE_TOKEN**: Attic token with push permission for `binary-cache-name`
 
 #### Minimal consumer workflow (copy-paste)
 
@@ -87,6 +94,30 @@ jobs:
       repository: ${{ github.repository }}
       ref: ${{ github.ref }}
 ```
+
+#### Attic-backed binary cache example
+
+```yaml
+jobs:
+  nix:
+    uses: jmmaloney4/sector7/.github/workflows/nix.yml@main
+    with:
+      runs-on: '["self-hosted","room-of-requirement"]'
+      repository: ${{ github.repository }}
+      ref: ${{ github.ref }}
+      binary-cache-url: ${{ vars.ATTIC_CACHE_URL }}
+      binary-cache-public-key: ${{ vars.ATTIC_CACHE_PUBLIC_KEY }}
+      binary-cache-endpoint: ${{ vars.ATTIC_SERVER_URL }}
+      binary-cache-name: ${{ vars.ATTIC_CACHE_NAME }}
+    secrets:
+      BINARY_CACHE_TOKEN: ${{ secrets.ATTIC_CACHE_TOKEN }}
+```
+
+This contract keeps the reusable workflow generic:
+
+- placement stays in the caller's `runs-on`
+- the caller decides which cache to use
+- Sector7 only wires the supplied cache into `nix.conf`, cache probing, and post-build Attic pushes
 
 ### 📦 `pnpm.yml`
 
@@ -138,20 +169,23 @@ jobs:
   - **google_service_account_email**: GCP service account email
   - **pulumi_backend_url**: GCS bucket URL for Pulumi backend (e.g., `gs://my-bucket-name`)
 - **Optional inputs**:
-  - **pr_number**: Pull request number for commenting (pass `0` or omit for non-PR triggers)
-  - **is_fork**: Whether the PR comes from a fork (affects commenting permissions)
+  - **runs-on**: Runner label (defaults to `ubuntu-latest`)
+  - **stack-filter**: Regex to limit which stack directories run
+  - **stack-config-passphrase**: Passphrase for Pulumi secrets when using passphrase backend
+  - **nodejs_package_manager**: `pnpm`, `npm`, or `none`
+  - **pr_number**: Pull request number for comment posting
+  - **is_fork**: Whether the PR comes from a fork
+  - **preview_only**: Skip `pulumi up` on pushes and run previews only
+  - **working_directory**: Relative path to the Pulumi project root inside the caller repo
 
 #### Minimal consumer workflow (copy-paste)
 
 ```yaml
-name: ☁️ pulumi
-
+name: '☁️ pulumi'
 on:
   push:
     branches:
     - main
-    tags:
-    - 'v*'
   pull_request:
   workflow_dispatch:
 

--- a/packages/sector7/litellm/admin.ts
+++ b/packages/sector7/litellm/admin.ts
@@ -59,12 +59,10 @@ export class LiteLLMApiKey extends pulumi.ComponentResource {
 					LITELLM_KEY_TEAM_ID: pulumi.output(args.teamId ?? ""),
 					LITELLM_KEY_USER_ID: pulumi.output(args.userId ?? ""),
 					LITELLM_KEY_BUDGET_ID: pulumi.output(args.budgetId ?? ""),
-					LITELLM_KEY_MAX_BUDGET: pulumi.output(args.maxBudget).apply((value) =>
-						value === undefined ? "" : String(value),
-					),
-					LITELLM_KEY_BUDGET_DURATION: pulumi.output(
-						args.budgetDuration ?? "",
-					),
+					LITELLM_KEY_MAX_BUDGET: pulumi
+						.output(args.maxBudget)
+						.apply((value) => (value === undefined ? "" : String(value))),
+					LITELLM_KEY_BUDGET_DURATION: pulumi.output(args.budgetDuration ?? ""),
 					LITELLM_KEY_DURATION: pulumi.output(args.duration ?? ""),
 					LITELLM_KEY_ALIASES_JSON: pulumiJsonString(args.aliases, {}),
 					LITELLM_KEY_TAGS_JSON: pulumiJsonString(args.tags, []),
@@ -75,9 +73,9 @@ export class LiteLLMApiKey extends pulumi.ComponentResource {
 		);
 
 		this.key = pulumi.secret(actualKey);
-		this.tokenId = pulumi.secret(commandResource.stdout).apply((stdout) =>
-			stdout.trim(),
-		);
+		this.tokenId = pulumi
+			.secret(commandResource.stdout)
+			.apply((stdout) => stdout.trim());
 
 		this.registerOutputs({
 			key: this.key,
@@ -107,9 +105,9 @@ export class LiteLLMTeam extends pulumi.ComponentResource {
 					LITELLM_TEAM_ALIAS: args.teamAlias,
 					LITELLM_TEAM_ID: pulumi.output(args.teamId ?? ""),
 					LITELLM_TEAM_MODELS_JSON: pulumiJsonString(args.models, []),
-					LITELLM_TEAM_MAX_BUDGET: pulumi.output(args.maxBudget).apply((value) =>
-						value === undefined ? "" : String(value),
-					),
+					LITELLM_TEAM_MAX_BUDGET: pulumi
+						.output(args.maxBudget)
+						.apply((value) => (value === undefined ? "" : String(value))),
 					LITELLM_TEAM_BUDGET_DURATION: pulumi.output(
 						args.budgetDuration ?? "",
 					),

--- a/packages/sector7/litellm/config.ts
+++ b/packages/sector7/litellm/config.ts
@@ -218,7 +218,9 @@ export function generateLiteLLMConfig(args: {
 	validateLiteLLMConfig(args);
 
 	const providerEnvVars = Object.entries(args.providers)
-		.map(([providerName, provider]) => getProviderEnvVar(providerName, provider))
+		.map(([providerName, provider]) =>
+			getProviderEnvVar(providerName, provider),
+		)
 		.filter((value): value is string => value !== undefined);
 	const deploymentsById = new Map(
 		args.deployments.map((deployment) => [deployment.id, deployment] as const),
@@ -290,11 +292,7 @@ export function generateLiteLLMConfig(args: {
 				"output_cost_per_token",
 				deployment.outputCostPerToken,
 			);
-			addIfDefined(
-				modelInfo,
-				"team_id",
-				deployment.teamId ?? group.teamId,
-			);
+			addIfDefined(modelInfo, "team_id", deployment.teamId ?? group.teamId);
 			addIfDefined(
 				modelInfo,
 				"team_alias",

--- a/packages/sector7/litellm/index.ts
+++ b/packages/sector7/litellm/index.ts
@@ -1,3 +1,4 @@
+export { LiteLLMApiKey, LiteLLMTeam } from "./admin.ts";
 export { generateLiteLLMConfig } from "./config.ts";
 export type {
 	BuildLiteLLMTeamScopedModelGroupsArgs,
@@ -19,6 +20,5 @@ export type {
 	LiteLLMTeamCapability,
 	LiteLLMTeamDefinition,
 } from "./config-types.ts";
-export { LiteLLMApiKey, LiteLLMTeam } from "./admin.ts";
 export { LiteLLMProxy } from "./litellm-proxy.ts";
 export { buildLiteLLMTeamScopedModelGroups } from "./team-plan.ts";

--- a/packages/sector7/nix-output/nix-output.ts
+++ b/packages/sector7/nix-output/nix-output.ts
@@ -64,7 +64,9 @@ function parseStorePath(stdout: string, name: string): string {
 		.split(/\r?\n/)
 		.find((entry) => entry.startsWith(prefix));
 	if (!line) {
-		throw new Error(`Could not parse STORE_PATH_OUTPUT from output for ${name}`);
+		throw new Error(
+			`Could not parse STORE_PATH_OUTPUT from output for ${name}`,
+		);
 	}
 	return line.slice(prefix.length);
 }

--- a/packages/sector7/pulumi-config/index.ts
+++ b/packages/sector7/pulumi-config/index.ts
@@ -1,8 +1,8 @@
 export {
-	requireMixedConfig,
 	type ArrayConfigOptions,
 	type FlatSecretsOptions,
 	type MapConfigOptions,
 	type RecordConfigOptions,
+	requireMixedConfig,
 	type SecretFieldsOf,
 } from "./mixed-config.js";

--- a/packages/sector7/pulumi-config/mixed-config.ts
+++ b/packages/sector7/pulumi-config/mixed-config.ts
@@ -1,4 +1,4 @@
-import * as pulumi from "@pulumi/pulumi";
+import type * as pulumi from "@pulumi/pulumi";
 
 export type SecretFieldsOf<
 	T extends Record<string, unknown>,

--- a/packages/sector7/scripts/litellm-admin.sh
+++ b/packages/sector7/scripts/litellm-admin.sh
@@ -5,7 +5,7 @@ ACTION="${1:-}"
 
 require_env() {
   local name="$1"
-  if [[ -z "${!name:-}" ]]; then
+  if [[ -z ${!name:-} ]]; then
     echo "missing required env: $name" >&2
     exit 1
   fi
@@ -89,10 +89,11 @@ require_env LITELLM_MASTER_KEY
 require_env LITELLM_PROXY_DEPLOYMENT
 
 case "$ACTION" in
-  create-key)
-    require_env LITELLM_KEY_ALIAS
-    require_env LITELLM_KEY_VALUE
-    body=$(python3 - <<'PYEOF'
+create-key)
+  require_env LITELLM_KEY_ALIAS
+  require_env LITELLM_KEY_VALUE
+  body=$(
+    python3 - <<'PYEOF'
 import json
 import os
 
@@ -121,23 +122,24 @@ for env_key, body_key in [
         body[body_key] = value
 print(json.dumps(body))
 PYEOF
-)
-    response=$(run_proxy_python "$(printf '%s' "$body" | base64)" "/key/generate")
-    extract_field "$response" "token"
-    ;;
+  )
+  response=$(run_proxy_python "$(printf '%s' "$body" | base64)" "/key/generate")
+  extract_field "$response" "token"
+  ;;
 
-  delete-key)
-    token_id="${PULUMI_COMMAND_STDOUT:-${LITELLM_KEY_VALUE:-}}"
-    if [[ -z "$token_id" ]]; then
-      exit 0
-    fi
-    body=$(printf '{"keys":["%s"]}' "$token_id")
-    run_proxy_python "$(printf '%s' "$body" | base64)" "/key/delete" >/dev/null
-    ;;
+delete-key)
+  token_id="${PULUMI_COMMAND_STDOUT:-${LITELLM_KEY_VALUE:-}}"
+  if [[ -z $token_id ]]; then
+    exit 0
+  fi
+  body=$(printf '{"keys":["%s"]}' "$token_id")
+  run_proxy_python "$(printf '%s' "$body" | base64)" "/key/delete" >/dev/null
+  ;;
 
-  create-team)
-    require_env LITELLM_TEAM_ALIAS
-    body=$(python3 - <<'PYEOF'
+create-team)
+  require_env LITELLM_TEAM_ALIAS
+  body=$(
+    python3 - <<'PYEOF'
 import json
 import os
 
@@ -161,22 +163,22 @@ for env_key, body_key in [
         body[body_key] = value
 print(json.dumps(body))
 PYEOF
-)
-    response=$(run_proxy_python "$(printf '%s' "$body" | base64)" "/team/new")
-    extract_field "$response" "team_id"
-    ;;
+  )
+  response=$(run_proxy_python "$(printf '%s' "$body" | base64)" "/team/new")
+  extract_field "$response" "team_id"
+  ;;
 
-  delete-team)
-    team_id="${LITELLM_TEAM_ID:-${PULUMI_COMMAND_STDOUT:-}}"
-    if [[ -z "$team_id" ]]; then
-      exit 0
-    fi
-    body=$(printf '{"team_ids":["%s"]}' "$team_id")
-    run_proxy_python "$(printf '%s' "$body" | base64)" "/team/delete" >/dev/null
-    ;;
+delete-team)
+  team_id="${LITELLM_TEAM_ID:-${PULUMI_COMMAND_STDOUT:-}}"
+  if [[ -z $team_id ]]; then
+    exit 0
+  fi
+  body=$(printf '{"team_ids":["%s"]}' "$team_id")
+  run_proxy_python "$(printf '%s' "$body" | base64)" "/team/delete" >/dev/null
+  ;;
 
-  *)
-    echo "usage: $0 {create-key|delete-key|create-team|delete-team}" >&2
-    exit 1
-    ;;
+*)
+  echo "usage: $0 {create-key|delete-key|create-team|delete-team}" >&2
+  exit 1
+  ;;
 esac

--- a/packages/sector7/scripts/nix-image-build-push.sh
+++ b/packages/sector7/scripts/nix-image-build-push.sh
@@ -98,7 +98,7 @@ chmod 600 "${AUTH_FILE}"
 if [ "${SCRIPT_MODE}" = "resolve" ]; then
   # Resolve-only: inspect the already-pushed image to get its digest
   echo "--- resolving digest ---"
-  nix run github:nlewo/nix2container#skopeo-nix2container -- \
+  nix run github:nlewo/nix2container/v1.0.0#skopeo-nix2container -- \
     --insecure-policy inspect --format '{{.Digest}}' \
     --authfile "${AUTH_FILE}" \
     docker://"${FULL_TAG}" |
@@ -115,7 +115,7 @@ else
 
   # Push the image
   echo "--- skopeo copy ---"
-  nix run github:nlewo/nix2container#skopeo-nix2container -- \
+  nix run github:nlewo/nix2container/v1.0.0#skopeo-nix2container -- \
     --insecure-policy copy --digestfile "${DIGEST_FILE}" \
     --authfile "${AUTH_FILE}" \
     "${IMAGE_PATH}" \

--- a/packages/sector7/scripts/nix-image-push.sh
+++ b/packages/sector7/scripts/nix-image-push.sh
@@ -85,7 +85,7 @@ chmod 600 "${AUTH_FILE}"
 
 if [ "${SCRIPT_MODE}" = "resolve" ]; then
   echo "--- resolving digest ---"
-  nix run github:nlewo/nix2container#skopeo-nix2container -- \
+  nix run github:nlewo/nix2container/v1.0.0#skopeo-nix2container -- \
     --insecure-policy inspect --format '{{.Digest}}' \
     --authfile "${AUTH_FILE}" \
     docker://"${FULL_TAG}" |
@@ -95,7 +95,7 @@ else
   IMAGE_PATH="nix:${STORE_PATH}"
 
   echo "--- skopeo copy ---"
-  nix run github:nlewo/nix2container#skopeo-nix2container -- \
+  nix run github:nlewo/nix2container/v1.0.0#skopeo-nix2container -- \
     --insecure-policy copy --digestfile "${DIGEST_FILE}" \
     --authfile "${AUTH_FILE}" \
     "${IMAGE_PATH}" \

--- a/packages/sector7/tests/mixed-config.test.ts
+++ b/packages/sector7/tests/mixed-config.test.ts
@@ -109,10 +109,7 @@ describe("requireMixedConfig", () => {
 	it("reads array-shaped config with plain and secret fields", async () => {
 		const config = fakeConfig({
 			objects: {
-				accounts: [
-					{ name: "jmmaloney4" },
-					{ name: "cavinsresearch" },
-				],
+				accounts: [{ name: "jmmaloney4" }, { name: "cavinsresearch" }],
 			},
 			secrets: {
 				"accounts[0].apiToken": "jmm-secret",

--- a/packages/sector7/tests/nix-output.test.ts
+++ b/packages/sector7/tests/nix-output.test.ts
@@ -266,9 +266,11 @@ describe("NixOutput", () => {
 	});
 
 	it("eager preview helper resolves a concrete store path when env is static", () => {
-		const execSpy = vi.mocked(execFileSync).mockReturnValue(
-			"=== Resolved: /nix/store/eager123-myapp-1.0.0 ===\nSTORE_PATH_OUTPUT:/nix/store/eager123-myapp-1.0.0\n",
-		);
+		const execSpy = vi
+			.mocked(execFileSync)
+			.mockReturnValue(
+				"=== Resolved: /nix/store/eager123-myapp-1.0.0 ===\nSTORE_PATH_OUTPUT:/nix/store/eager123-myapp-1.0.0\n",
+			);
 
 		const storePath = resolvePreviewStorePath(
 			"test-preview-eager",

--- a/packages/sector7/tests/renovate-nix-regex.test.ts
+++ b/packages/sector7/tests/renovate-nix-regex.test.ts
@@ -3,7 +3,10 @@ import { resolve } from "node:path";
 import { describe, expect, it } from "vitest";
 
 const nixConfig = JSON.parse(
-	readFileSync(resolve(import.meta.dirname, "../../../renovate/nix.json"), "utf8"),
+	readFileSync(
+		resolve(import.meta.dirname, "../../../renovate/nix.json"),
+		"utf8",
+	),
 ) as {
 	customManagers: Array<{
 		description: string;

--- a/renovate/default.json
+++ b/renovate/default.json
@@ -10,9 +10,7 @@
 		":enableVulnerabilityAlertsWithLabel(security)",
 		":pinAllExceptPeerDependencies"
 	],
-	"schedule": [
-		"before 4:00 am"
-	],
+	"schedule": ["before 4:00 am"],
 	"prHourlyLimit": 10,
 	"prConcurrentLimit": 5,
 	"rebaseWhen": "conflicted",
@@ -21,16 +19,11 @@
 	"platformAutomerge": false,
 	"dependencyDashboard": true,
 	"dependencyDashboardTitle": "Renovate Dashboard \ud83e\udd16",
-	"dependencyDashboardLabels": [
-		"chore/deps"
-	],
+	"dependencyDashboardLabels": ["chore/deps"],
 	"rangeStrategy": "pin",
 	"minimumReleaseAge": "4 days",
 	"pinDigests": true,
-	"labels": [
-		"chore/deps",
-		"renovate"
-	],
+	"labels": ["chore/deps", "renovate"],
 	"commitMessagePrefix": "deps: ",
 	"commitMessageAction": "update",
 	"prHeader": "This PR contains dependency updates managed by Renovate.",
@@ -38,12 +31,7 @@
 	"vulnerabilityAlerts": {
 		"enabled": true,
 		"automerge": true,
-		"addLabels": [
-			"security",
-			"vulnerability",
-			"deps/security",
-			"renovate"
-		]
+		"addLabels": ["security", "vulnerability", "deps/security", "renovate"]
 	},
 	"nix": {
 		"enabled": true
@@ -51,17 +39,13 @@
 	"packageRules": [
 		{
 			"description": "Skip pinning and stability days for internal sector7 actions (own repo)",
-			"matchPackageNames": [
-				"/^jmmaloney4\\/sector7($|\\/)/"
-			],
+			"matchPackageNames": ["/^jmmaloney4\\/sector7($|\\/)/"],
 			"minimumReleaseAge": null,
 			"pinDigests": false
 		},
 		{
 			"description": "Disable requires-python updates \u2014 managed manually per project as a capped minor range (e.g. >=3.13,<3.14)",
-			"matchDepTypes": [
-				"requires-python"
-			],
+			"matchDepTypes": ["requires-python"],
 			"enabled": false
 		}
 	]


### PR DESCRIPTION
## Summary
- add explicit binary-cache inputs to the reusable Nix workflows instead of inferring cache behavior from `self-hosted`
- teach `nix-setup` and `compute-flake-build-matrix` to honor caller-supplied substituters and trusted public keys
- add a small `push-attic-cache` action so build jobs can push realized store paths back into Attic
- document the new caller contract in the README and workflow docs

## Why
Garden's Attic cache is already deployed, but Sector7 had no way to consume it without hard-coding repo- or runner-specific assumptions into the shared workflow layer. The right boundary is explicit cache configuration from the caller:

- caller chooses runner placement
- caller chooses cache URL/public key/token
- Sector7 only wires the supplied cache into Nix and post-build pushes

## Test Plan
- [x] `nix shell nixpkgs#actionlint nixpkgs#shellcheck --command /tmp/validate-sector7-attic-cache.sh`
- [x] verified the reusable workflow shape with `actionlint`
- [x] verified the new shell actions with `shellcheck -e SC2016`

## Risks / Follow-ups
- caller repositories need to pass the new Attic inputs explicitly; this PR does not auto-discover cache topology
- Garden follow-on wiring is tracked in jmmaloney4/garden#678 and consumes this branch/ref until this PR merges

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes shared CI cache setup and optional secret-driven Attic pushes; misconfigured URLs/keys could break builds or push to the wrong cache, though behavior stays opt-in per caller.
> 
> **Overview**
> Adds an **explicit Attic/binary-cache contract** to the reusable Nix workflows so callers pass substituter URL, trusted public key, Attic server endpoint, cache name, and optional `BINARY_CACHE_TOKEN` instead of Sector7 inferring cache behavior from runner labels.
> 
> **`nix-setup`** gains optional `extra-substituters` / `extra-trusted-public-keys` and a new `configure-binary-cache.sh` step that deduplicates and appends those values to `nix.conf`. **`compute-flake-build-matrix`** accepts the same extras for `nix-eval-jobs` cache probing, pins **`nix-eval-jobs` to `v2.34.1`**, and simplifies flake attr parsing to the 2-part shape from `select.nix`. A new **`push-attic-cache`** composite action logs into Attic, realizes a flake attr, and pushes store paths (no-op when the token is empty, e.g. fork PRs).
> 
> **`nix.yml`** and **`push-nix-image.yml`** wire the new inputs through detect/build/image jobs: FlakeHub cache is skipped when `binary-cache-url` is set, and post-build steps push to Attic when endpoint, cache name, and token are present. **README** and **`docs/public/workflows.md`** document the caller-facing inputs.
> 
> Smaller changes: **Renovate** custom manager for pinned `nix run github:` refs in shell scripts; **nix2container** pinned to **`v1.0.0`** in image push scripts; shell/formatting touch-ups in pnpm analyze and LiteLLM/Pulumi files.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e4de5267ef397e65c287b43ce86939035017d9b4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->