### PR TITLE
fix(monitor): set D1 readReplication explicitly

### DIFF
--- a/packages/sector7/monitor/uptime-monitor.ts
+++ b/packages/sector7/monitor/uptime-monitor.ts
@@ -272,6 +272,8 @@ export class UptimeMonitor extends pulumi.ComponentResource {
 					{
 						accountId: args.accountId,
 						name: dbName,
+						// Explicitly set to avoid the @pulumi/cloudflare >= 6.17.0
+						// null-serialization bug on D1 updates after refresh.
 						readReplication: { mode: "disabled" },
 					},
 					resourceOpts,

--- a/packages/sector7/monitor/uptime-monitor.ts
+++ b/packages/sector7/monitor/uptime-monitor.ts
@@ -272,6 +272,7 @@ export class UptimeMonitor extends pulumi.ComponentResource {
 					{
 						accountId: args.accountId,
 						name: dbName,
+						readReplication: { mode: "disabled" },
 					},
 					resourceOpts,
 				);

--- a/packages/sector7/tests/uptime-monitor.test.ts
+++ b/packages/sector7/tests/uptime-monitor.test.ts
@@ -79,7 +79,9 @@ describe("UptimeMonitor", () => {
 		await resolveOutput(monitor.worker.id);
 		await resolveOutput(monitor.cronTrigger.id);
 
-		expect(findResource("basic-d1")).toBeDefined();
+		const d1 = findResource("basic-d1");
+		expect(d1).toBeDefined();
+		expect(d1?.inputs.readReplication).toEqual({ mode: "disabled" });
 		expect(findResource("basic-kv")).toBeDefined();
 		expect(findResource("basic-worker")).toBeDefined();
 		expect(findResource("basic-cron")).toBeDefined();


### PR DESCRIPTION
## Summary
- explicitly set `readReplication: { mode: "disabled" }` when `UptimeMonitor` creates a D1 database
- add a unit test asserting the D1 resource carries the explicit read-replication object
- document the workaround in the PR rationale via issue link

## Why
`@pulumi/cloudflare` 6.17.0 can fail D1 updates after refresh with:

```text
Invalid property: read_replication => Expected object, received null
```

`UptimeMonitor` currently relies on the provider default. This PR makes the default explicit so the created D1 resource state matches the observed Cloudflare-side default (`{ mode: "disabled" }`) and avoids the null-serialization path we hit in garden.

## Validation
- `pnpm --filter @jmmaloney4/sector7 test -- --run packages/sector7/tests/uptime-monitor.test.ts`
- `pnpm --filter @jmmaloney4/sector7 build`

Closes #235

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small infrastructure-as-code default change with no runtime monitor behavior change; only affects newly created D1 resources via this component.
> 
> **Overview**
> When `UptimeMonitor` provisions a new D1 database, it now sets **`readReplication: { mode: "disabled" }`** on the `cloudflare.D1Database` resource instead of leaving that field implicit. That pins the provider input to the same shape Cloudflare already uses by default, so **`pulumi refresh` / subsequent updates** with `@pulumi/cloudflare` ≥ 6.17.0 do not send `read_replication: null` and trip the API validation error.
> 
> A unit test asserts the mocked D1 resource inputs include that explicit read-replication object.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1f61249218696d7f3f90d63f7f15e81b8e9282e3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->