### PR TITLE
fix(litellm): make create-team and create-key idempotent

### DIFF
--- a/.github/actions/analyze-pnpm-packages/action.yml
+++ b/.github/actions/analyze-pnpm-packages/action.yml
@@ -1,11 +1,8 @@
 name: Analyze pnpm packages
 description: >
-  Unified monorepo release analyzer. Reads version from root package.json,
-  checks whether a v${version} GitHub Release with all expected tarballs already
-  exists, and emits a JSON matrix of packages to publish if needed.
+  Unified monorepo release analyzer. Reads version from root package.json, checks whether a v${version} GitHub Release with all expected tarballs already exists, and emits a JSON matrix of packages to publish if needed.
 
-  Only the 'release' target is supported. Registry targets (ghcr, npm, gcp)
-  have been removed.
+  Only the 'release' target is supported. Registry targets (ghcr, npm, gcp) have been removed.
 
 inputs:
   dry_run:
@@ -22,11 +19,10 @@ inputs:
     default: "."
   github_repository:
     description: >
-      Owner/repository for GitHub Release checks. Defaults to the workflow's
-      github.repository (set automatically by GitHub Actions).
+      Owner/repository for GitHub Release checks. Defaults to the workflow's github.repository (set automatically by GitHub Actions).
+
     required: false
     default: "${{ github.repository }}"
-
 outputs:
   matrix:
     description: JSON matrix of packages to publish
@@ -34,7 +30,6 @@ outputs:
   has_packages:
     description: Whether there are packages to publish (true/false)
     value: ${{ steps.analyze.outputs.has_packages }}
-
 runs:
   using: composite
   steps:

--- a/.github/actions/analyze-pnpm-packages/main.sh
+++ b/.github/actions/analyze-pnpm-packages/main.sh
@@ -30,7 +30,7 @@ if [[ ! -f "${ROOT}/package.json" ]]; then
 fi
 
 VERSION="$(jq -r '.version // empty' "${ROOT}/package.json")"
-if [[ -z "$VERSION" || "$VERSION" == "null" ]]; then
+if [[ -z $VERSION || $VERSION == "null" ]]; then
   echo "Error: version field missing or empty in ${ROOT}/package.json" >&2
   exit 1
 fi
@@ -38,7 +38,7 @@ fi
 TAG="v${VERSION}"
 
 echo "# 📦 Unified release analysis" >>"$SUMMARY_FILE"
-if [[ "${DRY_RUN}" == "true" ]]; then
+if [[ ${DRY_RUN} == "true" ]]; then
   echo "> **DRY RUN MODE** - No packages will be published" >>"$SUMMARY_FILE"
 fi
 echo "" >>"$SUMMARY_FILE"
@@ -48,16 +48,16 @@ echo "- **Target:** \`${TARGET}\`" >>"$SUMMARY_FILE"
 
 # ── Validate all package versions match the root version ────────────
 
-if [[ "${DRY_RUN}" == "true" ]]; then
+if [[ ${DRY_RUN} == "true" ]]; then
   echo "- **Version check:** skipped in dry run" >>"$SUMMARY_FILE"
 else
   if [[ -d "${ROOT}/packages" ]]; then
     VERSION_MISMATCH=0
     for pkg_json in "${ROOT}"/packages/*/package.json; do
-      [[ -f "$pkg_json" ]] || continue
+      [[ -f $pkg_json ]] || continue
       pkg_name="$(jq -r '.name' "$pkg_json")"
       pkg_ver="$(jq -r '.version // empty' "$pkg_json")"
-      if [[ "$pkg_ver" != "$VERSION" ]]; then
+      if [[ $pkg_ver != "$VERSION" ]]; then
         echo "❌ Version mismatch: ${pkg_name} is ${pkg_ver}, expected ${VERSION}" >&2
         VERSION_MISMATCH=1
       fi
@@ -75,7 +75,7 @@ fi
 PKG_PATHS=()
 if [[ -d "${ROOT}/packages" ]]; then
   for pkg_json in "${ROOT}/packages"/*/package.json; do
-    [[ -f "$pkg_json" ]] && PKG_PATHS+=("${pkg_json%/package.json}")
+    [[ -f $pkg_json ]] && PKG_PATHS+=("${pkg_json%/package.json}")
   done
 fi
 
@@ -93,45 +93,45 @@ fi
 
 ALREADY_PUBLISHED="false"
 case "$TARGET" in
-  release)
-    if [[ -n "$GITHUB_REPO" ]]; then
-      if gh release view "$TAG" --repo "$GITHUB_REPO" >/dev/null 2>&1; then
-        # Release exists — verify all expected assets are present.
-        # Partial releases (tag created but upload failed) must be retried.
-        # Fetch asset list once to avoid N API calls per package.
-        EXISTING_ASSETS="$(gh release view "$TAG" --repo "$GITHUB_REPO" --json assets -q ".assets[].name" 2>/dev/null || true)"
-        MISSING_ASSETS=()
-        for pkg_path in "${PKG_PATHS[@]}"; do
-          name="$(jq -r '.name' "${pkg_path}/package.json")"
-          pkg_version="$(jq -r '.version // empty' "${pkg_path}/package.json")"
-          stem="${name#@}"
-          stem="${stem//\//-}"
-          asset_name="${stem}-${pkg_version}.tgz"
-          # grep -F for literal match (asset names contain dots)
-          if ! echo "$EXISTING_ASSETS" | grep -Fqx "$asset_name"; then
-            MISSING_ASSETS+=("$asset_name")
-          fi
-        done
-        if [[ ${#MISSING_ASSETS[@]} -eq 0 ]]; then
-          ALREADY_PUBLISHED="true"
-          echo "- **Status:** already published (tag \`${TAG}\` exists with all assets)" >>"$SUMMARY_FILE"
-        else
-          echo "- **Status:** incomplete release (missing: ${MISSING_ASSETS[*]}), will republish" >>"$SUMMARY_FILE"
-          for asset in "${MISSING_ASSETS[@]}"; do
-            echo "  ⚠️ Missing asset: $asset" >&2
-          done
+release)
+  if [[ -n $GITHUB_REPO ]]; then
+    if gh release view "$TAG" --repo "$GITHUB_REPO" >/dev/null 2>&1; then
+      # Release exists — verify all expected assets are present.
+      # Partial releases (tag created but upload failed) must be retried.
+      # Fetch asset list once to avoid N API calls per package.
+      EXISTING_ASSETS="$(gh release view "$TAG" --repo "$GITHUB_REPO" --json assets -q ".assets[].name" 2>/dev/null || true)"
+      MISSING_ASSETS=()
+      for pkg_path in "${PKG_PATHS[@]}"; do
+        name="$(jq -r '.name' "${pkg_path}/package.json")"
+        pkg_version="$(jq -r '.version // empty' "${pkg_path}/package.json")"
+        stem="${name#@}"
+        stem="${stem//\//-}"
+        asset_name="${stem}-${pkg_version}.tgz"
+        # grep -F for literal match (asset names contain dots)
+        if ! echo "$EXISTING_ASSETS" | grep -Fqx "$asset_name"; then
+          MISSING_ASSETS+=("$asset_name")
         fi
+      done
+      if [[ ${#MISSING_ASSETS[@]} -eq 0 ]]; then
+        ALREADY_PUBLISHED="true"
+        echo "- **Status:** already published (tag \`${TAG}\` exists with all assets)" >>"$SUMMARY_FILE"
       else
-        echo "- **Status:** new release needed" >>"$SUMMARY_FILE"
+        echo "- **Status:** incomplete release (missing: ${MISSING_ASSETS[*]}), will republish" >>"$SUMMARY_FILE"
+        for asset in "${MISSING_ASSETS[@]}"; do
+          echo "  ⚠️ Missing asset: $asset" >&2
+        done
       fi
     else
-      echo "- **Status:** unknown (no GITHUB_REPO set, assuming not published)" >>"$SUMMARY_FILE"
+      echo "- **Status:** new release needed" >>"$SUMMARY_FILE"
     fi
-    ;;
-  *)
-    echo "Error: unknown or deprecated target '${TARGET}'. Only 'release' is supported." >&2
-    exit 1
-    ;;
+  else
+    echo "- **Status:** unknown (no GITHUB_REPO set, assuming not published)" >>"$SUMMARY_FILE"
+  fi
+  ;;
+*)
+  echo "Error: unknown or deprecated target '${TARGET}'. Only 'release' is supported." >&2
+  exit 1
+  ;;
 esac
 
 # ── Build matrix entries ────────────────────────────────────────────
@@ -168,7 +168,7 @@ done
 # ── Decide action ───────────────────────────────────────────────────
 
 ACTION="publish"
-if [[ "$ALREADY_PUBLISHED" == "true" || "$DRY_RUN" == "true" ]]; then
+if [[ $ALREADY_PUBLISHED == "true" || $DRY_RUN == "true" ]]; then
   ACTION="skip"
 fi
 
@@ -176,7 +176,7 @@ echo "" >>"$SUMMARY_FILE"
 echo "| Package | Version | Action |" >>"$SUMMARY_FILE"
 echo "|---|---|---|" >>"$SUMMARY_FILE"
 
-if [[ "$ACTION" == "skip" ]]; then
+if [[ $ACTION == "skip" ]]; then
   for entry in "${MATRIX_ENTRIES[@]}"; do
     name="$(echo "$entry" | jq -r '.name')"
     echo "| ${name} | ${VERSION} | ⏭️ skip |" >>"$SUMMARY_FILE"

--- a/docs/internal/designs/028-uptime-monitor-read-api.md
+++ b/docs/internal/designs/028-uptime-monitor-read-api.md
@@ -1,11 +1,12 @@
 ---
 id: ADR-028
-title: "Uptime Monitor Read Api"
+title: Uptime Monitor Read Api
 status: proposed
 date: 2026-05-24
 ---
 
 # ADR 028: Uptime Monitor Read Api
+
 *Date:* 2026-05-24
 *Status:* proposed
 

--- a/packages/sector7/litellm/admin.ts
+++ b/packages/sector7/litellm/admin.ts
@@ -59,12 +59,10 @@ export class LiteLLMApiKey extends pulumi.ComponentResource {
 					LITELLM_KEY_TEAM_ID: pulumi.output(args.teamId ?? ""),
 					LITELLM_KEY_USER_ID: pulumi.output(args.userId ?? ""),
 					LITELLM_KEY_BUDGET_ID: pulumi.output(args.budgetId ?? ""),
-					LITELLM_KEY_MAX_BUDGET: pulumi.output(args.maxBudget).apply((value) =>
-						value === undefined ? "" : String(value),
-					),
-					LITELLM_KEY_BUDGET_DURATION: pulumi.output(
-						args.budgetDuration ?? "",
-					),
+					LITELLM_KEY_MAX_BUDGET: pulumi
+						.output(args.maxBudget)
+						.apply((value) => (value === undefined ? "" : String(value))),
+					LITELLM_KEY_BUDGET_DURATION: pulumi.output(args.budgetDuration ?? ""),
 					LITELLM_KEY_DURATION: pulumi.output(args.duration ?? ""),
 					LITELLM_KEY_ALIASES_JSON: pulumiJsonString(args.aliases, {}),
 					LITELLM_KEY_TAGS_JSON: pulumiJsonString(args.tags, []),
@@ -75,9 +73,9 @@ export class LiteLLMApiKey extends pulumi.ComponentResource {
 		);
 
 		this.key = pulumi.secret(actualKey);
-		this.tokenId = pulumi.secret(commandResource.stdout).apply((stdout) =>
-			stdout.trim(),
-		);
+		this.tokenId = pulumi
+			.secret(commandResource.stdout)
+			.apply((stdout) => stdout.trim());
 
 		this.registerOutputs({
 			key: this.key,
@@ -107,9 +105,9 @@ export class LiteLLMTeam extends pulumi.ComponentResource {
 					LITELLM_TEAM_ALIAS: args.teamAlias,
 					LITELLM_TEAM_ID: pulumi.output(args.teamId ?? ""),
 					LITELLM_TEAM_MODELS_JSON: pulumiJsonString(args.models, []),
-					LITELLM_TEAM_MAX_BUDGET: pulumi.output(args.maxBudget).apply((value) =>
-						value === undefined ? "" : String(value),
-					),
+					LITELLM_TEAM_MAX_BUDGET: pulumi
+						.output(args.maxBudget)
+						.apply((value) => (value === undefined ? "" : String(value))),
 					LITELLM_TEAM_BUDGET_DURATION: pulumi.output(
 						args.budgetDuration ?? "",
 					),

--- a/packages/sector7/litellm/config.ts
+++ b/packages/sector7/litellm/config.ts
@@ -218,7 +218,9 @@ export function generateLiteLLMConfig(args: {
 	validateLiteLLMConfig(args);
 
 	const providerEnvVars = Object.entries(args.providers)
-		.map(([providerName, provider]) => getProviderEnvVar(providerName, provider))
+		.map(([providerName, provider]) =>
+			getProviderEnvVar(providerName, provider),
+		)
 		.filter((value): value is string => value !== undefined);
 	const deploymentsById = new Map(
 		args.deployments.map((deployment) => [deployment.id, deployment] as const),
@@ -290,11 +292,7 @@ export function generateLiteLLMConfig(args: {
 				"output_cost_per_token",
 				deployment.outputCostPerToken,
 			);
-			addIfDefined(
-				modelInfo,
-				"team_id",
-				deployment.teamId ?? group.teamId,
-			);
+			addIfDefined(modelInfo, "team_id", deployment.teamId ?? group.teamId);
 			addIfDefined(
 				modelInfo,
 				"team_alias",

--- a/packages/sector7/litellm/index.ts
+++ b/packages/sector7/litellm/index.ts
@@ -1,3 +1,4 @@
+export { LiteLLMApiKey, LiteLLMTeam } from "./admin.ts";
 export { generateLiteLLMConfig } from "./config.ts";
 export type {
 	BuildLiteLLMTeamScopedModelGroupsArgs,
@@ -19,6 +20,5 @@ export type {
 	LiteLLMTeamCapability,
 	LiteLLMTeamDefinition,
 } from "./config-types.ts";
-export { LiteLLMApiKey, LiteLLMTeam } from "./admin.ts";
 export { LiteLLMProxy } from "./litellm-proxy.ts";
 export { buildLiteLLMTeamScopedModelGroups } from "./team-plan.ts";

--- a/packages/sector7/nix-output/nix-output.ts
+++ b/packages/sector7/nix-output/nix-output.ts
@@ -64,7 +64,9 @@ function parseStorePath(stdout: string, name: string): string {
 		.split(/\r?\n/)
 		.find((entry) => entry.startsWith(prefix));
 	if (!line) {
-		throw new Error(`Could not parse STORE_PATH_OUTPUT from output for ${name}`);
+		throw new Error(
+			`Could not parse STORE_PATH_OUTPUT from output for ${name}`,
+		);
 	}
 	return line.slice(prefix.length);
 }

--- a/packages/sector7/pulumi-config/index.ts
+++ b/packages/sector7/pulumi-config/index.ts
@@ -1,8 +1,8 @@
 export {
-	requireMixedConfig,
 	type ArrayConfigOptions,
 	type FlatSecretsOptions,
 	type MapConfigOptions,
 	type RecordConfigOptions,
+	requireMixedConfig,
 	type SecretFieldsOf,
 } from "./mixed-config.js";

--- a/packages/sector7/pulumi-config/mixed-config.ts
+++ b/packages/sector7/pulumi-config/mixed-config.ts
@@ -1,4 +1,4 @@
-import * as pulumi from "@pulumi/pulumi";
+import type * as pulumi from "@pulumi/pulumi";
 
 export type SecretFieldsOf<
 	T extends Record<string, unknown>,

--- a/packages/sector7/scripts/litellm-admin.sh
+++ b/packages/sector7/scripts/litellm-admin.sh
@@ -243,7 +243,7 @@ create-key)
 
   # Idempotency: check if a key with this alias already exists.
   existing_token=$(find_key_by_alias "$LITELLM_KEY_ALIAS" 2>/dev/null) || true
-  if [[ -n "$existing_token" ]]; then
+  if [[ -n $existing_token ]]; then
     echo "$existing_token"
     exit 0
   fi
@@ -301,7 +301,7 @@ create-team)
 
   # Idempotency: check if a team with this team_id or team_alias already exists.
   existing_team=$(find_team "${LITELLM_TEAM_ID:-}" "$LITELLM_TEAM_ALIAS" 2>/dev/null) || true
-  if [[ -n "$existing_team" ]]; then
+  if [[ -n $existing_team ]]; then
     echo "$existing_team"
     exit 0
   fi

--- a/packages/sector7/scripts/litellm-admin.sh
+++ b/packages/sector7/scripts/litellm-admin.sh
@@ -140,10 +140,10 @@ for team in teams:
     if not isinstance(team, dict):
         continue
     if search_id and team.get("team_id") == search_id:
-        print(team["team_id"])
+        print(team.get("team_id", ""))
         sys.exit(0)
     if search_alias and team.get("team_alias") == search_alias:
-        print(team["team_id"])
+        print(team.get("team_id", ""))
         sys.exit(0)
 
 sys.exit(1)
@@ -213,6 +213,9 @@ def check_key(key_hash):
 
 
 # Check key info in parallel for matching alias
+if not keys:
+    sys.exit(1)
+
 with ThreadPoolExecutor(max_workers=min(len(keys), 8)) as pool:
     futures = {pool.submit(check_key, kh): kh for kh in keys}
     for future in as_completed(futures):

--- a/packages/sector7/scripts/litellm-admin.sh
+++ b/packages/sector7/scripts/litellm-admin.sh
@@ -11,11 +11,16 @@ require_env() {
   fi
 }
 
+# Encode a string to single-line base64 (safe for heredoc expansion).
+b64() {
+  printf '%s' "$1" | base64 | tr -d '\n'
+}
+
 run_proxy_python() {
   local body_b64="$1"
   local path="$2"
   local master_key_b64
-  master_key_b64=$(printf '%s' "$LITELLM_MASTER_KEY" | base64)
+  master_key_b64=$(b64 "$LITELLM_MASTER_KEY")
 
   kubectl exec -i \
     -n "$LITELLM_PROXY_NAMESPACE" \
@@ -59,52 +64,11 @@ except Exception as exc:
 PYEOF
 }
 
-# GET request to the LiteLLM proxy. Prints the response body to stdout.
-run_proxy_get() {
-  local path="$1"
-  local master_key_b64
-  master_key_b64=$(printf '%s' "$LITELLM_MASTER_KEY" | base64)
-
-  kubectl exec -i \
-    -n "$LITELLM_PROXY_NAMESPACE" \
-    "deploy/$LITELLM_PROXY_DEPLOYMENT" -- \
-    python3 - "$path" "${LITELLM_PROXY_PORT:-4000}" <<PYEOF
-import base64
-import json
-import sys
-import urllib.error
-import urllib.request
-
-master_key = base64.b64decode("${master_key_b64}").decode()
-path = sys.argv[1]
-port = int(sys.argv[2])
-
-req = urllib.request.Request(
-    f"http://localhost:{port}{path}",
-    headers={
-        "Authorization": f"Bearer {master_key}",
-    },
-    method="GET",
-)
-
-try:
-    with urllib.request.urlopen(req, timeout=30) as resp:
-        print(resp.read().decode())
-except urllib.error.HTTPError as exc:
-    body_text = exc.read().decode()
-    print(f"HTTP {exc.code}: {body_text}", file=sys.stderr)
-    sys.exit(1)
-except Exception as exc:
-    print(str(exc), file=sys.stderr)
-    sys.exit(1)
-PYEOF
-}
-
 extract_field() {
   local json_text="$1"
   local field="$2"
   local json_b64
-  json_b64=$(printf '%s' "$json_text" | base64)
+  json_b64=$(b64 "$json_text")
   python3 - "$json_b64" "$field" <<'PYEOF'
 import base64
 import json
@@ -129,23 +93,44 @@ PYEOF
 }
 
 # Find an existing team by team_id or team_alias.
+# Performs the full lookup inside the container (single kubectl exec).
 # Prints the team_id if found, exits with code 1 if not found.
 find_team() {
   local search_id="${1:-}"
   local search_alias="${2:-}"
-  local teams_json
-  teams_json=$(run_proxy_get "/team/list")
+  local master_key_b64
+  master_key_b64=$(b64 "$LITELLM_MASTER_KEY")
 
-  local teams_b64
-  teams_b64=$(printf '%s' "$teams_json" | base64)
-  python3 - "$teams_b64" "$search_id" "$search_alias" <<'PYEOF'
+  kubectl exec -i \
+    -n "$LITELLM_PROXY_NAMESPACE" \
+    "deploy/$LITELLM_PROXY_DEPLOYMENT" -- \
+    python3 - "$master_key_b64" "${LITELLM_PROXY_PORT:-4000}" "$search_id" "$search_alias" <<'PYEOF'
 import base64
 import json
 import sys
+import urllib.error
+import urllib.request
 
-teams = json.loads(base64.b64decode(sys.argv[1]).decode())
-search_id = sys.argv[2]
-search_alias = sys.argv[3]
+master_key = base64.b64decode(sys.argv[1]).decode()
+port = int(sys.argv[2])
+search_id = sys.argv[3]
+search_alias = sys.argv[4]
+
+req = urllib.request.Request(
+    f"http://localhost:{port}/team/list",
+    headers={"Authorization": f"Bearer {master_key}"},
+)
+try:
+    with urllib.request.urlopen(req, timeout=30) as resp:
+        data = json.loads(resp.read().decode())
+except Exception as exc:
+    print(str(exc), file=sys.stderr)
+    sys.exit(1)
+
+teams = data if isinstance(data, list) else data.get("teams", data.get("data", []))
+if not isinstance(teams, list):
+    print("unexpected /team/list response format", file=sys.stderr)
+    sys.exit(1)
 
 for team in teams:
     if search_id and team.get("team_id") == search_id:
@@ -160,52 +145,63 @@ PYEOF
 }
 
 # Find an existing key by key_alias.
+# Performs the full lookup inside the container (single kubectl exec).
+# Iterates /key/list -> /key/info for each key to match alias.
 # Prints the token if found, exits with code 1 if not found.
 find_key_by_alias() {
   local search_alias="$1"
-  local keys_json
-  keys_json=$(run_proxy_get "/key/list")
+  local master_key_b64
+  master_key_b64=$(b64 "$LITELLM_MASTER_KEY")
 
-  # /key/list returns {"keys": ["hash1", "hash2", ...], ...}
-  # We need /key/info for each to find the matching alias.
-  local payload_b64
-  payload_b64=$(printf '%s' "$keys_json" | base64)
-  python3 - "$payload_b64" "$search_alias" <<'PYEOF'
+  kubectl exec -i \
+    -n "$LITELLM_PROXY_NAMESPACE" \
+    "deploy/$LITELLM_PROXY_DEPLOYMENT" -- \
+    python3 - "$master_key_b64" "${LITELLM_PROXY_PORT:-4000}" "$search_alias" <<'PYEOF'
 import base64
 import json
 import sys
+import urllib.error
+import urllib.request
 
-data = json.loads(base64.b64decode(sys.argv[1]).decode())
-search_alias = sys.argv[2]
+master_key = base64.b64decode(sys.argv[1]).decode()
+port = int(sys.argv[2])
+search_alias = sys.argv[3]
+
+# List all key hashes
+list_req = urllib.request.Request(
+    f"http://localhost:{port}/key/list",
+    headers={"Authorization": f"Bearer {master_key}"},
+)
+try:
+    with urllib.request.urlopen(list_req, timeout=30) as resp:
+        data = json.loads(resp.read().decode())
+except Exception as exc:
+    print(str(exc), file=sys.stderr)
+    sys.exit(1)
 
 keys = data.get("keys", data) if isinstance(data, dict) else data
+if not isinstance(keys, list):
+    print("unexpected /key/list response format", file=sys.stderr)
+    sys.exit(1)
+
+# Check each key's info for matching alias
 for key_hash in keys:
-    print(key_hash)
-PYEOF
-}
+    info_req = urllib.request.Request(
+        f"http://localhost:{port}/key/info?key={key_hash}",
+        headers={"Authorization": f"Bearer {master_key}"},
+    )
+    try:
+        with urllib.request.urlopen(info_req, timeout=15) as resp:
+            info_data = json.loads(resp.read().decode())
+    except Exception:
+        continue
 
-# Given a key hash, fetch its info and extract the token if alias matches.
-find_key_by_hash() {
-  local key_hash="$1"
-  local search_alias="$2"
-  local info_json
-  info_json=$(run_proxy_get "/key/info?key=${key_hash}")
-
-  local info_b64
-  info_b64=$(printf '%s' "$info_json" | base64)
-  python3 - "$info_b64" "$search_alias" <<'PYEOF'
-import base64
-import json
-import sys
-
-data = json.loads(base64.b64decode(sys.argv[1]).decode())
-search_alias = sys.argv[2]
-
-# /key/info returns {"key": "hash", "info": {"key_alias": "...", "token": "..."}}
-info = data.get("info", data)
-if info.get("key_alias") == search_alias:
-    print(info.get("token", ""))
-    sys.exit(0)
+    info = info_data.get("info", info_data)
+    if info.get("key_alias") == search_alias:
+        token = info.get("token", "")
+        if token:
+            print(token)
+            sys.exit(0)
 
 sys.exit(1)
 PYEOF
@@ -221,15 +217,10 @@ create-key)
   require_env LITELLM_KEY_VALUE
 
   # Idempotency: check if a key with this alias already exists.
-  key_hashes=$(find_key_by_alias "$LITELLM_KEY_ALIAS" 2>/dev/null) || true
-  if [[ -n "$key_hashes" ]]; then
-    while IFS= read -r key_hash; do
-      existing_token=$(find_key_by_hash "$key_hash" "$LITELLM_KEY_ALIAS" 2>/dev/null) || continue
-      if [[ -n "$existing_token" ]]; then
-        echo "$existing_token"
-        exit 0
-      fi
-    done <<< "$key_hashes"
+  existing_token=$(find_key_by_alias "$LITELLM_KEY_ALIAS" 2>/dev/null) || true
+  if [[ -n "$existing_token" ]]; then
+    echo "$existing_token"
+    exit 0
   fi
 
   # Key not found — create it.
@@ -267,7 +258,7 @@ for env_key, body_key in [
 print(json.dumps(body))
 PYEOF
   )
-  response=$(run_proxy_python "$(printf '%s' "$body" | base64)" "/key/generate")
+  response=$(run_proxy_python "$(b64 "$body")" "/key/generate")
   extract_field "$response" "token"
   ;;
 
@@ -277,7 +268,7 @@ delete-key)
     exit 0
   fi
   body=$(printf '{"keys":["%s"]}' "$token_id")
-  run_proxy_python "$(printf '%s' "$body" | base64)" "/key/delete" >/dev/null
+  run_proxy_python "$(b64 "$body")" "/key/delete" >/dev/null
   ;;
 
 create-team)
@@ -320,7 +311,7 @@ for env_key, body_key in [
 print(json.dumps(body))
 PYEOF
   )
-  response=$(run_proxy_python "$(printf '%s' "$body" | base64)" "/team/new")
+  response=$(run_proxy_python "$(b64 "$body")" "/team/new")
   extract_field "$response" "team_id"
   ;;
 
@@ -330,7 +321,7 @@ delete-team)
     exit 0
   fi
   body=$(printf '{"team_ids":["%s"]}' "$team_id")
-  run_proxy_python "$(printf '%s' "$body" | base64)" "/team/delete" >/dev/null
+  run_proxy_python "$(b64 "$body")" "/team/delete" >/dev/null
   ;;
 
 *)

--- a/packages/sector7/scripts/litellm-admin.sh
+++ b/packages/sector7/scripts/litellm-admin.sh
@@ -59,6 +59,47 @@ except Exception as exc:
 PYEOF
 }
 
+# GET request to the LiteLLM proxy. Prints the response body to stdout.
+run_proxy_get() {
+  local path="$1"
+  local master_key_b64
+  master_key_b64=$(printf '%s' "$LITELLM_MASTER_KEY" | base64)
+
+  kubectl exec -i \
+    -n "$LITELLM_PROXY_NAMESPACE" \
+    "deploy/$LITELLM_PROXY_DEPLOYMENT" -- \
+    python3 - "$path" "${LITELLM_PROXY_PORT:-4000}" <<PYEOF
+import base64
+import json
+import sys
+import urllib.error
+import urllib.request
+
+master_key = base64.b64decode("${master_key_b64}").decode()
+path = sys.argv[1]
+port = int(sys.argv[2])
+
+req = urllib.request.Request(
+    f"http://localhost:{port}{path}",
+    headers={
+        "Authorization": f"Bearer {master_key}",
+    },
+    method="GET",
+)
+
+try:
+    with urllib.request.urlopen(req, timeout=30) as resp:
+        print(resp.read().decode())
+except urllib.error.HTTPError as exc:
+    body_text = exc.read().decode()
+    print(f"HTTP {exc.code}: {body_text}", file=sys.stderr)
+    sys.exit(1)
+except Exception as exc:
+    print(str(exc), file=sys.stderr)
+    sys.exit(1)
+PYEOF
+}
+
 extract_field() {
   local json_text="$1"
   local field="$2"
@@ -87,6 +128,89 @@ else:
 PYEOF
 }
 
+# Find an existing team by team_id or team_alias.
+# Prints the team_id if found, exits with code 1 if not found.
+find_team() {
+  local search_id="${1:-}"
+  local search_alias="${2:-}"
+  local teams_json
+  teams_json=$(run_proxy_get "/team/list")
+
+  local teams_b64
+  teams_b64=$(printf '%s' "$teams_json" | base64)
+  python3 - "$teams_b64" "$search_id" "$search_alias" <<'PYEOF'
+import base64
+import json
+import sys
+
+teams = json.loads(base64.b64decode(sys.argv[1]).decode())
+search_id = sys.argv[2]
+search_alias = sys.argv[3]
+
+for team in teams:
+    if search_id and team.get("team_id") == search_id:
+        print(team["team_id"])
+        sys.exit(0)
+    if search_alias and team.get("team_alias") == search_alias:
+        print(team["team_id"])
+        sys.exit(0)
+
+sys.exit(1)
+PYEOF
+}
+
+# Find an existing key by key_alias.
+# Prints the token if found, exits with code 1 if not found.
+find_key_by_alias() {
+  local search_alias="$1"
+  local keys_json
+  keys_json=$(run_proxy_get "/key/list")
+
+  # /key/list returns {"keys": ["hash1", "hash2", ...], ...}
+  # We need /key/info for each to find the matching alias.
+  local payload_b64
+  payload_b64=$(printf '%s' "$keys_json" | base64)
+  python3 - "$payload_b64" "$search_alias" <<'PYEOF'
+import base64
+import json
+import sys
+
+data = json.loads(base64.b64decode(sys.argv[1]).decode())
+search_alias = sys.argv[2]
+
+keys = data.get("keys", data) if isinstance(data, dict) else data
+for key_hash in keys:
+    print(key_hash)
+PYEOF
+}
+
+# Given a key hash, fetch its info and extract the token if alias matches.
+find_key_by_hash() {
+  local key_hash="$1"
+  local search_alias="$2"
+  local info_json
+  info_json=$(run_proxy_get "/key/info?key=${key_hash}")
+
+  local info_b64
+  info_b64=$(printf '%s' "$info_json" | base64)
+  python3 - "$info_b64" "$search_alias" <<'PYEOF'
+import base64
+import json
+import sys
+
+data = json.loads(base64.b64decode(sys.argv[1]).decode())
+search_alias = sys.argv[2]
+
+# /key/info returns {"key": "hash", "info": {"key_alias": "...", "token": "..."}}
+info = data.get("info", data)
+if info.get("key_alias") == search_alias:
+    print(info.get("token", ""))
+    sys.exit(0)
+
+sys.exit(1)
+PYEOF
+}
+
 require_env LITELLM_PROXY_NAMESPACE
 require_env LITELLM_MASTER_KEY
 require_env LITELLM_PROXY_DEPLOYMENT
@@ -95,6 +219,20 @@ case "$ACTION" in
 create-key)
   require_env LITELLM_KEY_ALIAS
   require_env LITELLM_KEY_VALUE
+
+  # Idempotency: check if a key with this alias already exists.
+  key_hashes=$(find_key_by_alias "$LITELLM_KEY_ALIAS" 2>/dev/null) || true
+  if [[ -n "$key_hashes" ]]; then
+    while IFS= read -r key_hash; do
+      existing_token=$(find_key_by_hash "$key_hash" "$LITELLM_KEY_ALIAS" 2>/dev/null) || continue
+      if [[ -n "$existing_token" ]]; then
+        echo "$existing_token"
+        exit 0
+      fi
+    done <<< "$key_hashes"
+  fi
+
+  # Key not found — create it.
   body=$(
     python3 - <<'PYEOF'
 import json
@@ -144,6 +282,15 @@ delete-key)
 
 create-team)
   require_env LITELLM_TEAM_ALIAS
+
+  # Idempotency: check if a team with this team_id or team_alias already exists.
+  existing_team=$(find_team "${LITELLM_TEAM_ID:-}" "$LITELLM_TEAM_ALIAS" 2>/dev/null) || true
+  if [[ -n "$existing_team" ]]; then
+    echo "$existing_team"
+    exit 0
+  fi
+
+  # Team not found — create it.
   body=$(
     python3 - <<'PYEOF'
 import json

--- a/packages/sector7/scripts/litellm-admin.sh
+++ b/packages/sector7/scripts/litellm-admin.sh
@@ -127,12 +127,18 @@ except Exception as exc:
     print(str(exc), file=sys.stderr)
     sys.exit(1)
 
+if not isinstance(data, (list, dict)):
+    print("unexpected /team/list response format", file=sys.stderr)
+    sys.exit(1)
+
 teams = data if isinstance(data, list) else data.get("teams", data.get("data", []))
 if not isinstance(teams, list):
     print("unexpected /team/list response format", file=sys.stderr)
     sys.exit(1)
 
 for team in teams:
+    if not isinstance(team, dict):
+        continue
     if search_id and team.get("team_id") == search_id:
         print(team["team_id"])
         sys.exit(0)
@@ -162,6 +168,7 @@ import json
 import sys
 import urllib.error
 import urllib.request
+from concurrent.futures import ThreadPoolExecutor, as_completed
 
 master_key = base64.b64decode(sys.argv[1]).decode()
 port = int(sys.argv[2])
@@ -179,13 +186,18 @@ except Exception as exc:
     print(str(exc), file=sys.stderr)
     sys.exit(1)
 
+if not isinstance(data, (list, dict)):
+    print("unexpected /key/list response format", file=sys.stderr)
+    sys.exit(1)
+
 keys = data.get("keys", data) if isinstance(data, dict) else data
 if not isinstance(keys, list):
     print("unexpected /key/list response format", file=sys.stderr)
     sys.exit(1)
 
-# Check each key's info for matching alias
-for key_hash in keys:
+
+def check_key(key_hash):
+    """Return (key_hash, info_dict) or (key_hash, None) on failure."""
     info_req = urllib.request.Request(
         f"http://localhost:{port}/key/info?key={key_hash}",
         headers={"Authorization": f"Bearer {master_key}"},
@@ -194,14 +206,24 @@ for key_hash in keys:
         with urllib.request.urlopen(info_req, timeout=15) as resp:
             info_data = json.loads(resp.read().decode())
     except Exception:
-        continue
+        return key_hash, None
+    if not isinstance(info_data, dict):
+        return key_hash, None
+    return key_hash, info_data.get("info", info_data)
 
-    info = info_data.get("info", info_data)
-    if info.get("key_alias") == search_alias:
-        token = info.get("token", "")
-        if token:
-            print(token)
-            sys.exit(0)
+
+# Check key info in parallel for matching alias
+with ThreadPoolExecutor(max_workers=min(len(keys), 8)) as pool:
+    futures = {pool.submit(check_key, kh): kh for kh in keys}
+    for future in as_completed(futures):
+        _, info = future.result()
+        if not isinstance(info, dict):
+            continue
+        if info.get("key_alias") == search_alias:
+            token = info.get("token", "")
+            if token:
+                print(token)
+                sys.exit(0)
 
 sys.exit(1)
 PYEOF

--- a/packages/sector7/tests/mixed-config.test.ts
+++ b/packages/sector7/tests/mixed-config.test.ts
@@ -109,10 +109,7 @@ describe("requireMixedConfig", () => {
 	it("reads array-shaped config with plain and secret fields", async () => {
 		const config = fakeConfig({
 			objects: {
-				accounts: [
-					{ name: "jmmaloney4" },
-					{ name: "cavinsresearch" },
-				],
+				accounts: [{ name: "jmmaloney4" }, { name: "cavinsresearch" }],
 			},
 			secrets: {
 				"accounts[0].apiToken": "jmm-secret",

--- a/packages/sector7/tests/monitor-script.test.ts
+++ b/packages/sector7/tests/monitor-script.test.ts
@@ -50,7 +50,11 @@ describe("generateMonitorScript", () => {
 	it("embeds monitor config as JSON", () => {
 		const script = generateMonitorScript([
 			{ id: "grafana", url: "https://grafana.example.com/healthz" },
-			{ id: "api", url: "https://api.example.com/healthz", expectedCodes: [200, 204] },
+			{
+				id: "api",
+				url: "https://api.example.com/healthz",
+				expectedCodes: [200, 204],
+			},
 		]);
 		expect(script).toContain("grafana");
 		expect(script).toContain("https://grafana.example.com/healthz");

--- a/packages/sector7/tests/nix-output.test.ts
+++ b/packages/sector7/tests/nix-output.test.ts
@@ -266,9 +266,11 @@ describe("NixOutput", () => {
 	});
 
 	it("eager preview helper resolves a concrete store path when env is static", () => {
-		const execSpy = vi.mocked(execFileSync).mockReturnValue(
-			"=== Resolved: /nix/store/eager123-myapp-1.0.0 ===\nSTORE_PATH_OUTPUT:/nix/store/eager123-myapp-1.0.0\n",
-		);
+		const execSpy = vi
+			.mocked(execFileSync)
+			.mockReturnValue(
+				"=== Resolved: /nix/store/eager123-myapp-1.0.0 ===\nSTORE_PATH_OUTPUT:/nix/store/eager123-myapp-1.0.0\n",
+			);
 
 		const storePath = resolvePreviewStorePath(
 			"test-preview-eager",

--- a/packages/sector7/tests/renovate-nix-regex.test.ts
+++ b/packages/sector7/tests/renovate-nix-regex.test.ts
@@ -3,7 +3,10 @@ import { resolve } from "node:path";
 import { describe, expect, it } from "vitest";
 
 const nixConfig = JSON.parse(
-	readFileSync(resolve(import.meta.dirname, "../../../renovate/nix.json"), "utf8"),
+	readFileSync(
+		resolve(import.meta.dirname, "../../../renovate/nix.json"),
+		"utf8",
+	),
 ) as {
 	customManagers: Array<{
 		description: string;

--- a/renovate/default.json
+++ b/renovate/default.json
@@ -10,9 +10,7 @@
 		":enableVulnerabilityAlertsWithLabel(security)",
 		":pinAllExceptPeerDependencies"
 	],
-	"schedule": [
-		"before 4:00 am"
-	],
+	"schedule": ["before 4:00 am"],
 	"prHourlyLimit": 10,
 	"prConcurrentLimit": 5,
 	"rebaseWhen": "conflicted",
@@ -21,16 +19,11 @@
 	"platformAutomerge": false,
 	"dependencyDashboard": true,
 	"dependencyDashboardTitle": "Renovate Dashboard \ud83e\udd16",
-	"dependencyDashboardLabels": [
-		"chore/deps"
-	],
+	"dependencyDashboardLabels": ["chore/deps"],
 	"rangeStrategy": "pin",
 	"minimumReleaseAge": "4 days",
 	"pinDigests": true,
-	"labels": [
-		"chore/deps",
-		"renovate"
-	],
+	"labels": ["chore/deps", "renovate"],
 	"commitMessagePrefix": "deps: ",
 	"commitMessageAction": "update",
 	"prHeader": "This PR contains dependency updates managed by Renovate.",
@@ -38,12 +31,7 @@
 	"vulnerabilityAlerts": {
 		"enabled": true,
 		"automerge": true,
-		"addLabels": [
-			"security",
-			"vulnerability",
-			"deps/security",
-			"renovate"
-		]
+		"addLabels": ["security", "vulnerability", "deps/security", "renovate"]
 	},
 	"nix": {
 		"enabled": true
@@ -51,17 +39,13 @@
 	"packageRules": [
 		{
 			"description": "Skip pinning and stability days for internal sector7 actions (own repo)",
-			"matchPackageNames": [
-				"/^jmmaloney4\\/sector7($|\\/)/"
-			],
+			"matchPackageNames": ["/^jmmaloney4\\/sector7($|\\/)/"],
 			"minimumReleaseAge": null,
 			"pinDigests": false
 		},
 		{
 			"description": "Disable requires-python updates \u2014 managed manually per project as a capped minor range (e.g. >=3.13,<3.14)",
-			"matchDepTypes": [
-				"requires-python"
-			],
+			"matchDepTypes": ["requires-python"],
 			"enabled": false
 		}
 	]


### PR DESCRIPTION
## Problem

`litellm-admin.sh` `create-team` and `create-key` operations call LiteLLM REST endpoints (`/team/new`, `/key/generate`) without checking if the resource already exists. When Pulumi re-runs the `command.local.Command` `create` trigger (e.g., after a deployment replacement or stack repair), the command fails with HTTP 400 `"Team id = personal already exists"`.

This causes the entire `pulumi up` to report failure even though the LiteLLM proxy is healthy and the resource already exists in the database.

## Changes

- **`run_proxy_get`**: New helper for GET requests to the LiteLLM proxy (team/key lookup queries)
- **`find_team`**: Queries `/team/list` and matches by `team_id` (if provided) or `team_alias`. Returns the `team_id` if found.
- **`find_key_by_alias`** + **`find_key_by_hash`**: Queries `/key/list` then `/key/info` for each key to match by `key_alias`. Returns the `token` if found.
- **`create-team`**: Checks existence before calling `/team/new`. Returns existing `team_id` if found.
- **`create-key`**: Checks existence before calling `/key/generate`. Returns existing `token` if found.

## Testing

- `bash -n` syntax check passes
- `shellcheck` passes with no warnings
- Logic validated against live LiteLLM proxy API (`/team/list`, `/key/list`, `/key/info`)

Closes #233

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes provisioning behavior for LiteLLM teams and API keys during stack repair; wrong lookup logic could mask misconfiguration or return unexpected tokens, though scope is limited to the admin shell script.
> 
> **Overview**
> Makes **LiteLLM admin** `create-team` and `create-key` safe to re-run when Pulumi’s `command.local.Command` create hook fires again. **`litellm-admin.sh`** adds in-proxy lookups (`find_team` via `/team/list`, `find_key_by_alias` via `/key/list` and parallel `/key/info`) and returns the existing `team_id` or token instead of calling `/team/new` or `/key/generate` when a match exists. A shared **`b64`** helper replaces ad hoc base64 encoding for proxy requests.
> 
> The rest of the diff is **non-behavioral**: shell style in **analyze-pnpm-packages** `main.sh`, export ordering and formatting in sector7 **litellm** / **pulumi-config** / tests, compact JSON in **renovate/default.json**, and a small ADR front-matter tweak.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4040a3e0101744a9efa4aea874a8897ee624f15d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->