### PR TITLE
feat(litellm): add extraSecretRefEnv to consume external Secrets (v0.11.4)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@jmmaloney4/sector7",
 	"private": true,
-	"version": "0.11.3",
+	"version": "0.11.4",
 	"description": "Sector7 monorepo",
 	"license": "MPL-2.0",
 	"workspaces": [

--- a/packages/sector7/litellm/config-types.ts
+++ b/packages/sector7/litellm/config-types.ts
@@ -210,6 +210,21 @@ export interface LiteLLMProxyArgs {
 	 * be stored in git-tracked config.
 	 */
 	extraSecretEnv?: Record<string, pulumi.Input<string>>;
+	/**
+	 * Additional secret environment variables sourced from a Kubernetes Secret
+	 * the component does NOT manage — e.g. a Secret materialized by the 1Password
+	 * operator from an `OnePasswordItem`. Each entry maps an environment variable
+	 * name to a `{ secretName, key }` reference rendered as `valueFrom.secretKeyRef`.
+	 *
+	 * Use this instead of `extraSecretEnv` when the value lives in an externally
+	 * managed Secret (so it never transits Pulumi state), and when the Secret's
+	 * key names differ from the desired env var names (e.g. a 1Password item whose
+	 * fields are labeled `username`/`credential`).
+	 */
+	extraSecretRefEnv?: Record<
+		string,
+		{ secretName: pulumi.Input<string>; key: pulumi.Input<string> }
+	>;
 	resources?: k8s.types.input.core.v1.ResourceRequirements;
 	extraLiteLLMSettings?: Record<string, unknown>;
 	extraGeneralSettings?: Record<string, unknown>;

--- a/packages/sector7/litellm/litellm-proxy.ts
+++ b/packages/sector7/litellm/litellm-proxy.ts
@@ -283,13 +283,28 @@ export class LiteLLMProxy extends pulumi.ComponentResource {
 		);
 		// Env vars sourced from externally-managed Secrets (e.g. 1Password operator),
 		// rendered as valueFrom.secretKeyRef. Never enter the component's runtime Secret.
-		const extraSecretRefEnv = pulumi.all(
-			extraSecretRefEnvEntries.map(([envName, ref]) =>
-				pulumi
-					.all([pulumi.output(ref.secretName), pulumi.output(ref.key)])
-					.apply(([secretName, key]) => ({ envName, secretName, key })),
-			),
-		);
+		// Entries whose secretName/key resolve to nullish are dropped, mirroring how
+		// extraEnv/extraSecretEnv handle nullish values, to avoid an invalid secretKeyRef.
+		const extraSecretRefEnv = pulumi
+			.all(
+				extraSecretRefEnvEntries.map(([envName, ref]) =>
+					pulumi
+						.all([pulumi.output(ref.secretName), pulumi.output(ref.key)])
+						.apply(([secretName, key]) =>
+							secretName == null || key == null
+								? undefined
+								: { envName, secretName, key },
+						),
+				),
+			)
+			.apply((entries) =>
+				entries.filter(
+					(
+						entry,
+					): entry is { envName: string; secretName: string; key: string } =>
+						entry !== undefined,
+				),
+			);
 
 		const configYaml = pulumi
 			.all([resolvedProviderConfigs, resolvedDeployments, replicas])

--- a/packages/sector7/litellm/litellm-proxy.ts
+++ b/packages/sector7/litellm/litellm-proxy.ts
@@ -20,7 +20,10 @@ type ResolvedDeployment = Omit<LiteLLMModelDeployment, "apiBase"> & {
 	apiBase?: string;
 };
 
-const RESERVED_RUNTIME_ENV_VARS = new Set(["LITELLM_MASTER_KEY", "DATABASE_URL"]);
+const RESERVED_RUNTIME_ENV_VARS = new Set([
+	"LITELLM_MASTER_KEY",
+	"DATABASE_URL",
+]);
 
 function toSecretKey(envVar: string): string {
 	return envVar.toLowerCase();
@@ -35,7 +38,9 @@ function assertUniqueEnvNames(
 	const seen = new Set<string>();
 	for (const name of names) {
 		if (seen.has(name)) {
-			throw new Error(`${context} contains duplicate environment variable '${name}'`);
+			throw new Error(
+				`${context} contains duplicate environment variable '${name}'`,
+			);
 		}
 		if (reservedSet.has(name)) {
 			throw new Error(
@@ -54,7 +59,9 @@ function assertNoEnvOverlap(
 	const conflictingNameSet = new Set(conflictingNames);
 	for (const name of names) {
 		if (conflictingNameSet.has(name)) {
-			throw new Error(`${context} cannot override provider environment variable '${name}'`);
+			throw new Error(
+				`${context} cannot override provider environment variable '${name}'`,
+			);
 		}
 	}
 }
@@ -63,6 +70,7 @@ export function validateExtraEnvNameCollisions(
 	extraEnvNames: string[],
 	extraSecretEnvNames: string[],
 	providerEnvVarNames: Iterable<string> = [],
+	extraSecretRefEnvNames: string[] = [],
 ): void {
 	assertUniqueEnvNames(
 		extraEnvNames,
@@ -74,17 +82,42 @@ export function validateExtraEnvNameCollisions(
 		"LiteLLMProxy extraSecretEnv",
 		RESERVED_RUNTIME_ENV_VARS,
 	);
-	const extraEnvKeys = new Set(extraEnvNames);
-	for (const name of extraSecretEnvNames) {
-		if (extraEnvKeys.has(name)) {
-			throw new Error(`LiteLLMProxy extraEnv and extraSecretEnv both define '${name}'`);
+	assertUniqueEnvNames(
+		extraSecretRefEnvNames,
+		"LiteLLMProxy extraSecretRefEnv",
+		RESERVED_RUNTIME_ENV_VARS,
+	);
+	// No env var name may be defined by more than one of the extra-env sources.
+	const seen = new Map<string, string>();
+	for (const [source, names] of [
+		["extraEnv", extraEnvNames],
+		["extraSecretEnv", extraSecretEnvNames],
+		["extraSecretRefEnv", extraSecretRefEnvNames],
+	] as const) {
+		for (const name of names) {
+			const prior = seen.get(name);
+			if (prior) {
+				throw new Error(
+					`LiteLLMProxy ${prior} and ${source} both define '${name}'`,
+				);
+			}
+			seen.set(name, source);
 		}
 	}
-	assertNoEnvOverlap(extraEnvNames, providerEnvVarNames, "LiteLLMProxy extraEnv");
+	assertNoEnvOverlap(
+		extraEnvNames,
+		providerEnvVarNames,
+		"LiteLLMProxy extraEnv",
+	);
 	assertNoEnvOverlap(
 		extraSecretEnvNames,
 		providerEnvVarNames,
 		"LiteLLMProxy extraSecretEnv",
+	);
+	assertNoEnvOverlap(
+		extraSecretRefEnvNames,
+		providerEnvVarNames,
+		"LiteLLMProxy extraSecretRefEnv",
 	);
 }
 
@@ -182,9 +215,14 @@ export class LiteLLMProxy extends pulumi.ComponentResource {
 		);
 		const extraEnvEntries = Object.entries(args.extraEnv ?? {});
 		const extraSecretEnvEntries = Object.entries(args.extraSecretEnv ?? {});
+		const extraSecretRefEnvEntries = Object.entries(
+			args.extraSecretRefEnv ?? {},
+		);
 		validateExtraEnvNameCollisions(
 			extraEnvEntries.map(([name]) => name),
 			extraSecretEnvEntries.map(([name]) => name),
+			[],
+			extraSecretRefEnvEntries.map(([name]) => name),
 		);
 
 		const providerSecretName = `${name}-provider-keys`;
@@ -206,28 +244,52 @@ export class LiteLLMProxy extends pulumi.ComponentResource {
 		const extraEnv = pulumi
 			.all(
 				extraEnvEntries.map(([name, value]) =>
-					pulumi.output(value).apply((resolvedValue) =>
-						resolvedValue == null ? undefined : { name, value: resolvedValue },
-					),
+					pulumi
+						.output(value)
+						.apply((resolvedValue) =>
+							resolvedValue == null
+								? undefined
+								: { name, value: resolvedValue },
+						),
 				),
 			)
 			.apply((entries) =>
 				entries.filter(
-					(entry): entry is { name: string; value: string } => entry !== undefined,
+					(entry): entry is { name: string; value: string } =>
+						entry !== undefined,
 				),
 			);
 		const extraSecretEnv = pulumi
 			.all(
 				extraSecretEnvEntries.map(([name, value]) =>
-					pulumi.output(value).apply((resolvedValue) =>
-						resolvedValue == null ? undefined : ([name, resolvedValue] as const),
-					),
+					pulumi
+						.output(value)
+						.apply((resolvedValue) =>
+							resolvedValue == null
+								? undefined
+								: ([name, resolvedValue] as const),
+						),
 				),
 			)
 			.apply((entries) =>
-				Object.fromEntries(entries.filter((entry): entry is readonly [string, string] => entry !== undefined)),
+				Object.fromEntries(
+					entries.filter(
+						(entry): entry is readonly [string, string] => entry !== undefined,
+					),
+				),
 			);
-		const extraSecretEnvKeys = extraSecretEnv.apply((resolvedEnv) => Object.keys(resolvedEnv));
+		const extraSecretEnvKeys = extraSecretEnv.apply((resolvedEnv) =>
+			Object.keys(resolvedEnv),
+		);
+		// Env vars sourced from externally-managed Secrets (e.g. 1Password operator),
+		// rendered as valueFrom.secretKeyRef. Never enter the component's runtime Secret.
+		const extraSecretRefEnv = pulumi.all(
+			extraSecretRefEnvEntries.map(([envName, ref]) =>
+				pulumi
+					.all([pulumi.output(ref.secretName), pulumi.output(ref.key)])
+					.apply(([secretName, key]) => ({ envName, secretName, key })),
+			),
+		);
 
 		const configYaml = pulumi
 			.all([resolvedProviderConfigs, resolvedDeployments, replicas])
@@ -395,6 +457,7 @@ export class LiteLLMProxy extends pulumi.ComponentResource {
 				this.providerSecret.metadata.name,
 				extraEnv,
 				extraSecretEnvKeys,
+				extraSecretRefEnv,
 			])
 			.apply(
 				([
@@ -403,11 +466,13 @@ export class LiteLLMProxy extends pulumi.ComponentResource {
 					providerSecretName,
 					extraEnvVars,
 					resolvedExtraSecretEnvKeys,
+					resolvedExtraSecretRefEnv,
 				]) => {
 					validateExtraEnvNameCollisions(
 						extraEnvEntries.map(([name]) => name),
 						extraSecretEnvEntries.map(([name]) => name),
 						providerSecretEnvVars,
+						resolvedExtraSecretRefEnv.map(({ envName }) => envName),
 					);
 					return [
 						{
@@ -446,6 +511,17 @@ export class LiteLLMProxy extends pulumi.ComponentResource {
 								},
 							},
 						})),
+						...resolvedExtraSecretRefEnv.map(
+							({ envName, secretName, key }) => ({
+								name: envName,
+								valueFrom: {
+									secretKeyRef: {
+										name: secretName,
+										key,
+									},
+								},
+							}),
+						),
 						...extraEnvVars,
 					];
 				},

--- a/packages/sector7/package.json
+++ b/packages/sector7/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@jmmaloney4/sector7",
-	"version": "0.11.3",
+	"version": "0.11.4",
 	"description": "Reusable Pulumi components for infrastructure management",
 	"license": "MPL-2.0",
 	"publishConfig": {

--- a/packages/sector7/tests/litellm-proxy.test.ts
+++ b/packages/sector7/tests/litellm-proxy.test.ts
@@ -1,7 +1,10 @@
 import * as pulumi from "@pulumi/pulumi";
 import { beforeAll, beforeEach, describe, expect, it } from "vitest";
 import { LiteLLMApiKey, LiteLLMTeam } from "../litellm/admin.ts";
-import { LiteLLMProxy, validateExtraEnvNameCollisions } from "../litellm/litellm-proxy.ts";
+import {
+	LiteLLMProxy,
+	validateExtraEnvNameCollisions,
+} from "../litellm/litellm-proxy.ts";
 import {
 	findResource,
 	installPulumiMocks,
@@ -224,7 +227,9 @@ describe("LiteLLMProxy", () => {
 		const spec = (await resolveRecord(
 			deployment?.inputs.spec as Record<string, unknown> | undefined,
 		)) as {
-			template: { spec: { containers: Array<{ env?: Array<Record<string, unknown>> }> } };
+			template: {
+				spec: { containers: Array<{ env?: Array<Record<string, unknown>> }> };
+			};
 		};
 		const env = spec.template.spec.containers[0]?.env ?? [];
 		expect(
@@ -244,6 +249,67 @@ describe("LiteLLMProxy", () => {
 		});
 	});
 
+	it("injects extraSecretRefEnv from an externally-managed Secret", async () => {
+		const proxy = new LiteLLMProxy("oprefs-proxy", {
+			namespace: "litellm-prod",
+			providers: { anthropic: { apiKey: pulumi.secret("anthropic-secret") } },
+			deployments: [
+				{
+					id: "anthropic-smart",
+					provider: "anthropic",
+					providerModel: "anthropic/claude-sonnet-4-20250514",
+				},
+			],
+			modelGroups: [{ name: "smart", deploymentIds: ["anthropic-smart"] }],
+			databaseUrl: pulumi.secret("postgres://db-user:***@db.internal/litellm"),
+			extraSecretRefEnv: {
+				LANGFUSE_PUBLIC_KEY: {
+					secretName: "langfuse-api-keys",
+					key: "username",
+				},
+				LANGFUSE_SECRET_KEY: {
+					secretName: "langfuse-api-keys",
+					key: "credential",
+				},
+			},
+		});
+
+		await Promise.all([
+			resolveOutput(proxy.runtimeSecret.id),
+			resolveOutput(proxy.deployment.id),
+		]);
+
+		// The external secret values must NOT enter the component-managed runtime Secret.
+		const runtimeSecret = findResource("oprefs-proxy-runtime");
+		const runtimeData = runtimeSecret?.inputs.stringData as {
+			value: Record<string, string>;
+		};
+		expect(runtimeData.value).not.toHaveProperty("LANGFUSE_PUBLIC_KEY");
+		expect(runtimeData.value).not.toHaveProperty("LANGFUSE_SECRET_KEY");
+
+		const deployment = findResource("oprefs-proxy-deployment");
+		const spec = (await resolveRecord(
+			deployment?.inputs.spec as Record<string, unknown> | undefined,
+		)) as {
+			template: {
+				spec: { containers: Array<{ env?: Array<Record<string, unknown>> }> };
+			};
+		};
+		const env = spec.template.spec.containers[0]?.env ?? [];
+		expect(env.find((e) => e.name === "LANGFUSE_PUBLIC_KEY")).toMatchObject({
+			name: "LANGFUSE_PUBLIC_KEY",
+			valueFrom: {
+				secretKeyRef: { name: "langfuse-api-keys", key: "username" },
+			},
+		});
+		expect(env.find((e) => e.name === "LANGFUSE_SECRET_KEY")).toMatchObject({
+			name: "LANGFUSE_SECRET_KEY",
+			valueFrom: {
+				secretKeyRef: { name: "langfuse-api-keys", key: "credential" },
+			},
+		});
+	});
+
 	it("rejects collisions between provider secrets and extra env names", () => {
 		expect(() =>
 			validateExtraEnvNameCollisions(
@@ -257,7 +323,9 @@ describe("LiteLLMProxy", () => {
 	});
 
 	it("rejects collisions against provider env vars resolved from outputs", async () => {
-		const resolvedProviderEnvVar = await resolveOutput(pulumi.output("LANGFUSE_SECRET_KEY"));
+		const resolvedProviderEnvVar = await resolveOutput(
+			pulumi.output("LANGFUSE_SECRET_KEY"),
+		);
 		expect(() =>
 			validateExtraEnvNameCollisions(
 				[],
@@ -267,6 +335,43 @@ describe("LiteLLMProxy", () => {
 		).toThrow(
 			"extraSecretEnv cannot override provider environment variable 'LANGFUSE_SECRET_KEY'",
 		);
+	});
+
+	it("rejects collisions between extraSecretEnv and extraSecretRefEnv names", () => {
+		expect(() =>
+			validateExtraEnvNameCollisions(
+				[],
+				["LANGFUSE_PUBLIC_KEY"],
+				[],
+				["LANGFUSE_PUBLIC_KEY"],
+			),
+		).toThrow(
+			"extraSecretEnv and extraSecretRefEnv both define 'LANGFUSE_PUBLIC_KEY'",
+		);
+	});
+
+	it("rejects extraSecretRefEnv names that override provider env vars", () => {
+		expect(() =>
+			validateExtraEnvNameCollisions(
+				[],
+				[],
+				["ANTHROPIC_API_KEY"],
+				["ANTHROPIC_API_KEY"],
+			),
+		).toThrow(
+			"extraSecretRefEnv cannot override provider environment variable 'ANTHROPIC_API_KEY'",
+		);
+	});
+
+	it("accepts distinct extraSecretRefEnv names", () => {
+		expect(() =>
+			validateExtraEnvNameCollisions(
+				["LANGFUSE_HOST"],
+				["OTHER_SECRET"],
+				["ANTHROPIC_API_KEY"],
+				["LANGFUSE_PUBLIC_KEY", "LANGFUSE_SECRET_KEY"],
+			),
+		).not.toThrow();
 	});
 
 	it("omits nullish resolved extra env values from rendered resources", async () => {
@@ -310,15 +415,21 @@ describe("LiteLLMProxy", () => {
 		const spec = (await resolveRecord(
 			deployment?.inputs.spec as Record<string, unknown> | undefined,
 		)) as {
-			template: { spec: { containers: Array<{ env?: Array<Record<string, unknown>> }> } };
+			template: {
+				spec: { containers: Array<{ env?: Array<Record<string, unknown>> }> };
+			};
 		};
 		const env = spec.template.spec.containers[0]?.env ?? [];
-		expect(env.find((entry) => entry.name === "LANGFUSE_TRACING_ENVIRONMENT")).toMatchObject({
+		expect(
+			env.find((entry) => entry.name === "LANGFUSE_TRACING_ENVIRONMENT"),
+		).toMatchObject({
 			name: "LANGFUSE_TRACING_ENVIRONMENT",
 			value: "prod",
 		});
 		expect(env.find((entry) => entry.name === "IGNORED_ENV")).toBeUndefined();
-		expect(env.find((entry) => entry.name === "IGNORED_SECRET")).toBeUndefined();
+		expect(
+			env.find((entry) => entry.name === "IGNORED_SECRET"),
+		).toBeUndefined();
 	});
 
 	it("creates admin command resources for teams and api keys", async () => {


### PR DESCRIPTION
## Summary

`LiteLLMProxy` could only inject secret env via `extraSecretEnv` — literal values packed into the component-managed runtime Secret. This adds **`extraSecretRefEnv`**: `Record<envName, { secretName, key }>` rendered as `valueFrom.secretKeyRef`, so the proxy can consume a Secret it does **not** manage (e.g. one synced by the 1Password operator from an `OnePasswordItem`), and map field-derived keys like `username`/`credential` to the desired env var names (`LANGFUSE_PUBLIC_KEY`/`LANGFUSE_SECRET_KEY`). Values never transit Pulumi state.

Collision validation now covers all three extra-env sources (extraEnv / extraSecretEnv / extraSecretRefEnv) + reserved + provider names.

## Test plan
- [x] `pnpm build`; `vitest` 166 pass (added 4: 3 collision + 1 rendering that asserts the secretKeyRef env entry and that the external values stay out of the runtime Secret)

## Context
Enables garden's litellm stack to source the Langfuse API keys from a 1Password item via the operator. Release v0.11.4.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches proxy Deployment env and secret wiring for credentials; behavior is additive with validation and tests, but misconfigured secret refs would break runtime env at deploy time.
> 
> **Overview**
> Adds **`extraSecretRefEnv`** to `LiteLLMProxy` so secret env vars can come from **externally managed** Kubernetes Secrets via `valueFrom.secretKeyRef`, instead of only via `extraSecretEnv` (values in the component runtime Secret / Pulumi state). Each entry maps an env name to `{ secretName, key }`, supporting different Secret key names (e.g. 1Password `username`/`credential` → `LANGFUSE_*`).
> 
> Collision checks now treat **`extraEnv`**, **`extraSecretEnv`**, and **`extraSecretRefEnv`** as one namespace (plus reserved and provider env vars). Nullish `secretName`/`key` refs are dropped like other extra env sources.
> 
> Bumps **`@jmmaloney4/sector7` to 0.11.4**; tests cover external-secret injection, runtime Secret exclusion, and new collision rules.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6d2c3ff7fe930abd04ef06aab428ddeac2274e02. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->