### PR TITLE
feat(litellm): source env vars from an existing secret via secretKeyRef

### DIFF
--- a/packages/sector7/litellm/config-types.ts
+++ b/packages/sector7/litellm/config-types.ts
@@ -176,6 +176,18 @@ export interface CloudSqlAuthProxy {
 	>;
 }
 
+/**
+ * Reference to a value in an existing Kubernetes Secret, used to inject an
+ * environment variable via `secretKeyRef` without the value passing through
+ * Pulumi state. See {@link LiteLLMProxyArgs.extraSecretRefEnv}.
+ */
+export interface LiteLLMSecretKeyRef {
+	/** Name of the existing Kubernetes Secret to read from. */
+	secretName: pulumi.Input<string>;
+	/** Key within that Secret holding the value. */
+	key: pulumi.Input<string>;
+}
+
 export interface LiteLLMProxyArgs {
 	namespace?: pulumi.Input<string>;
 	createNamespace?: boolean;
@@ -210,6 +222,16 @@ export interface LiteLLMProxyArgs {
 	 * be stored in git-tracked config.
 	 */
 	extraSecretEnv?: Record<string, pulumi.Input<string>>;
+	/**
+	 * Additional secret environment variables sourced from an existing
+	 * Kubernetes Secret via `secretKeyRef`, keyed by environment variable name.
+	 *
+	 * Unlike {@link extraSecretEnv} — whose values are written into the
+	 * component-managed runtime Secret — these reference a Secret managed
+	 * outside the component (for example one synced by the 1Password operator),
+	 * so the secret values never pass through Pulumi state.
+	 */
+	extraSecretRefEnv?: Record<string, LiteLLMSecretKeyRef>;
 	resources?: k8s.types.input.core.v1.ResourceRequirements;
 	extraLiteLLMSettings?: Record<string, unknown>;
 	extraGeneralSettings?: Record<string, unknown>;

--- a/packages/sector7/litellm/litellm-proxy.ts
+++ b/packages/sector7/litellm/litellm-proxy.ts
@@ -20,7 +20,10 @@ type ResolvedDeployment = Omit<LiteLLMModelDeployment, "apiBase"> & {
 	apiBase?: string;
 };
 
-const RESERVED_RUNTIME_ENV_VARS = new Set(["LITELLM_MASTER_KEY", "DATABASE_URL"]);
+const RESERVED_RUNTIME_ENV_VARS = new Set([
+	"LITELLM_MASTER_KEY",
+	"DATABASE_URL",
+]);
 
 function toSecretKey(envVar: string): string {
 	return envVar.toLowerCase();
@@ -35,7 +38,9 @@ function assertUniqueEnvNames(
 	const seen = new Set<string>();
 	for (const name of names) {
 		if (seen.has(name)) {
-			throw new Error(`${context} contains duplicate environment variable '${name}'`);
+			throw new Error(
+				`${context} contains duplicate environment variable '${name}'`,
+			);
 		}
 		if (reservedSet.has(name)) {
 			throw new Error(
@@ -54,7 +59,9 @@ function assertNoEnvOverlap(
 	const conflictingNameSet = new Set(conflictingNames);
 	for (const name of names) {
 		if (conflictingNameSet.has(name)) {
-			throw new Error(`${context} cannot override provider environment variable '${name}'`);
+			throw new Error(
+				`${context} cannot override provider environment variable '${name}'`,
+			);
 		}
 	}
 }
@@ -63,6 +70,7 @@ export function validateExtraEnvNameCollisions(
 	extraEnvNames: string[],
 	extraSecretEnvNames: string[],
 	providerEnvVarNames: Iterable<string> = [],
+	extraSecretRefEnvNames: string[] = [],
 ): void {
 	assertUniqueEnvNames(
 		extraEnvNames,
@@ -74,17 +82,46 @@ export function validateExtraEnvNameCollisions(
 		"LiteLLMProxy extraSecretEnv",
 		RESERVED_RUNTIME_ENV_VARS,
 	);
+	assertUniqueEnvNames(
+		extraSecretRefEnvNames,
+		"LiteLLMProxy extraSecretRefEnv",
+		RESERVED_RUNTIME_ENV_VARS,
+	);
 	const extraEnvKeys = new Set(extraEnvNames);
 	for (const name of extraSecretEnvNames) {
 		if (extraEnvKeys.has(name)) {
-			throw new Error(`LiteLLMProxy extraEnv and extraSecretEnv both define '${name}'`);
+			throw new Error(
+				`LiteLLMProxy extraEnv and extraSecretEnv both define '${name}'`,
+			);
 		}
 	}
-	assertNoEnvOverlap(extraEnvNames, providerEnvVarNames, "LiteLLMProxy extraEnv");
+	const secretEnvKeys = new Set(extraSecretEnvNames);
+	for (const name of extraSecretRefEnvNames) {
+		if (extraEnvKeys.has(name)) {
+			throw new Error(
+				`LiteLLMProxy extraEnv and extraSecretRefEnv both define '${name}'`,
+			);
+		}
+		if (secretEnvKeys.has(name)) {
+			throw new Error(
+				`LiteLLMProxy extraSecretEnv and extraSecretRefEnv both define '${name}'`,
+			);
+		}
+	}
+	assertNoEnvOverlap(
+		extraEnvNames,
+		providerEnvVarNames,
+		"LiteLLMProxy extraEnv",
+	);
 	assertNoEnvOverlap(
 		extraSecretEnvNames,
 		providerEnvVarNames,
 		"LiteLLMProxy extraSecretEnv",
+	);
+	assertNoEnvOverlap(
+		extraSecretRefEnvNames,
+		providerEnvVarNames,
+		"LiteLLMProxy extraSecretRefEnv",
 	);
 }
 
@@ -182,9 +219,14 @@ export class LiteLLMProxy extends pulumi.ComponentResource {
 		);
 		const extraEnvEntries = Object.entries(args.extraEnv ?? {});
 		const extraSecretEnvEntries = Object.entries(args.extraSecretEnv ?? {});
+		const extraSecretRefEnvEntries = Object.entries(
+			args.extraSecretRefEnv ?? {},
+		);
 		validateExtraEnvNameCollisions(
 			extraEnvEntries.map(([name]) => name),
 			extraSecretEnvEntries.map(([name]) => name),
+			[],
+			extraSecretRefEnvEntries.map(([name]) => name),
 		);
 
 		const providerSecretName = `${name}-provider-keys`;
@@ -206,28 +248,50 @@ export class LiteLLMProxy extends pulumi.ComponentResource {
 		const extraEnv = pulumi
 			.all(
 				extraEnvEntries.map(([name, value]) =>
-					pulumi.output(value).apply((resolvedValue) =>
-						resolvedValue == null ? undefined : { name, value: resolvedValue },
-					),
+					pulumi
+						.output(value)
+						.apply((resolvedValue) =>
+							resolvedValue == null
+								? undefined
+								: { name, value: resolvedValue },
+						),
 				),
 			)
 			.apply((entries) =>
 				entries.filter(
-					(entry): entry is { name: string; value: string } => entry !== undefined,
+					(entry): entry is { name: string; value: string } =>
+						entry !== undefined,
 				),
 			);
 		const extraSecretEnv = pulumi
 			.all(
 				extraSecretEnvEntries.map(([name, value]) =>
-					pulumi.output(value).apply((resolvedValue) =>
-						resolvedValue == null ? undefined : ([name, resolvedValue] as const),
-					),
+					pulumi
+						.output(value)
+						.apply((resolvedValue) =>
+							resolvedValue == null
+								? undefined
+								: ([name, resolvedValue] as const),
+						),
 				),
 			)
 			.apply((entries) =>
-				Object.fromEntries(entries.filter((entry): entry is readonly [string, string] => entry !== undefined)),
+				Object.fromEntries(
+					entries.filter(
+						(entry): entry is readonly [string, string] => entry !== undefined,
+					),
+				),
 			);
-		const extraSecretEnvKeys = extraSecretEnv.apply((resolvedEnv) => Object.keys(resolvedEnv));
+		const extraSecretEnvKeys = extraSecretEnv.apply((resolvedEnv) =>
+			Object.keys(resolvedEnv),
+		);
+		const extraSecretRefEnv = pulumi.all(
+			extraSecretRefEnvEntries.map(([name, ref]) =>
+				pulumi
+					.all([pulumi.output(ref.secretName), pulumi.output(ref.key)])
+					.apply(([secretName, key]) => ({ name, secretName, key })),
+			),
+		);
 
 		const configYaml = pulumi
 			.all([resolvedProviderConfigs, resolvedDeployments, replicas])
@@ -395,6 +459,7 @@ export class LiteLLMProxy extends pulumi.ComponentResource {
 				this.providerSecret.metadata.name,
 				extraEnv,
 				extraSecretEnvKeys,
+				extraSecretRefEnv,
 			])
 			.apply(
 				([
@@ -403,11 +468,13 @@ export class LiteLLMProxy extends pulumi.ComponentResource {
 					providerSecretName,
 					extraEnvVars,
 					resolvedExtraSecretEnvKeys,
+					resolvedExtraSecretRefEnv,
 				]) => {
 					validateExtraEnvNameCollisions(
 						extraEnvEntries.map(([name]) => name),
 						extraSecretEnvEntries.map(([name]) => name),
 						providerSecretEnvVars,
+						extraSecretRefEnvEntries.map(([name]) => name),
 					);
 					return [
 						{
@@ -443,6 +510,15 @@ export class LiteLLMProxy extends pulumi.ComponentResource {
 								secretKeyRef: {
 									name: runtimeSecretName,
 									key: name,
+								},
+							},
+						})),
+						...resolvedExtraSecretRefEnv.map((ref) => ({
+							name: ref.name,
+							valueFrom: {
+								secretKeyRef: {
+									name: ref.secretName,
+									key: ref.key,
 								},
 							},
 						})),

--- a/packages/sector7/tests/litellm-proxy.test.ts
+++ b/packages/sector7/tests/litellm-proxy.test.ts
@@ -1,7 +1,10 @@
 import * as pulumi from "@pulumi/pulumi";
 import { beforeAll, beforeEach, describe, expect, it } from "vitest";
 import { LiteLLMApiKey, LiteLLMTeam } from "../litellm/admin.ts";
-import { LiteLLMProxy, validateExtraEnvNameCollisions } from "../litellm/litellm-proxy.ts";
+import {
+	LiteLLMProxy,
+	validateExtraEnvNameCollisions,
+} from "../litellm/litellm-proxy.ts";
 import {
 	findResource,
 	installPulumiMocks,
@@ -224,7 +227,9 @@ describe("LiteLLMProxy", () => {
 		const spec = (await resolveRecord(
 			deployment?.inputs.spec as Record<string, unknown> | undefined,
 		)) as {
-			template: { spec: { containers: Array<{ env?: Array<Record<string, unknown>> }> } };
+			template: {
+				spec: { containers: Array<{ env?: Array<Record<string, unknown>> }> };
+			};
 		};
 		const env = spec.template.spec.containers[0]?.env ?? [];
 		expect(
@@ -244,6 +249,78 @@ describe("LiteLLMProxy", () => {
 		});
 	});
 
+	it("injects extra secret-ref env from an existing secret without storing values", async () => {
+		const proxy = new LiteLLMProxy("ref-proxy", {
+			namespace: "litellm-prod",
+			providers: { anthropic: { apiKey: pulumi.secret("anthropic-secret") } },
+			deployments: [
+				{
+					id: "anthropic-smart",
+					provider: "anthropic",
+					providerModel: "anthropic/claude-sonnet-4-20250514",
+				},
+			],
+			modelGroups: [{ name: "smart", deploymentIds: ["anthropic-smart"] }],
+			databaseUrl: pulumi.secret("postgres://db-user:***@db.internal/litellm"),
+			extraSecretRefEnv: {
+				LANGFUSE_PUBLIC_KEY: { secretName: "langfuse-keys", key: "username" },
+				LANGFUSE_SECRET_KEY: {
+					secretName: pulumi.output("langfuse-keys"),
+					key: "credential",
+				},
+			},
+		});
+
+		await Promise.all([
+			resolveOutput(proxy.runtimeSecret.id),
+			resolveOutput(proxy.deployment.id),
+		]);
+
+		// The referenced values must NOT be copied into the component-managed
+		// runtime secret — they live only in the external (operator-synced) secret.
+		const runtimeSecret = findResource("ref-proxy-runtime");
+		const runtimeSecretData = runtimeSecret?.inputs.stringData as {
+			value: Record<string, string>;
+		};
+		expect(runtimeSecretData.value).not.toHaveProperty("LANGFUSE_PUBLIC_KEY");
+		expect(runtimeSecretData.value).not.toHaveProperty("LANGFUSE_SECRET_KEY");
+
+		const deployment = findResource("ref-proxy-deployment");
+		const spec = (await resolveRecord(
+			deployment?.inputs.spec as Record<string, unknown> | undefined,
+		)) as {
+			template: {
+				spec: { containers: Array<{ env?: Array<Record<string, unknown>> }> };
+			};
+		};
+		const env = spec.template.spec.containers[0]?.env ?? [];
+		expect(
+			env.find((entry) => entry.name === "LANGFUSE_PUBLIC_KEY"),
+		).toMatchObject({
+			name: "LANGFUSE_PUBLIC_KEY",
+			valueFrom: { secretKeyRef: { name: "langfuse-keys", key: "username" } },
+		});
+		expect(
+			env.find((entry) => entry.name === "LANGFUSE_SECRET_KEY"),
+		).toMatchObject({
+			name: "LANGFUSE_SECRET_KEY",
+			valueFrom: { secretKeyRef: { name: "langfuse-keys", key: "credential" } },
+		});
+	});
+
+	it("rejects collisions between extraSecretEnv and extraSecretRefEnv", () => {
+		expect(() =>
+			validateExtraEnvNameCollisions(
+				[],
+				["LANGFUSE_SECRET_KEY"],
+				[],
+				["LANGFUSE_SECRET_KEY"],
+			),
+		).toThrow(
+			"LiteLLMProxy extraSecretEnv and extraSecretRefEnv both define 'LANGFUSE_SECRET_KEY'",
+		);
+	});
+
 	it("rejects collisions between provider secrets and extra env names", () => {
 		expect(() =>
 			validateExtraEnvNameCollisions(
@@ -257,7 +334,9 @@ describe("LiteLLMProxy", () => {
 	});
 
 	it("rejects collisions against provider env vars resolved from outputs", async () => {
-		const resolvedProviderEnvVar = await resolveOutput(pulumi.output("LANGFUSE_SECRET_KEY"));
+		const resolvedProviderEnvVar = await resolveOutput(
+			pulumi.output("LANGFUSE_SECRET_KEY"),
+		);
 		expect(() =>
 			validateExtraEnvNameCollisions(
 				[],
@@ -310,15 +389,21 @@ describe("LiteLLMProxy", () => {
 		const spec = (await resolveRecord(
 			deployment?.inputs.spec as Record<string, unknown> | undefined,
 		)) as {
-			template: { spec: { containers: Array<{ env?: Array<Record<string, unknown>> }> } };
+			template: {
+				spec: { containers: Array<{ env?: Array<Record<string, unknown>> }> };
+			};
 		};
 		const env = spec.template.spec.containers[0]?.env ?? [];
-		expect(env.find((entry) => entry.name === "LANGFUSE_TRACING_ENVIRONMENT")).toMatchObject({
+		expect(
+			env.find((entry) => entry.name === "LANGFUSE_TRACING_ENVIRONMENT"),
+		).toMatchObject({
 			name: "LANGFUSE_TRACING_ENVIRONMENT",
 			value: "prod",
 		});
 		expect(env.find((entry) => entry.name === "IGNORED_ENV")).toBeUndefined();
-		expect(env.find((entry) => entry.name === "IGNORED_SECRET")).toBeUndefined();
+		expect(
+			env.find((entry) => entry.name === "IGNORED_SECRET"),
+		).toBeUndefined();
 	});
 
 	it("creates admin command resources for teams and api keys", async () => {


### PR DESCRIPTION
## Summary

Adds `extraSecretRefEnv` to `LiteLLMProxy` — a map of env var name → `{ secretName, key }` that injects the variable into the proxy container via a Kubernetes `secretKeyRef` pointing at a Secret **managed outside the component**.

This complements the existing knobs:
- `extraEnv` — literal non-secret values rendered onto the Deployment.
- `extraSecretEnv` — secret values written into the component-managed `*-runtime` Secret (so they pass through Pulumi state).
- **`extraSecretRefEnv` (new)** — `secretKeyRef` to an existing Secret; values **never pass through Pulumi state**.

### Motivation
Lets a consumer source credentials (e.g. `LANGFUSE_PUBLIC_KEY`/`LANGFUSE_SECRET_KEY`) from a Secret synced by the **1Password Kubernetes operator** (`OnePasswordItem` CR), instead of resolving them into Pulumi config/state. garden's litellm stack will use this to pull the Langfuse keys from a 1Password item.

### Behavior
- Each entry renders `{ name, valueFrom: { secretKeyRef: { name: secretName, key } } }`.
- The referenced values are **not** copied into the `*-runtime` Secret.
- Name-collision validation (`validateExtraEnvNameCollisions`) is extended to check the new map for duplicates and against `extraEnv`, `extraSecretEnv`, reserved runtime vars (`LITELLM_MASTER_KEY`, `DATABASE_URL`), and provider env vars.

## Test plan
- New tests in `litellm-proxy.test.ts`:
  - injects `extraSecretRefEnv` as a `secretKeyRef` to the external secret **and** asserts the values are not written into the runtime Secret.
  - rejects an `extraSecretEnv` vs `extraSecretRefEnv` name collision.
- `pnpm build` (tsc) clean; full suite **164/164** green; `nix fmt` clean.

## Compatibility
Additive, optional field. No change to existing `extraEnv`/`extraSecretEnv` behavior.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Optional additive config and collision checks only; no changes to how existing secret env or core proxy credentials are managed.
> 
> **Overview**
> Adds **`extraSecretRefEnv`** on `LiteLLMProxy` so integration secrets can be injected via Kubernetes **`secretKeyRef`** to a Secret **outside** the component (e.g. 1Password operator–synced), instead of being written into the `*-runtime` Secret through Pulumi.
> 
> Introduces **`LiteLLMSecretKeyRef`** (`secretName`, `key`) and wires each entry into the Deployment env list. **`validateExtraEnvNameCollisions`** now covers the new map against `extraEnv`, `extraSecretEnv`, reserved vars, and provider env vars. Tests assert external refs on the Deployment, values **not** in the runtime Secret, and `extraSecretEnv` vs `extraSecretRefEnv` name clashes.
> 
> Additive, optional API; existing `extraEnv` / `extraSecretEnv` behavior unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3224675d35f3ebdbefd662f2bb254d9a9149b334. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->