### PR TITLE
revert: back out duplicate extraSecretRefEnv (#242) + 0.11.4 bump (#243)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@jmmaloney4/sector7",
 	"private": true,
-	"version": "0.11.4",
+	"version": "0.11.3",
 	"description": "Sector7 monorepo",
 	"license": "MPL-2.0",
 	"workspaces": [

--- a/packages/sector7/litellm/config-types.ts
+++ b/packages/sector7/litellm/config-types.ts
@@ -176,18 +176,6 @@ export interface CloudSqlAuthProxy {
 	>;
 }
 
-/**
- * Reference to a value in an existing Kubernetes Secret, used to inject an
- * environment variable via `secretKeyRef` without the value passing through
- * Pulumi state. See {@link LiteLLMProxyArgs.extraSecretRefEnv}.
- */
-export interface LiteLLMSecretKeyRef {
-	/** Name of the existing Kubernetes Secret to read from. */
-	secretName: pulumi.Input<string>;
-	/** Key within that Secret holding the value. */
-	key: pulumi.Input<string>;
-}
-
 export interface LiteLLMProxyArgs {
 	namespace?: pulumi.Input<string>;
 	createNamespace?: boolean;
@@ -222,16 +210,6 @@ export interface LiteLLMProxyArgs {
 	 * be stored in git-tracked config.
 	 */
 	extraSecretEnv?: Record<string, pulumi.Input<string>>;
-	/**
-	 * Additional secret environment variables sourced from an existing
-	 * Kubernetes Secret via `secretKeyRef`, keyed by environment variable name.
-	 *
-	 * Unlike {@link extraSecretEnv} — whose values are written into the
-	 * component-managed runtime Secret — these reference a Secret managed
-	 * outside the component (for example one synced by the 1Password operator),
-	 * so the secret values never pass through Pulumi state.
-	 */
-	extraSecretRefEnv?: Record<string, LiteLLMSecretKeyRef>;
 	resources?: k8s.types.input.core.v1.ResourceRequirements;
 	extraLiteLLMSettings?: Record<string, unknown>;
 	extraGeneralSettings?: Record<string, unknown>;

--- a/packages/sector7/litellm/litellm-proxy.ts
+++ b/packages/sector7/litellm/litellm-proxy.ts
@@ -20,10 +20,7 @@ type ResolvedDeployment = Omit<LiteLLMModelDeployment, "apiBase"> & {
 	apiBase?: string;
 };
 
-const RESERVED_RUNTIME_ENV_VARS = new Set([
-	"LITELLM_MASTER_KEY",
-	"DATABASE_URL",
-]);
+const RESERVED_RUNTIME_ENV_VARS = new Set(["LITELLM_MASTER_KEY", "DATABASE_URL"]);
 
 function toSecretKey(envVar: string): string {
 	return envVar.toLowerCase();
@@ -38,9 +35,7 @@ function assertUniqueEnvNames(
 	const seen = new Set<string>();
 	for (const name of names) {
 		if (seen.has(name)) {
-			throw new Error(
-				`${context} contains duplicate environment variable '${name}'`,
-			);
+			throw new Error(`${context} contains duplicate environment variable '${name}'`);
 		}
 		if (reservedSet.has(name)) {
 			throw new Error(
@@ -59,9 +54,7 @@ function assertNoEnvOverlap(
 	const conflictingNameSet = new Set(conflictingNames);
 	for (const name of names) {
 		if (conflictingNameSet.has(name)) {
-			throw new Error(
-				`${context} cannot override provider environment variable '${name}'`,
-			);
+			throw new Error(`${context} cannot override provider environment variable '${name}'`);
 		}
 	}
 }
@@ -70,7 +63,6 @@ export function validateExtraEnvNameCollisions(
 	extraEnvNames: string[],
 	extraSecretEnvNames: string[],
 	providerEnvVarNames: Iterable<string> = [],
-	extraSecretRefEnvNames: string[] = [],
 ): void {
 	assertUniqueEnvNames(
 		extraEnvNames,
@@ -82,46 +74,17 @@ export function validateExtraEnvNameCollisions(
 		"LiteLLMProxy extraSecretEnv",
 		RESERVED_RUNTIME_ENV_VARS,
 	);
-	assertUniqueEnvNames(
-		extraSecretRefEnvNames,
-		"LiteLLMProxy extraSecretRefEnv",
-		RESERVED_RUNTIME_ENV_VARS,
-	);
 	const extraEnvKeys = new Set(extraEnvNames);
 	for (const name of extraSecretEnvNames) {
 		if (extraEnvKeys.has(name)) {
-			throw new Error(
-				`LiteLLMProxy extraEnv and extraSecretEnv both define '${name}'`,
-			);
+			throw new Error(`LiteLLMProxy extraEnv and extraSecretEnv both define '${name}'`);
 		}
 	}
-	const secretEnvKeys = new Set(extraSecretEnvNames);
-	for (const name of extraSecretRefEnvNames) {
-		if (extraEnvKeys.has(name)) {
-			throw new Error(
-				`LiteLLMProxy extraEnv and extraSecretRefEnv both define '${name}'`,
-			);
-		}
-		if (secretEnvKeys.has(name)) {
-			throw new Error(
-				`LiteLLMProxy extraSecretEnv and extraSecretRefEnv both define '${name}'`,
-			);
-		}
-	}
-	assertNoEnvOverlap(
-		extraEnvNames,
-		providerEnvVarNames,
-		"LiteLLMProxy extraEnv",
-	);
+	assertNoEnvOverlap(extraEnvNames, providerEnvVarNames, "LiteLLMProxy extraEnv");
 	assertNoEnvOverlap(
 		extraSecretEnvNames,
 		providerEnvVarNames,
 		"LiteLLMProxy extraSecretEnv",
-	);
-	assertNoEnvOverlap(
-		extraSecretRefEnvNames,
-		providerEnvVarNames,
-		"LiteLLMProxy extraSecretRefEnv",
 	);
 }
 
@@ -219,14 +182,9 @@ export class LiteLLMProxy extends pulumi.ComponentResource {
 		);
 		const extraEnvEntries = Object.entries(args.extraEnv ?? {});
 		const extraSecretEnvEntries = Object.entries(args.extraSecretEnv ?? {});
-		const extraSecretRefEnvEntries = Object.entries(
-			args.extraSecretRefEnv ?? {},
-		);
 		validateExtraEnvNameCollisions(
 			extraEnvEntries.map(([name]) => name),
 			extraSecretEnvEntries.map(([name]) => name),
-			[],
-			extraSecretRefEnvEntries.map(([name]) => name),
 		);
 
 		const providerSecretName = `${name}-provider-keys`;
@@ -248,50 +206,28 @@ export class LiteLLMProxy extends pulumi.ComponentResource {
 		const extraEnv = pulumi
 			.all(
 				extraEnvEntries.map(([name, value]) =>
-					pulumi
-						.output(value)
-						.apply((resolvedValue) =>
-							resolvedValue == null
-								? undefined
-								: { name, value: resolvedValue },
-						),
+					pulumi.output(value).apply((resolvedValue) =>
+						resolvedValue == null ? undefined : { name, value: resolvedValue },
+					),
 				),
 			)
 			.apply((entries) =>
 				entries.filter(
-					(entry): entry is { name: string; value: string } =>
-						entry !== undefined,
+					(entry): entry is { name: string; value: string } => entry !== undefined,
 				),
 			);
 		const extraSecretEnv = pulumi
 			.all(
 				extraSecretEnvEntries.map(([name, value]) =>
-					pulumi
-						.output(value)
-						.apply((resolvedValue) =>
-							resolvedValue == null
-								? undefined
-								: ([name, resolvedValue] as const),
-						),
+					pulumi.output(value).apply((resolvedValue) =>
+						resolvedValue == null ? undefined : ([name, resolvedValue] as const),
+					),
 				),
 			)
 			.apply((entries) =>
-				Object.fromEntries(
-					entries.filter(
-						(entry): entry is readonly [string, string] => entry !== undefined,
-					),
-				),
+				Object.fromEntries(entries.filter((entry): entry is readonly [string, string] => entry !== undefined)),
 			);
-		const extraSecretEnvKeys = extraSecretEnv.apply((resolvedEnv) =>
-			Object.keys(resolvedEnv),
-		);
-		const extraSecretRefEnv = pulumi.all(
-			extraSecretRefEnvEntries.map(([name, ref]) =>
-				pulumi
-					.all([pulumi.output(ref.secretName), pulumi.output(ref.key)])
-					.apply(([secretName, key]) => ({ name, secretName, key })),
-			),
-		);
+		const extraSecretEnvKeys = extraSecretEnv.apply((resolvedEnv) => Object.keys(resolvedEnv));
 
 		const configYaml = pulumi
 			.all([resolvedProviderConfigs, resolvedDeployments, replicas])
@@ -459,7 +395,6 @@ export class LiteLLMProxy extends pulumi.ComponentResource {
 				this.providerSecret.metadata.name,
 				extraEnv,
 				extraSecretEnvKeys,
-				extraSecretRefEnv,
 			])
 			.apply(
 				([
@@ -468,13 +403,11 @@ export class LiteLLMProxy extends pulumi.ComponentResource {
 					providerSecretName,
 					extraEnvVars,
 					resolvedExtraSecretEnvKeys,
-					resolvedExtraSecretRefEnv,
 				]) => {
 					validateExtraEnvNameCollisions(
 						extraEnvEntries.map(([name]) => name),
 						extraSecretEnvEntries.map(([name]) => name),
 						providerSecretEnvVars,
-						extraSecretRefEnvEntries.map(([name]) => name),
 					);
 					return [
 						{
@@ -510,15 +443,6 @@ export class LiteLLMProxy extends pulumi.ComponentResource {
 								secretKeyRef: {
 									name: runtimeSecretName,
 									key: name,
-								},
-							},
-						})),
-						...resolvedExtraSecretRefEnv.map((ref) => ({
-							name: ref.name,
-							valueFrom: {
-								secretKeyRef: {
-									name: ref.secretName,
-									key: ref.key,
 								},
 							},
 						})),

--- a/packages/sector7/package.json
+++ b/packages/sector7/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@jmmaloney4/sector7",
-	"version": "0.11.4",
+	"version": "0.11.3",
 	"description": "Reusable Pulumi components for infrastructure management",
 	"license": "MPL-2.0",
 	"publishConfig": {

--- a/packages/sector7/tests/litellm-proxy.test.ts
+++ b/packages/sector7/tests/litellm-proxy.test.ts
@@ -1,10 +1,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import { beforeAll, beforeEach, describe, expect, it } from "vitest";
 import { LiteLLMApiKey, LiteLLMTeam } from "../litellm/admin.ts";
-import {
-	LiteLLMProxy,
-	validateExtraEnvNameCollisions,
-} from "../litellm/litellm-proxy.ts";
+import { LiteLLMProxy, validateExtraEnvNameCollisions } from "../litellm/litellm-proxy.ts";
 import {
 	findResource,
 	installPulumiMocks,
@@ -227,9 +224,7 @@ describe("LiteLLMProxy", () => {
 		const spec = (await resolveRecord(
 			deployment?.inputs.spec as Record<string, unknown> | undefined,
 		)) as {
-			template: {
-				spec: { containers: Array<{ env?: Array<Record<string, unknown>> }> };
-			};
+			template: { spec: { containers: Array<{ env?: Array<Record<string, unknown>> }> } };
 		};
 		const env = spec.template.spec.containers[0]?.env ?? [];
 		expect(
@@ -249,78 +244,6 @@ describe("LiteLLMProxy", () => {
 		});
 	});
 
-	it("injects extra secret-ref env from an existing secret without storing values", async () => {
-		const proxy = new LiteLLMProxy("ref-proxy", {
-			namespace: "litellm-prod",
-			providers: { anthropic: { apiKey: pulumi.secret("anthropic-secret") } },
-			deployments: [
-				{
-					id: "anthropic-smart",
-					provider: "anthropic",
-					providerModel: "anthropic/claude-sonnet-4-20250514",
-				},
-			],
-			modelGroups: [{ name: "smart", deploymentIds: ["anthropic-smart"] }],
-			databaseUrl: pulumi.secret("postgres://db-user:***@db.internal/litellm"),
-			extraSecretRefEnv: {
-				LANGFUSE_PUBLIC_KEY: { secretName: "langfuse-keys", key: "username" },
-				LANGFUSE_SECRET_KEY: {
-					secretName: pulumi.output("langfuse-keys"),
-					key: "credential",
-				},
-			},
-		});
-
-		await Promise.all([
-			resolveOutput(proxy.runtimeSecret.id),
-			resolveOutput(proxy.deployment.id),
-		]);
-
-		// The referenced values must NOT be copied into the component-managed
-		// runtime secret — they live only in the external (operator-synced) secret.
-		const runtimeSecret = findResource("ref-proxy-runtime");
-		const runtimeSecretData = runtimeSecret?.inputs.stringData as {
-			value: Record<string, string>;
-		};
-		expect(runtimeSecretData.value).not.toHaveProperty("LANGFUSE_PUBLIC_KEY");
-		expect(runtimeSecretData.value).not.toHaveProperty("LANGFUSE_SECRET_KEY");
-
-		const deployment = findResource("ref-proxy-deployment");
-		const spec = (await resolveRecord(
-			deployment?.inputs.spec as Record<string, unknown> | undefined,
-		)) as {
-			template: {
-				spec: { containers: Array<{ env?: Array<Record<string, unknown>> }> };
-			};
-		};
-		const env = spec.template.spec.containers[0]?.env ?? [];
-		expect(
-			env.find((entry) => entry.name === "LANGFUSE_PUBLIC_KEY"),
-		).toMatchObject({
-			name: "LANGFUSE_PUBLIC_KEY",
-			valueFrom: { secretKeyRef: { name: "langfuse-keys", key: "username" } },
-		});
-		expect(
-			env.find((entry) => entry.name === "LANGFUSE_SECRET_KEY"),
-		).toMatchObject({
-			name: "LANGFUSE_SECRET_KEY",
-			valueFrom: { secretKeyRef: { name: "langfuse-keys", key: "credential" } },
-		});
-	});
-
-	it("rejects collisions between extraSecretEnv and extraSecretRefEnv", () => {
-		expect(() =>
-			validateExtraEnvNameCollisions(
-				[],
-				["LANGFUSE_SECRET_KEY"],
-				[],
-				["LANGFUSE_SECRET_KEY"],
-			),
-		).toThrow(
-			"LiteLLMProxy extraSecretEnv and extraSecretRefEnv both define 'LANGFUSE_SECRET_KEY'",
-		);
-	});
-
 	it("rejects collisions between provider secrets and extra env names", () => {
 		expect(() =>
 			validateExtraEnvNameCollisions(
@@ -334,9 +257,7 @@ describe("LiteLLMProxy", () => {
 	});
 
 	it("rejects collisions against provider env vars resolved from outputs", async () => {
-		const resolvedProviderEnvVar = await resolveOutput(
-			pulumi.output("LANGFUSE_SECRET_KEY"),
-		);
+		const resolvedProviderEnvVar = await resolveOutput(pulumi.output("LANGFUSE_SECRET_KEY"));
 		expect(() =>
 			validateExtraEnvNameCollisions(
 				[],
@@ -389,21 +310,15 @@ describe("LiteLLMProxy", () => {
 		const spec = (await resolveRecord(
 			deployment?.inputs.spec as Record<string, unknown> | undefined,
 		)) as {
-			template: {
-				spec: { containers: Array<{ env?: Array<Record<string, unknown>> }> };
-			};
+			template: { spec: { containers: Array<{ env?: Array<Record<string, unknown>> }> } };
 		};
 		const env = spec.template.spec.containers[0]?.env ?? [];
-		expect(
-			env.find((entry) => entry.name === "LANGFUSE_TRACING_ENVIRONMENT"),
-		).toMatchObject({
+		expect(env.find((entry) => entry.name === "LANGFUSE_TRACING_ENVIRONMENT")).toMatchObject({
 			name: "LANGFUSE_TRACING_ENVIRONMENT",
 			value: "prod",
 		});
 		expect(env.find((entry) => entry.name === "IGNORED_ENV")).toBeUndefined();
-		expect(
-			env.find((entry) => entry.name === "IGNORED_SECRET"),
-		).toBeUndefined();
+		expect(env.find((entry) => entry.name === "IGNORED_SECRET")).toBeUndefined();
 	});
 
 	it("creates admin command resources for teams and api keys", async () => {


### PR DESCRIPTION
Reverts #242 and the #243 release bump. #242 independently re-implemented `extraSecretRefEnv`, duplicating the pre-existing open PR #241 (same feature, same API). Backing both out so #241 — the canonical implementation (cleaner single-pass collision validation + more tests) — can merge and own the v0.11.4 release.

After this merges: merge #241, then tag v0.11.4.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Removes a public API surface from the published package and changes release version; runtime impact is low if nothing depended on `extraSecretRefEnv` yet.
> 
> **Overview**
> Reverts the **`extraSecretRefEnv`** / **`LiteLLMSecretKeyRef`** API and all related **`LiteLLMProxy`** wiring (external Kubernetes `secretKeyRef` env injection, extra collision checks, and deployment env entries). **`extraEnv`** and **`extraSecretEnv`** behavior is unchanged.
> 
> Package versions are rolled back from **0.11.4** to **0.11.3** at the repo root and **`@jmmaloney4/sector7`**. Tests for secret-ref injection and **`extraSecretRefEnv`** collisions are removed; remaining LiteLLM proxy tests are mostly formatting-only.
> 
> This clears the duplicate implementation so the canonical **`extraSecretRefEnv`** work can land via a separate PR and own the next release bump.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit adfad004f610b73c44056a3be6049e441df46b75. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->