### PR TITLE
fix(nix-image): pin skopeo-nix2container to known-good nix2container rev (v0.11.3)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@jmmaloney4/sector7",
 	"private": true,
-	"version": "0.11.2",
+	"version": "0.11.3",
 	"description": "Sector7 monorepo",
 	"license": "MPL-2.0",
 	"workspaces": [

--- a/packages/sector7/package.json
+++ b/packages/sector7/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@jmmaloney4/sector7",
-	"version": "0.11.2",
+	"version": "0.11.3",
 	"description": "Reusable Pulumi components for infrastructure management",
 	"license": "MPL-2.0",
 	"publishConfig": {

--- a/packages/sector7/scripts/nix-image-build-push.sh
+++ b/packages/sector7/scripts/nix-image-build-push.sh
@@ -98,7 +98,7 @@ chmod 600 "${AUTH_FILE}"
 if [ "${SCRIPT_MODE}" = "resolve" ]; then
   # Resolve-only: inspect the already-pushed image to get its digest
   echo "--- resolving digest ---"
-  nix run github:nlewo/nix2container/v1.0.0#skopeo-nix2container -- \
+  nix run github:nlewo/nix2container/76be9608a7f4d6c985d28b0e7be903ae2547df3e#skopeo-nix2container -- \
     --insecure-policy inspect --format '{{.Digest}}' \
     --authfile "${AUTH_FILE}" \
     docker://"${FULL_TAG}" |
@@ -115,7 +115,7 @@ else
 
   # Push the image
   echo "--- skopeo copy ---"
-  nix run github:nlewo/nix2container/v1.0.0#skopeo-nix2container -- \
+  nix run github:nlewo/nix2container/76be9608a7f4d6c985d28b0e7be903ae2547df3e#skopeo-nix2container -- \
     --insecure-policy copy --digestfile "${DIGEST_FILE}" \
     --authfile "${AUTH_FILE}" \
     "${IMAGE_PATH}" \

--- a/packages/sector7/scripts/nix-image-push.sh
+++ b/packages/sector7/scripts/nix-image-push.sh
@@ -85,7 +85,7 @@ chmod 600 "${AUTH_FILE}"
 
 if [ "${SCRIPT_MODE}" = "resolve" ]; then
   echo "--- resolving digest ---"
-  nix run github:nlewo/nix2container/v1.0.0#skopeo-nix2container -- \
+  nix run github:nlewo/nix2container/76be9608a7f4d6c985d28b0e7be903ae2547df3e#skopeo-nix2container -- \
     --insecure-policy inspect --format '{{.Digest}}' \
     --authfile "${AUTH_FILE}" \
     docker://"${FULL_TAG}" |
@@ -95,7 +95,7 @@ else
   IMAGE_PATH="nix:${STORE_PATH}"
 
   echo "--- skopeo copy ---"
-  nix run github:nlewo/nix2container/v1.0.0#skopeo-nix2container -- \
+  nix run github:nlewo/nix2container/76be9608a7f4d6c985d28b0e7be903ae2547df3e#skopeo-nix2container -- \
     --insecure-policy copy --digestfile "${DIGEST_FILE}" \
     --authfile "${AUTH_FILE}" \
     "${IMAGE_PATH}" \


### PR DESCRIPTION
## Summary

The four `nix run github:nlewo/nix2container/v1.0.0#skopeo-nix2container` call sites in `nix-image-push.sh` and `nix-image-build-push.sh` fail to build: the `v1.0.0` tag's skopeo pins a fixed-output patch hash (`sha256-dKEObf…`) that GitHub invalidated by changing how it serves `.patch` URLs (now `sha256-1Tj9D+…`). This breaks **every** nix-image build/push/resolve that goes through these scripts — e.g. garden's codex-proxy image during `pulumi up`.

Pin all four call sites to nix2container rev `76be9608` (known-good; the rev garden's flake already pins). Bumps sector7 to 0.11.3.

## Test plan
- [x] `pnpm run build` succeeds; dist/scripts carry the pinned rev (verified all 4 sites)
- [ ] Consumer `pulumi up` (garden litellm) builds + pushes the codex-proxy image

Note: CI publish runs on self-hosted runners which are currently down; release tgz will be cut accordingly.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Shell-only dependency pin and version bump; no application auth, data, or API logic changes.
> 
> **Overview**
> Restores **nix-image** build, push, and digest-resolve flows by pinning `skopeo-nix2container` to nix2container commit `76be9608…` instead of the `v1.0.0` flake ref. All four `nix run github:nlewo/nix2container/…#skopeo-nix2container` invocations in `nix-image-push.sh` and `nix-image-build-push.sh` use that rev.
> 
> Bumps the monorepo and `@jmmaloney4/sector7` package version to **0.11.3**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e7322793cbd3b840be70f9c965f5232ead9e2ca1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->