### PR TITLE
feat(litellm): support extra runtime env injection

### DIFF
--- a/packages/sector7/litellm/config-types.ts
+++ b/packages/sector7/litellm/config-types.ts
@@ -192,6 +192,24 @@ export interface LiteLLMProxyArgs {
 	redis?: LiteLLMRedisPolicy;
 	service?: LiteLLMServiceSpec;
 	cloudSqlAuthProxy?: CloudSqlAuthProxy;
+	/**
+	 * Additional non-secret environment variables injected directly into the
+	 * LiteLLM container.
+	 *
+	 * Use this for runtime flags and metadata such as
+	 * `LANGFUSE_TRACING_ENVIRONMENT`. Values are rendered onto the Deployment,
+	 * so do not pass secrets here.
+	 */
+	extraEnv?: Record<string, pulumi.Input<string>>;
+	/**
+	 * Additional secret environment variables injected into the LiteLLM
+	 * container via the component-managed runtime Secret.
+	 *
+	 * Use this for integration credentials such as `LANGFUSE_PUBLIC_KEY`,
+	 * `LANGFUSE_SECRET_KEY`, or other callback-specific secrets that should not
+	 * be stored in git-tracked config.
+	 */
+	extraSecretEnv?: Record<string, pulumi.Input<string>>;
 	resources?: k8s.types.input.core.v1.ResourceRequirements;
 	extraLiteLLMSettings?: Record<string, unknown>;
 	extraGeneralSettings?: Record<string, unknown>;

--- a/packages/sector7/litellm/litellm-proxy.ts
+++ b/packages/sector7/litellm/litellm-proxy.ts
@@ -46,25 +46,6 @@ function assertUniqueEnvNames(
 	}
 }
 
-function getStaticProviderEnvVarNames(
-	providers: Record<string, LiteLLMProviderConfig>,
-): string[] {
-	return Object.entries(providers)
-		.flatMap(([providerName, provider]) => {
-			if (provider.apiKey === undefined) {
-				return [];
-			}
-			return [
-				getProviderEnvVar(providerName, {
-					hasApiKey: true,
-					envVar:
-						typeof provider.envVar === "string" ? provider.envVar : undefined,
-				}) ?? `${providerName.toUpperCase()}_API_KEY`,
-			];
-		})
-		.filter((name): name is string => Boolean(name));
-}
-
 function assertNoEnvOverlap(
 	names: string[],
 	conflictingNames: Iterable<string>,
@@ -76,6 +57,35 @@ function assertNoEnvOverlap(
 			throw new Error(`${context} cannot override provider environment variable '${name}'`);
 		}
 	}
+}
+
+export function validateExtraEnvNameCollisions(
+	extraEnvNames: string[],
+	extraSecretEnvNames: string[],
+	providerEnvVarNames: Iterable<string> = [],
+): void {
+	assertUniqueEnvNames(
+		extraEnvNames,
+		"LiteLLMProxy extraEnv",
+		RESERVED_RUNTIME_ENV_VARS,
+	);
+	assertUniqueEnvNames(
+		extraSecretEnvNames,
+		"LiteLLMProxy extraSecretEnv",
+		RESERVED_RUNTIME_ENV_VARS,
+	);
+	const extraEnvKeys = new Set(extraEnvNames);
+	for (const name of extraSecretEnvNames) {
+		if (extraEnvKeys.has(name)) {
+			throw new Error(`LiteLLMProxy extraEnv and extraSecretEnv both define '${name}'`);
+		}
+	}
+	assertNoEnvOverlap(extraEnvNames, providerEnvVarNames, "LiteLLMProxy extraEnv");
+	assertNoEnvOverlap(
+		extraSecretEnvNames,
+		providerEnvVarNames,
+		"LiteLLMProxy extraSecretEnv",
+	);
 }
 
 function resolveProviderConfig(
@@ -172,33 +182,9 @@ export class LiteLLMProxy extends pulumi.ComponentResource {
 		);
 		const extraEnvEntries = Object.entries(args.extraEnv ?? {});
 		const extraSecretEnvEntries = Object.entries(args.extraSecretEnv ?? {});
-		const staticProviderEnvVarNames = getStaticProviderEnvVarNames(args.providers);
-		assertUniqueEnvNames(
+		validateExtraEnvNameCollisions(
 			extraEnvEntries.map(([name]) => name),
-			"LiteLLMProxy extraEnv",
-			RESERVED_RUNTIME_ENV_VARS,
-		);
-		assertUniqueEnvNames(
 			extraSecretEnvEntries.map(([name]) => name),
-			"LiteLLMProxy extraSecretEnv",
-			RESERVED_RUNTIME_ENV_VARS,
-		);
-		for (const [name] of extraSecretEnvEntries) {
-			if (extraEnvEntries.some(([plainName]) => plainName === name)) {
-				throw new Error(
-					`LiteLLMProxy extraEnv and extraSecretEnv both define '${name}'`,
-				);
-			}
-		}
-		assertNoEnvOverlap(
-			extraEnvEntries.map(([name]) => name),
-			staticProviderEnvVarNames,
-			"LiteLLMProxy extraEnv",
-		);
-		assertNoEnvOverlap(
-			extraSecretEnvEntries.map(([name]) => name),
-			staticProviderEnvVarNames,
-			"LiteLLMProxy extraSecretEnv",
 		);
 
 		const providerSecretName = `${name}-provider-keys`;
@@ -225,6 +211,13 @@ export class LiteLLMProxy extends pulumi.ComponentResource {
 				})),
 			),
 		);
+		const extraSecretEnv = pulumi
+			.all(
+				extraSecretEnvEntries.map(([name, value]) =>
+					pulumi.output(value).apply((resolvedValue) => [name, resolvedValue] as const),
+				),
+			)
+			.apply((entries) => Object.fromEntries(entries));
 
 		const configYaml = pulumi
 			.all([resolvedProviderConfigs, resolvedDeployments, replicas])
@@ -342,18 +335,12 @@ export class LiteLLMProxy extends pulumi.ComponentResource {
 		);
 
 		const runtimeSecretData = pulumi
-			.all([
-				this.masterKey,
-				effectiveDatabaseUrl,
-				pulumi.output(args.extraSecretEnv ?? {}),
-			])
-			.apply<Record<string, string>>(
-				([masterKey, databaseUrl, extraSecretEnv]) => ({
-					LITELLM_MASTER_KEY: masterKey,
-					DATABASE_URL: databaseUrl,
-					...extraSecretEnv,
-				}),
-			);
+			.all([this.masterKey, effectiveDatabaseUrl, extraSecretEnv])
+			.apply(([masterKey, databaseUrl, resolvedExtraSecretEnv]) => ({
+				LITELLM_MASTER_KEY: masterKey,
+				DATABASE_URL: databaseUrl,
+				...resolvedExtraSecretEnv,
+			}));
 
 		this.runtimeSecret = new k8s.core.v1.Secret(
 			`${name}-runtime`,
@@ -405,6 +392,11 @@ export class LiteLLMProxy extends pulumi.ComponentResource {
 					providerSecretName,
 					extraEnvVars,
 				]) => {
+					validateExtraEnvNameCollisions(
+						extraEnvEntries.map(([name]) => name),
+						extraSecretEnvEntries.map(([name]) => name),
+						providerSecretEnvVars,
+					);
 					return [
 						{
 							name: "LITELLM_MASTER_KEY",

--- a/packages/sector7/litellm/litellm-proxy.ts
+++ b/packages/sector7/litellm/litellm-proxy.ts
@@ -20,8 +20,62 @@ type ResolvedDeployment = Omit<LiteLLMModelDeployment, "apiBase"> & {
 	apiBase?: string;
 };
 
+const RESERVED_RUNTIME_ENV_VARS = new Set(["LITELLM_MASTER_KEY", "DATABASE_URL"]);
+
 function toSecretKey(envVar: string): string {
 	return envVar.toLowerCase();
+}
+
+function assertUniqueEnvNames(
+	names: string[],
+	context: string,
+	reserved: Iterable<string> = [],
+): void {
+	const reservedSet = new Set(reserved);
+	const seen = new Set<string>();
+	for (const name of names) {
+		if (seen.has(name)) {
+			throw new Error(`${context} contains duplicate environment variable '${name}'`);
+		}
+		if (reservedSet.has(name)) {
+			throw new Error(
+				`${context} cannot override reserved environment variable '${name}'`,
+			);
+		}
+		seen.add(name);
+	}
+}
+
+function getStaticProviderEnvVarNames(
+	providers: Record<string, LiteLLMProviderConfig>,
+): string[] {
+	return Object.entries(providers)
+		.flatMap(([providerName, provider]) => {
+			if (provider.apiKey === undefined) {
+				return [];
+			}
+			return [
+				getProviderEnvVar(providerName, {
+					hasApiKey: true,
+					envVar:
+						typeof provider.envVar === "string" ? provider.envVar : undefined,
+				}) ?? `${providerName.toUpperCase()}_API_KEY`,
+			];
+		})
+		.filter((name): name is string => Boolean(name));
+}
+
+function assertNoEnvOverlap(
+	names: string[],
+	conflictingNames: Iterable<string>,
+	context: string,
+): void {
+	const conflictingNameSet = new Set(conflictingNames);
+	for (const name of names) {
+		if (conflictingNameSet.has(name)) {
+			throw new Error(`${context} cannot override provider environment variable '${name}'`);
+		}
+	}
 }
 
 function resolveProviderConfig(
@@ -116,6 +170,36 @@ export class LiteLLMProxy extends pulumi.ComponentResource {
 		const resolvedDeployments = pulumi.all(
 			args.deployments.map((deployment) => resolveDeployment(deployment)),
 		);
+		const extraEnvEntries = Object.entries(args.extraEnv ?? {});
+		const extraSecretEnvEntries = Object.entries(args.extraSecretEnv ?? {});
+		const staticProviderEnvVarNames = getStaticProviderEnvVarNames(args.providers);
+		assertUniqueEnvNames(
+			extraEnvEntries.map(([name]) => name),
+			"LiteLLMProxy extraEnv",
+			RESERVED_RUNTIME_ENV_VARS,
+		);
+		assertUniqueEnvNames(
+			extraSecretEnvEntries.map(([name]) => name),
+			"LiteLLMProxy extraSecretEnv",
+			RESERVED_RUNTIME_ENV_VARS,
+		);
+		for (const [name] of extraSecretEnvEntries) {
+			if (extraEnvEntries.some(([plainName]) => plainName === name)) {
+				throw new Error(
+					`LiteLLMProxy extraEnv and extraSecretEnv both define '${name}'`,
+				);
+			}
+		}
+		assertNoEnvOverlap(
+			extraEnvEntries.map(([name]) => name),
+			staticProviderEnvVarNames,
+			"LiteLLMProxy extraEnv",
+		);
+		assertNoEnvOverlap(
+			extraSecretEnvEntries.map(([name]) => name),
+			staticProviderEnvVarNames,
+			"LiteLLMProxy extraSecretEnv",
+		);
 
 		const providerSecretName = `${name}-provider-keys`;
 
@@ -132,6 +216,14 @@ export class LiteLLMProxy extends pulumi.ComponentResource {
 			providers
 				.filter((provider) => provider.hasApiKey && provider.envVar)
 				.map((provider) => provider.envVar!),
+		);
+		const extraEnv = pulumi.all(
+			extraEnvEntries.map(([name, value]) =>
+				pulumi.output(value).apply((resolvedValue) => ({
+					name,
+					value: resolvedValue,
+				})),
+			),
 		);
 
 		const configYaml = pulumi
@@ -250,11 +342,18 @@ export class LiteLLMProxy extends pulumi.ComponentResource {
 		);
 
 		const runtimeSecretData = pulumi
-			.all([this.masterKey, effectiveDatabaseUrl])
-			.apply<Record<string, string>>(([masterKey, databaseUrl]) => ({
-				LITELLM_MASTER_KEY: masterKey,
-				DATABASE_URL: databaseUrl,
-			}));
+			.all([
+				this.masterKey,
+				effectiveDatabaseUrl,
+				pulumi.output(args.extraSecretEnv ?? {}),
+			])
+			.apply<Record<string, string>>(
+				([masterKey, databaseUrl, extraSecretEnv]) => ({
+					LITELLM_MASTER_KEY: masterKey,
+					DATABASE_URL: databaseUrl,
+					...extraSecretEnv,
+				}),
+			);
 
 		this.runtimeSecret = new k8s.core.v1.Secret(
 			`${name}-runtime`,
@@ -297,36 +396,56 @@ export class LiteLLMProxy extends pulumi.ComponentResource {
 				providerEnvVars,
 				this.runtimeSecret.metadata.name,
 				this.providerSecret.metadata.name,
+				extraEnv,
 			])
-			.apply(([envVars, runtimeSecretName, providerSecretName]) => [
-				{
-					name: "LITELLM_MASTER_KEY",
-					valueFrom: {
-						secretKeyRef: {
-							name: runtimeSecretName,
-							key: "LITELLM_MASTER_KEY",
+			.apply(
+				([
+					providerSecretEnvVars,
+					runtimeSecretName,
+					providerSecretName,
+					extraEnvVars,
+				]) => {
+					return [
+						{
+							name: "LITELLM_MASTER_KEY",
+							valueFrom: {
+								secretKeyRef: {
+									name: runtimeSecretName,
+									key: "LITELLM_MASTER_KEY",
+								},
+							},
 						},
-					},
+						{
+							name: "DATABASE_URL",
+							valueFrom: {
+								secretKeyRef: {
+									name: runtimeSecretName,
+									key: "DATABASE_URL",
+								},
+							},
+						},
+						...providerSecretEnvVars.map((envVar) => ({
+							name: envVar,
+							valueFrom: {
+								secretKeyRef: {
+									name: providerSecretName,
+									key: toSecretKey(envVar),
+								},
+							},
+						})),
+						...extraSecretEnvEntries.map(([name]) => ({
+							name,
+							valueFrom: {
+								secretKeyRef: {
+									name: runtimeSecretName,
+									key: name,
+								},
+							},
+						})),
+						...extraEnvVars,
+					];
 				},
-				{
-					name: "DATABASE_URL",
-					valueFrom: {
-						secretKeyRef: {
-							name: runtimeSecretName,
-							key: "DATABASE_URL",
-						},
-					},
-				},
-				...envVars.map((envVar) => ({
-					name: envVar,
-					valueFrom: {
-						secretKeyRef: {
-							name: providerSecretName,
-							key: toSecretKey(envVar),
-						},
-					},
-				})),
-			]);
+			);
 
 		this.deployment = new k8s.apps.v1.Deployment(
 			`${name}-deployment`,

--- a/packages/sector7/litellm/litellm-proxy.ts
+++ b/packages/sector7/litellm/litellm-proxy.ts
@@ -203,21 +203,31 @@ export class LiteLLMProxy extends pulumi.ComponentResource {
 				.filter((provider) => provider.hasApiKey && provider.envVar)
 				.map((provider) => provider.envVar!),
 		);
-		const extraEnv = pulumi.all(
-			extraEnvEntries.map(([name, value]) =>
-				pulumi.output(value).apply((resolvedValue) => ({
-					name,
-					value: resolvedValue,
-				})),
-			),
-		);
+		const extraEnv = pulumi
+			.all(
+				extraEnvEntries.map(([name, value]) =>
+					pulumi.output(value).apply((resolvedValue) =>
+						resolvedValue == null ? undefined : { name, value: resolvedValue },
+					),
+				),
+			)
+			.apply((entries) =>
+				entries.filter(
+					(entry): entry is { name: string; value: string } => entry !== undefined,
+				),
+			);
 		const extraSecretEnv = pulumi
 			.all(
 				extraSecretEnvEntries.map(([name, value]) =>
-					pulumi.output(value).apply((resolvedValue) => [name, resolvedValue] as const),
+					pulumi.output(value).apply((resolvedValue) =>
+						resolvedValue == null ? undefined : ([name, resolvedValue] as const),
+					),
 				),
 			)
-			.apply((entries) => Object.fromEntries(entries));
+			.apply((entries) =>
+				Object.fromEntries(entries.filter((entry): entry is readonly [string, string] => entry !== undefined)),
+			);
+		const extraSecretEnvKeys = extraSecretEnv.apply((resolvedEnv) => Object.keys(resolvedEnv));
 
 		const configYaml = pulumi
 			.all([resolvedProviderConfigs, resolvedDeployments, replicas])
@@ -384,6 +394,7 @@ export class LiteLLMProxy extends pulumi.ComponentResource {
 				this.runtimeSecret.metadata.name,
 				this.providerSecret.metadata.name,
 				extraEnv,
+				extraSecretEnvKeys,
 			])
 			.apply(
 				([
@@ -391,6 +402,7 @@ export class LiteLLMProxy extends pulumi.ComponentResource {
 					runtimeSecretName,
 					providerSecretName,
 					extraEnvVars,
+					resolvedExtraSecretEnvKeys,
 				]) => {
 					validateExtraEnvNameCollisions(
 						extraEnvEntries.map(([name]) => name),
@@ -425,7 +437,7 @@ export class LiteLLMProxy extends pulumi.ComponentResource {
 								},
 							},
 						})),
-						...extraSecretEnvEntries.map(([name]) => ({
+						...resolvedExtraSecretEnvKeys.map((name) => ({
 							name,
 							valueFrom: {
 								secretKeyRef: {

--- a/packages/sector7/tests/litellm-proxy.test.ts
+++ b/packages/sector7/tests/litellm-proxy.test.ts
@@ -1,7 +1,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import { beforeAll, beforeEach, describe, expect, it } from "vitest";
 import { LiteLLMApiKey, LiteLLMTeam } from "../litellm/admin.ts";
-import { LiteLLMProxy } from "../litellm/litellm-proxy.ts";
+import { LiteLLMProxy, validateExtraEnvNameCollisions } from "../litellm/litellm-proxy.ts";
 import {
 	findResource,
 	installPulumiMocks,
@@ -244,27 +244,28 @@ describe("LiteLLMProxy", () => {
 		});
 	});
 
-	it("rejects collisions between provider secrets and extra env", () => {
-		expect(
-			() =>
-				new LiteLLMProxy("conflict-proxy", {
-					namespace: "litellm-prod",
-					providers: { anthropic: { apiKey: pulumi.secret("anthropic-secret") } },
-					deployments: [
-						{
-							id: "anthropic-smart",
-							provider: "anthropic",
-							providerModel: "anthropic/claude-sonnet-4-20250514",
-						},
-					],
-					modelGroups: [{ name: "smart", deploymentIds: ["anthropic-smart"] }],
-					databaseUrl: pulumi.secret("postgres://db-user:***@db.internal/litellm"),
-					extraEnv: {
-						ANTHROPIC_API_KEY: "should-not-override-provider-secret",
-					},
-				}),
+	it("rejects collisions between provider secrets and extra env names", () => {
+		expect(() =>
+			validateExtraEnvNameCollisions(
+				["ANTHROPIC_API_KEY"],
+				[],
+				["ANTHROPIC_API_KEY"],
+			),
 		).toThrow(
 			"extraEnv cannot override provider environment variable 'ANTHROPIC_API_KEY'",
+		);
+	});
+
+	it("rejects collisions against provider env vars resolved from outputs", async () => {
+		const resolvedProviderEnvVar = await resolveOutput(pulumi.output("LANGFUSE_SECRET_KEY"));
+		expect(() =>
+			validateExtraEnvNameCollisions(
+				[],
+				["LANGFUSE_SECRET_KEY"],
+				[resolvedProviderEnvVar],
+			),
+		).toThrow(
+			"extraSecretEnv cannot override provider environment variable 'LANGFUSE_SECRET_KEY'",
 		);
 	});
 

--- a/packages/sector7/tests/litellm-proxy.test.ts
+++ b/packages/sector7/tests/litellm-proxy.test.ts
@@ -182,6 +182,92 @@ describe("LiteLLMProxy", () => {
 		expect(await resolveOutput(proxy.namespace)).toBe("shared-services");
 	});
 
+	it("injects extra env and extra secret env into the proxy container", async () => {
+		const proxy = new LiteLLMProxy("observed-proxy", {
+			namespace: "litellm-prod",
+			providers: { anthropic: { apiKey: pulumi.secret("anthropic-secret") } },
+			deployments: [
+				{
+					id: "anthropic-smart",
+					provider: "anthropic",
+					providerModel: "anthropic/claude-sonnet-4-20250514",
+				},
+			],
+			modelGroups: [{ name: "smart", deploymentIds: ["anthropic-smart"] }],
+			databaseUrl: pulumi.secret("postgres://db-user:***@db.internal/litellm"),
+			extraEnv: {
+				LANGFUSE_TRACING_ENVIRONMENT: "prod",
+			},
+			extraSecretEnv: {
+				LANGFUSE_PUBLIC_KEY: pulumi.secret("pk-lf-test"),
+				LANGFUSE_SECRET_KEY: pulumi.secret("sk-lf-test"),
+				LANGFUSE_HOST: "http://langfuse-web.langfuse.svc.cluster.local:3000",
+			},
+		});
+
+		await Promise.all([
+			resolveOutput(proxy.runtimeSecret.id),
+			resolveOutput(proxy.deployment.id),
+		]);
+
+		const runtimeSecret = findResource("observed-proxy-runtime");
+		const runtimeSecretData = runtimeSecret?.inputs.stringData as {
+			value: Record<string, string>;
+		};
+		expect(runtimeSecretData.value).toMatchObject({
+			LANGFUSE_PUBLIC_KEY: "pk-lf-test",
+			LANGFUSE_SECRET_KEY: "sk-lf-test",
+			LANGFUSE_HOST: "http://langfuse-web.langfuse.svc.cluster.local:3000",
+		});
+
+		const deployment = findResource("observed-proxy-deployment");
+		const spec = (await resolveRecord(
+			deployment?.inputs.spec as Record<string, unknown> | undefined,
+		)) as {
+			template: { spec: { containers: Array<{ env?: Array<Record<string, unknown>> }> } };
+		};
+		const env = spec.template.spec.containers[0]?.env ?? [];
+		expect(
+			env.find((entry) => entry.name === "LANGFUSE_TRACING_ENVIRONMENT"),
+		).toMatchObject({
+			name: "LANGFUSE_TRACING_ENVIRONMENT",
+			value: "prod",
+		});
+		expect(env.find((entry) => entry.name === "LANGFUSE_HOST")).toMatchObject({
+			name: "LANGFUSE_HOST",
+			valueFrom: {
+				secretKeyRef: {
+					name: "observed-proxy-runtime",
+					key: "LANGFUSE_HOST",
+				},
+			},
+		});
+	});
+
+	it("rejects collisions between provider secrets and extra env", () => {
+		expect(
+			() =>
+				new LiteLLMProxy("conflict-proxy", {
+					namespace: "litellm-prod",
+					providers: { anthropic: { apiKey: pulumi.secret("anthropic-secret") } },
+					deployments: [
+						{
+							id: "anthropic-smart",
+							provider: "anthropic",
+							providerModel: "anthropic/claude-sonnet-4-20250514",
+						},
+					],
+					modelGroups: [{ name: "smart", deploymentIds: ["anthropic-smart"] }],
+					databaseUrl: pulumi.secret("postgres://db-user:***@db.internal/litellm"),
+					extraEnv: {
+						ANTHROPIC_API_KEY: "should-not-override-provider-secret",
+					},
+				}),
+		).toThrow(
+			"extraEnv cannot override provider environment variable 'ANTHROPIC_API_KEY'",
+		);
+	});
+
 	it("creates admin command resources for teams and api keys", async () => {
 		const team = new LiteLLMTeam("personal-team", {
 			proxyNamespace: "litellm-prod",

--- a/packages/sector7/tests/litellm-proxy.test.ts
+++ b/packages/sector7/tests/litellm-proxy.test.ts
@@ -269,6 +269,58 @@ describe("LiteLLMProxy", () => {
 		);
 	});
 
+	it("omits nullish resolved extra env values from rendered resources", async () => {
+		const proxy = new LiteLLMProxy("filtered-proxy", {
+			namespace: "litellm-prod",
+			providers: { anthropic: { apiKey: pulumi.secret("anthropic-secret") } },
+			deployments: [
+				{
+					id: "anthropic-smart",
+					provider: "anthropic",
+					providerModel: "anthropic/claude-sonnet-4-20250514",
+				},
+			],
+			modelGroups: [{ name: "smart", deploymentIds: ["anthropic-smart"] }],
+			databaseUrl: pulumi.secret("postgres://db-user:***@db.internal/litellm"),
+			extraEnv: {
+				LANGFUSE_TRACING_ENVIRONMENT: "prod",
+				IGNORED_ENV: undefined as unknown as pulumi.Input<string>,
+			},
+			extraSecretEnv: {
+				LANGFUSE_SECRET_KEY: pulumi.secret("sk-lf-test"),
+				IGNORED_SECRET: undefined as unknown as pulumi.Input<string>,
+			},
+		});
+
+		await Promise.all([
+			resolveOutput(proxy.runtimeSecret.id),
+			resolveOutput(proxy.deployment.id),
+		]);
+
+		const runtimeSecret = findResource("filtered-proxy-runtime");
+		const runtimeSecretData = runtimeSecret?.inputs.stringData as {
+			value: Record<string, string>;
+		};
+		expect(runtimeSecretData.value).toMatchObject({
+			LANGFUSE_SECRET_KEY: "sk-lf-test",
+		});
+		expect(runtimeSecretData.value).not.toHaveProperty("IGNORED_SECRET");
+
+		const deployment = findResource("filtered-proxy-deployment");
+		const spec = (await resolveRecord(
+			deployment?.inputs.spec as Record<string, unknown> | undefined,
+		)) as {
+			template: { spec: { containers: Array<{ env?: Array<Record<string, unknown>> }> } };
+		};
+		const env = spec.template.spec.containers[0]?.env ?? [];
+		expect(env.find((entry) => entry.name === "LANGFUSE_TRACING_ENVIRONMENT")).toMatchObject({
+			name: "LANGFUSE_TRACING_ENVIRONMENT",
+			value: "prod",
+		});
+		expect(env.find((entry) => entry.name === "IGNORED_ENV")).toBeUndefined();
+		expect(env.find((entry) => entry.name === "IGNORED_SECRET")).toBeUndefined();
+	});
+
 	it("creates admin command resources for teams and api keys", async () => {
 		const team = new LiteLLMTeam("personal-team", {
 			proxyNamespace: "litellm-prod",


### PR DESCRIPTION
## Summary
- add `extraEnv` and `extraSecretEnv` to `LiteLLMProxyArgs`
- inject `extraSecretEnv` via the component-managed runtime Secret and `extraEnv` directly on the LiteLLM container
- reject collisions with reserved runtime vars and provider API key env vars
- cover the new wiring and guardrails with LiteLLM proxy tests

## Why
Garden needs to feed Langfuse proxy-side tracing config into the shared `LiteLLMProxy` component without forking the deployment shape. Yard already proved the runtime pattern we need: some values are plain env flags, others are secret callback credentials.

The current sector7 release only exposes provider API key env wiring plus the fixed runtime vars (`LITELLM_MASTER_KEY`, `DATABASE_URL`). That made downstream repos choose between hand-rolled LiteLLM deployments or patching sector7 locally.

This change keeps the component backward-compatible while making it flexible enough for both:
- garden-style StackReference-driven Langfuse wiring
- addendalabs-style proxy integrations that need arbitrary runtime env injection

## Implementation notes
- `extraSecretEnv` is merged into the existing runtime Secret rather than creating a second secret resource.
- `extraEnv` stays non-secret and is rendered directly into the Deployment env list.
- collisions now fail fast for:
  - `LITELLM_MASTER_KEY`
  - `DATABASE_URL`
  - provider env vars like `ANTHROPIC_API_KEY`
  - duplicate names across `extraEnv` and `extraSecretEnv`

## Validation
- `vitest run tests/litellm-proxy.test.ts`
- `vitest run`
- `tsc -p tsconfig.build.json`
- `node tools/copy-shell-scripts.mjs` after a clean `dist/`

## Downstream impact
This is additive. Existing consumers do not need to change.

Follow-up in garden can now pass:
- `LANGFUSE_PUBLIC_KEY`
- `LANGFUSE_SECRET_KEY`
- `LANGFUSE_HOST`
- optional non-secret env like `LANGFUSE_TRACING_ENVIRONMENT`
through the shared component instead of reimplementing the Deployment.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive proxy env/secret wiring with explicit collision guards; no change to existing auth or provider key behavior unless misconfigured names are supplied.
> 
> **Overview**
> Adds **`extraEnv`** and **`extraSecretEnv`** to **`LiteLLMProxy`** so callers can pass integration settings (e.g. Langfuse tracing) without forking the Deployment.
> 
> **`extraEnv`** is rendered as plain container env vars; **`extraSecretEnv`** is merged into the existing **runtime Secret** and mounted via **`secretKeyRef`**. **`validateExtraEnvNameCollisions`** fails fast on duplicates, overlap between the two maps, overrides of **`LITELLM_MASTER_KEY`** / **`DATABASE_URL`**, and clashes with provider API-key env vars (including after Pulumi outputs resolve). Nullish **`extraEnv`** / **`extraSecretEnv`** values are dropped from the rendered Secret and Deployment.
> 
> Tests cover injection, collision errors, and filtered null entries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ae8f080797d6c410b946192daca961d24716ca98. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->