### PR TITLE
release: bump sector7 to 0.11.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@jmmaloney4/sector7",
 	"private": true,
-	"version": "0.11.3",
+	"version": "0.11.4",
 	"description": "Sector7 monorepo",
 	"license": "MPL-2.0",
 	"workspaces": [

--- a/packages/sector7/package.json
+++ b/packages/sector7/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@jmmaloney4/sector7",
-	"version": "0.11.3",
+	"version": "0.11.4",
 	"description": "Reusable Pulumi components for infrastructure management",
 	"license": "MPL-2.0",
 	"publishConfig": {


### PR DESCRIPTION
Release bump to **0.11.4**. Ships `extraSecretRefEnv` on `LiteLLMProxy` (#242) — source env vars from an existing Secret via `secretKeyRef` (values never pass through Pulumi state).

Bumps root + `packages/sector7` package.json. After merge, tag `v0.11.4` on the merge commit to publish the release tarball.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only version fields change; no runtime or infrastructure logic in this diff.
> 
> **Overview**
> Bumps the monorepo and published `@jmmaloney4/sector7` package version from **0.11.3** to **0.11.4** in the root and `packages/sector7` `package.json` files. This is a release-only change; the functional work for this version (notably `LiteLLMProxy` **`extraSecretRefEnv`** for env vars via external Secret `secretKeyRef`) is already on the branch from prior work and is what consumers get when **`v0.11.4`** is tagged and published after merge.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3f7264d5648c642514cb6a0d02d9a1009d430f2b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->