### PR TITLE
fix(renovate): update tarball regex for new semver tag format

### DIFF
--- a/renovate/sector7-release-tarballs.json
+++ b/renovate/sector7-release-tarballs.json
@@ -7,12 +7,12 @@
 			"description": "Update @jmmaloney4/sector7 release tarball URLs in package.json files",
 			"managerFilePatterns": ["/(^|/)package\\.json$/"],
 			"matchStrings": [
-				"\"(?<depName>@jmmaloney4/sector7)\":\\s*\"https://github\\.com/jmmaloney4/sector7/releases/download/sector7-v(?<currentValue>\\d+\\.\\d+\\.\\d+-[0-9a-f]+)/jmmaloney4-sector7-(?:\\d+\\.\\d+\\.\\d+)\\.tgz\""
+				"\"(?<depName>@jmmaloney4/sector7)\":\\s*\"https://github\\.com/jmmaloney4/sector7/releases/download/v(?<currentValue>\\d+\\.\\d+\\.\\d+)/jmmaloney4-sector7-(?:\\d+\\.\\d+\\.\\d+)\\.tgz\""
 			],
 			"packageNameTemplate": "jmmaloney4/sector7",
 			"datasourceTemplate": "github-releases",
 			"versioningTemplate": "semver",
-			"autoReplaceStringTemplate": "\"{{{depName}}}\": \"https://github.com/jmmaloney4/sector7/releases/download/sector7-v{{{newValue}}}/jmmaloney4-sector7-{{{replace '-[0-9a-f]+$' '' newValue}}}.tgz\""
+			"autoReplaceStringTemplate": "\"{{{depName}}}\": \"https://github.com/jmmaloney4/sector7/releases/download/v{{{newValue}}}/jmmaloney4-sector7-{{{newValue}}}.tgz\""
 		}
 	],
 	"packageRules": [
@@ -21,7 +21,7 @@
 			"matchDatasources": ["github-releases"],
 			"matchPackageNames": ["jmmaloney4/sector7"],
 			"minimumReleaseAge": null,
-			"extractVersion": "^sector7-v(?<version>\\d+\\.\\d+\\.\\d+-[0-9a-f]+)$"
+			"extractVersion": "^v(?<version>\\d+\\.\\d+\\.\\d+)$"
 		}
 	]
 }


### PR DESCRIPTION
## What changed

Updated `renovate/sector7-release-tarballs.json` to match the new release tag format.

The release tag format changed from `sector7-vX.Y.Z-<sha>` (e.g., `sector7-v0.9.2-007f69a`) to plain `vX.Y.Z` (e.g., `v0.10.0`) starting with v0.10.0. The Renovate custom regex manager, `extractVersion`, and `autoReplaceStringTemplate` all hardcoded the old format, so Renovate could not detect v0.10.0 as an available update.

### Changes

- `matchStrings`: matches `v<VERSION>` in the download URL instead of `sector7-v<VERSION>-<SHA>`
- `autoReplaceStringTemplate`: generates plain `v<VERSION>` URLs (no prefix, no SHA suffix, no `{{replace}}` template helper)
- `extractVersion`: parses `^v(?<version>\d+\.\d+\.\d+)$` instead of `^sector7-v(?<version>…-[0-9a-f]+)$`

### Breaking

No longer matches old-format tags (`sector7-vX.Y.Z-<sha>`). Downstream `package.json` files must be updated to the new URL format first.

### Follow-up

- garden repo `package.json` files will be updated in a separate PR to use v0.10.0 URLs with the new format

## Test plan

- [ ] Verify the regex matches `https://github.com/jmmaloney4/sector7/releases/download/v0.10.0/jmmaloney4-sector7-0.10.0.tgz`
- [ ] Verify `extractVersion` correctly extracts `0.10.0` from tag `v0.10.0`
- [ ] After garden package.json files are updated, confirm Renovate detects the dependency and offers future updates

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Renovate-only config change with no runtime, auth, or data impact; old-format dependency URLs stop receiving automated updates until migrated.
> 
> **Overview**
> Updates **`renovate/sector7-release-tarballs.json`** so Renovate can track **`@jmmaloney4/sector7`** GitHub release tarball URLs after the release tag scheme changed from **`sector7-vX.Y.Z-<sha>`** to plain **`vX.Y.Z`** (from v0.10.0 onward).
> 
> The custom regex manager now matches and rewrites download URLs under **`.../releases/download/v<semver>/...`**, with **`autoReplaceStringTemplate`** emitting **`v{{{newValue}}}`** tarball paths (no SHA suffix or replace helper). **`extractVersion`** on the **`github-releases`** package rule is aligned to **`^v(?<version>\d+\.\d+\.\d+)$`**.
> 
> **Breaking for Renovate only:** old-tag URLs are no longer recognized; consuming **`package.json`** entries must already use the new URL shape before updates are offered (planned separately for garden).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b42809599094f952d9dbc73677be480881cf0794. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->