### PR TITLE
feat(nix-image): coordinate push phase to dedupe shared base layers (ADR-029)

### DIFF
--- a/docs/internal/designs/029-nix-image-push-coordination.md
+++ b/docs/internal/designs/029-nix-image-push-coordination.md
@@ -1,0 +1,229 @@
+---
+id: ADR-029
+title: Coordinated Push Phase for NixImage (Shared Base Layer Deduplication)
+status: Proposed
+date: 2026-06-03
+deciders: [jmmaloney4]
+consulted: []
+tags: [design, adr, nix-image]
+supersedes: []
+superseded_by: []
+links: [ADR-017]
+---
+
+# Context
+
+Repositories that build several container images from one monorepo (yard, zeus)
+almost always produce images that **share a large base layer** and differ only
+in a small top layer. With nix2container this is the normal outcome: the shared
+runtime closure is one content-addressed store path, so every image references
+the *same* layer digest.
+
+`NixImage` (ADR-017) builds each image with a `NixOutput` (the `nix build`) and
+pushes it with a `command.local.Command` running `skopeo copy nix:<store-path> docker://<ref>`. Pulumi has no dependency edge between independent `NixImage`s,
+so it runs their pushes **concurrently**. Each push independently probes the
+registry for each layer (`HEAD /v2/<name>/blobs/<digest>`) and uploads the ones
+that are missing.
+
+When N images that share a base layer are pushed at once, all N `HEAD`s for the
+shared blob return 404 before any push has finished uploading it, so the
+identical multi-hundred-MB base is uploaded N times. Only one copy is kept; the
+other N-1 uploads are wasted bandwidth and wall-clock. This was observed in
+yard's cron stack, where three images (`discovery-runner`, `dbt`,
+`pipeline-runner`) each re-push the same `sha256:…` base on every rebuild.
+
+**Deduplication boundary.** Registries deduplicate layer blobs per *registry*,
+not globally. For GCP Artifact Registry the boundary is the **repository
+resource** (`PROJECT/REPO`): images pushed under different image names within
+one AR repository share stored blobs, and a layer already present anywhere in
+that repository satisfies the `HEAD` existence check, so a later push skips it.
+Across *different* AR repositories nothing is shared (skopeo does not implement
+the OCI cross-repo blob `mount` API — only crane/gcrane do). The fix therefore
+only needs to coordinate pushes **destined for the same registry**.
+
+In scope: avoiding concurrent re-upload of shared layers from `NixImage`'s push
+phase, with a default that requires no consumer changes. Out of scope:
+cross-registry layer sharing (would require swapping skopeo for crane); changing
+the image build or the push script; multi-arch manifests.
+
+Triggers: yard PR observing triple-pushed base layers; this ADR proposes the
+upstream fix so consumers can drop their hand-rolled `dependsOn` workarounds.
+
+# Decision
+
+Add a **push-coordination** layer to `NixImage` that serializes the pushes of
+images sharing a registry, while leaving the `nix build` phase fully parallel.
+
+## `NixImagePushGroup`
+
+Introduce a small, Pulumi-state-free coordinator exported from
+`@jmmaloney4/sector7/nix-image`:
+
+```ts
+export class NixImagePushGroup {
+  constructor(args?: { strategy?: "serial" | "primer" });
+  dependencies(): pulumi.Resource[]; // what the next push must wait for
+  register(push: pulumi.Resource): void; // record a constructed push
+}
+```
+
+`NixImage` calls `dependencies()` before constructing its push `Command` (adding
+the result to `dependsOn`) and `register()` after. The group holds only
+in-memory references to already-constructed push commands.
+
+- **`"serial"`** (default): each push waits for the previously registered push,
+  so at most one runs at a time. Correct regardless of which layers the images
+  share.
+- **`"primer"`**: only the first push runs alone; every later push waits for
+  that first ("primer") push and then runs concurrently. Optimal when all images
+  share a base (the primer uploads it once; the rest skip it and upload only
+  their unique top layers in parallel). Assumes the first image carries the
+  shared base.
+
+## `NixImage` integration
+
+Add `pushGroup?: NixImagePushGroup | false` to `NixImageArgs`:
+
+- **omitted (default):** the image joins an **internal default group keyed on its
+  `artifactRegistryUrl`**. Images pushing to the same registry are serialized;
+  images on different registries stay parallel. Zero-config — existing consumers
+  get the dedup automatically.
+- **a `NixImagePushGroup`:** the image joins that explicit group instead, to
+  widen/narrow the coordination set or opt into `"primer"`.
+- **`false`:** opt out; the push runs unordered (pre-ADR behavior).
+
+The default group map is keyed on the `artifactRegistryUrl` Input itself: plain
+strings collapse by value; Output registries collapse by reference (the common
+case where one `artifactRegistryUrl` Output is shared across `NixImage`s). If a
+consumer passes a distinct Output per image, keys differ and the default
+degrades to the prior fully-parallel behavior — never worse than before.
+
+Coordination applies to `"build"` mode only; `"resolve"` mode performs no upload
+and never joins a group.
+
+The component MUST:
+
+- Serialize pushes within a registry by default, with no required consumer
+  changes (RFC 2119 MUST).
+- Keep `nix build` (`NixOutput`) phases parallel — only the push `Command`
+  carries the added `dependsOn` (MUST). This is strictly better than a
+  consumer-level `dependsOn` between whole `NixImage`s, which also serializes
+  builds.
+- Never let coordination affect correctness: push order is irrelevant to the
+  result, so mis-grouping changes only performance (MUST).
+- Provide an explicit opt-out (`pushGroup: false`) and an explicit override
+  (`pushGroup: group`) (SHOULD).
+
+# Consequences
+
+## Positive
+
+- Shared base layers are uploaded once per registry instead of once per image —
+  the common monorepo case gets the bandwidth/wall-clock win for free.
+- Builds stay parallel; only the (I/O-bound) pushes serialize.
+- Consumers can delete hand-rolled `dependsOn` chains between `NixImage`s.
+- `"primer"` lets callers recover push parallelism for unique layers when images
+  are known to share a base.
+- The coordinator is pure in-memory state — no new Pulumi resources, no state
+  bloat, nothing to import in the typical path.
+
+## Negative
+
+- **Behavior change:** pushes to the same registry that previously ran in
+  parallel now serialize by default. For images that genuinely share no layers
+  this trades a little wall-clock for no benefit; opt out with `pushGroup: false` or use `"primer"`. Warrants a minor version bump and changelog note.
+- Module-level mutable state (the default-group map) — acceptable because it
+  only affects scheduling and degrades safely, but it is global to the program.
+- Reference-identity keying for Output registries is a heuristic; an unusual
+  consumer pattern (fresh Output per image) silently forgoes the optimization.
+- Under the Automation API, multiple stacks in one process share the module
+  state; harmless (serialization is correctness-safe) but worth noting. Explicit
+  groups sidestep it.
+
+# Alternatives
+
+### 1. Consumer-level `dependsOn` between `NixImage`s (status quo workaround)
+
+Chain whole components with `dependsOn` in each consumer.
+
+Pros: no library change; already works.
+
+Cons: serializes **builds too**, not just pushes; must be re-implemented in every
+consumer; easy to get wrong or forget. Rejected as the durable solution — it is
+exactly what this ADR replaces.
+
+### 2. Opt-in only (no default group)
+
+Ship `NixImagePushGroup` but require consumers to wire it.
+
+Pros: no behavior change; no module-global state.
+
+Cons: the common case stays broken until each consumer opts in — fails the "just
+works" goal. Rejected; kept available as the explicit-group path.
+
+### 3. Cross-repo blob mount / shared base image (crane)
+
+Push a shared base once and have app images mount its layers across repositories
+via the OCI `mount` API.
+
+Pros: dedups across *different* registries/repositories; preserves full push
+parallelism.
+
+Cons: skopeo does not implement cross-repo mount, so this means replacing the
+pusher with crane/gcrane; needs a canonical base-repo convention; IAM-gated and
+silently falls back to full upload on misconfig. Much larger change for a case
+we do not currently have (our images share one AR repository). Rejected for now;
+revisit if cross-registry dedup becomes a real requirement.
+
+### 4. Single global serial chain (no registry keying)
+
+Serialize *all* pushes program-wide.
+
+Pros: simplest; always correct.
+
+Cons: needlessly serializes pushes to unrelated registries, a larger
+behavior-change blast radius. Rejected in favor of per-registry default groups.
+
+# Security / Privacy / Compliance
+
+- No change to authentication, tokens, or the push script. Coordination only
+  reorders existing push commands.
+- No new data in Pulumi state; the coordinator holds in-memory resource handles
+  during program evaluation only.
+
+# Operational Notes
+
+- Default behavior changes deploy timing: same-registry pushes run sequentially.
+  For a handful of images this is dominated by upload time that would otherwise
+  be partly wasted re-uploading shared layers.
+- Observability: push ordering is visible in the Pulumi resource graph
+  (`dependsOn` edges on the `…-push` commands).
+- Rollback: set `pushGroup: false` on affected images, or pin the prior sector7
+  version.
+- Cost: reduces egress/registry write amplification for shared layers; the
+  primary motivation.
+
+# Status Transitions
+
+- Extends ADR-017 (NixImage). Does not supersede it.
+
+# Implementation Notes
+
+1. `packages/sector7/nix-image/push-group.ts` — `NixImagePushGroup` + types.
+2. `packages/sector7/nix-image/nix-image.ts` — default-group map keyed on
+   `artifactRegistryUrl`; `pushGroup` arg; wire `dependsOn`/`register` on the
+   push command (build mode only).
+3. `packages/sector7/nix-image/index.ts` — export `NixImagePushGroup` and types.
+4. Tests: `tests/nix-image-push-group.test.ts` (pure group logic: serial,
+   primer, empty) and additions to `tests/nix-image.test.ts` (registration in
+   build mode, no registration in resolve mode, opt-out).
+5. Minor version bump for the new feature + behavior change.
+
+# References
+
+- ADR-017: NixImage Pulumi Component for nix2container Build-Push
+- OCI Distribution Spec — blob existence (`HEAD`) and cross-repo `mount`:
+  https://github.com/opencontainers/distribution-spec/blob/main/spec.md
+- GCP Artifact Registry container concepts (layer sharing within a repository):
+  https://cloud.google.com/artifact-registry/docs/container-concepts
+- nix2container: https://github.com/nlewo/nix2container

--- a/packages/sector7/barrel-guard-gateway.ts
+++ b/packages/sector7/barrel-guard-gateway.ts
@@ -1,16 +1,16 @@
-// Gateway helpers live on the ./gateway sub-path, not in the main barrel.
-// If someone adds them here, tsc will flag the unused @ts-expect-error.
+// Gateway helpers live on the ./gateway sub-path, not in the main barrel, so
+// their @pulumi/kubernetes type closure stays out of the root barrel for
+// consumers that do not need it. This guard asserts that exclusion: the main
+// barrel (./index.ts) must not surface a `gateway` namespace.
+//
+// Referencing the (absent) `gateway` member of the barrel is expected to error,
+// which the @ts-expect-error below suppresses. If someone adds
+// `export * as gateway from "./gateway/index.ts"` to index.ts, the reference
+// type-checks, the directive becomes unused, and tsc fails — flagging the
+// boundary violation. (This file is excluded from the build via
+// tsconfig.build.json and only type-checked by the default tsconfig, so the
+// import is never emitted.)
+import * as barrel from "./index.ts";
 
-// @ts-expect-error — gateway exports live on ./gateway sub-path
-export type {
-	ServiceHttpRouteArgs,
-	SharedGatewayReferenceGrantArgs,
-	TailnetIngressArgs,
-} from "./gateway/index.ts";
-
-// @ts-expect-error — gateway exports live on ./gateway sub-path
-export {
-	createServiceHttpRoute,
-	createSharedGatewayReferenceGrant,
-	createTailnetIngress,
-} from "./gateway/index.ts";
+// @ts-expect-error — gateway must stay on the ./gateway sub-path, not the main barrel
+export const _gatewayNotInBarrel = barrel.gateway;

--- a/packages/sector7/nix-image/index.ts
+++ b/packages/sector7/nix-image/index.ts
@@ -1,1 +1,6 @@
 export { NixImage, type NixImageArgs } from "./nix-image.ts";
+export {
+	NixImagePushGroup,
+	type NixImagePushGroupArgs,
+	type NixImagePushStrategy,
+} from "./push-group.ts";

--- a/packages/sector7/nix-image/nix-image.ts
+++ b/packages/sector7/nix-image/nix-image.ts
@@ -2,6 +2,37 @@ import * as command from "@pulumi/command";
 import * as pulumi from "@pulumi/pulumi";
 import { NixOutput } from "../nix-output/nix-output.ts";
 import { getScriptPath } from "../scripts/index.ts";
+import { NixImagePushGroup } from "./push-group.ts";
+
+/**
+ * Internal default push groups, one per distinct `artifactRegistryUrl`.
+ *
+ * Layer-blob deduplication happens within a single registry (for GCP Artifact
+ * Registry, within one repository resource), so images pushed to the same
+ * registry are the ones that benefit from coordinated pushes. Keying on the
+ * `artifactRegistryUrl` Input means images sharing a registry are serialized by
+ * default, while images pushed to *different* registries stay fully parallel.
+ *
+ * The map is keyed on the Input itself: plain-string registries collapse by
+ * value, and Output registries collapse by reference (the common case where one
+ * `artifactRegistryUrl` Output is reused across several `NixImage`s). If a
+ * consumer passes a freshly-derived Output per image the keys differ and the
+ * default degrades to the previous fully-parallel behavior — never worse than
+ * before, since push order never affects correctness.
+ */
+const defaultPushGroups = new Map<pulumi.Input<string>, NixImagePushGroup>();
+
+function defaultPushGroupFor(
+	artifactRegistryUrl: pulumi.Input<string>,
+): NixImagePushGroup {
+	const existing = defaultPushGroups.get(artifactRegistryUrl);
+	if (existing) {
+		return existing;
+	}
+	const group = new NixImagePushGroup();
+	defaultPushGroups.set(artifactRegistryUrl, group);
+	return group;
+}
 
 export interface NixImageArgs {
 	/** Flake attribute path (e.g. "packages.x86_64-linux.lens-api-image") */
@@ -29,6 +60,22 @@ export interface NixImageArgs {
 	authMode?: "gcloud" | "ghcr";
 	/** Extra environment variables to pass to the build-push command. */
 	env?: Record<string, pulumi.Input<string>>;
+	/**
+	 * Coordinates the push phase with other images to avoid concurrently
+	 * uploading a shared base layer (see {@link NixImagePushGroup}). Only
+	 * affects `"build"` mode — `"resolve"` mode performs no upload.
+	 *
+	 * - omitted (default): the image joins an internal group shared by every
+	 *   `NixImage` pushing to the same `artifactRegistryUrl`, serializing their
+	 *   pushes so the shared layer is uploaded once. Images on different
+	 *   registries remain parallel. This is the zero-config "just works" path.
+	 * - a {@link NixImagePushGroup}: the image joins that explicit group
+	 *   instead, letting you widen, narrow, or re-strategize the coordination
+	 *   (e.g. opt into the `"primer"` strategy).
+	 * - `false`: the image opts out of coordination entirely and its push runs
+	 *   unordered (the pre-coordination behavior).
+	 */
+	pushGroup?: NixImagePushGroup | false;
 }
 
 export class NixImage extends pulumi.ComponentResource {
@@ -49,7 +96,13 @@ export class NixImage extends pulumi.ComponentResource {
 			aliases.push({ parent: opts.parent });
 		}
 
-		super("sector7:nix:NixImage", name, args, {
+		// Keep the push coordinator out of the component's registered inputs.
+		// It is scheduling-only state (and once populated holds references to
+		// this component's own child push commands); leaking it into the input
+		// bag would create a registration cycle.
+		const { pushGroup: _pushGroup, ...registrableArgs } = args;
+
+		super("sector7:nix:NixImage", name, registrableArgs, {
 			...opts,
 			aliases: [...aliases, ...(opts?.aliases ?? [])],
 		});
@@ -108,6 +161,15 @@ export class NixImage extends pulumi.ComponentResource {
 				{ parent: this },
 			);
 
+			// Coordinate the push with sibling images so a shared base layer
+			// is not uploaded concurrently. An explicit `pushGroup` wins; `false`
+			// opts out; otherwise join the default group for this registry.
+			const pushGroup =
+				args.pushGroup === false
+					? undefined
+					: (args.pushGroup ?? defaultPushGroupFor(args.artifactRegistryUrl));
+			const pushDependsOn = pushGroup?.dependencies() ?? [];
+
 			// Push the built image from the store path
 			const pushCmd = new command.local.Command(
 				`${name}-push`,
@@ -124,8 +186,9 @@ export class NixImage extends pulumi.ComponentResource {
 						...(args.triggers ?? []),
 					]),
 				},
-				{ parent: this },
+				{ parent: this, dependsOn: pushDependsOn },
 			);
+			pushGroup?.register(pushCmd);
 
 			this.digest = pushCmd.stdout.apply((stdout: string) => {
 				const match = stdout.trim().match(/DIGEST_OUTPUT:(sha256:[a-f0-9]+)/);

--- a/packages/sector7/nix-image/push-group.ts
+++ b/packages/sector7/nix-image/push-group.ts
@@ -1,0 +1,92 @@
+import type * as pulumi from "@pulumi/pulumi";
+
+/**
+ * Strategy controlling how a {@link NixImagePushGroup} orders the pushes of the
+ * images that belong to it.
+ *
+ * - `"serial"` (default): every push waits for the previously registered push
+ *   in the group, so at most one push runs at a time. Correct regardless of
+ *   which layers the images actually share — the shared base blob is uploaded
+ *   by whichever push runs first, and every later push finds it already present
+ *   in the registry and skips re-uploading it.
+ * - `"primer"`: only the *first* push in the group runs alone; every later push
+ *   waits for that first ("primer") push and then runs concurrently with its
+ *   peers. Optimal when every image sits on the same base layer: the primer
+ *   uploads the shared base once, and the rest skip it and upload only their
+ *   unique top layers in parallel. Assumes the first image carries the shared
+ *   base; if it does not, the remaining pushes can still race on a base the
+ *   primer never uploaded, so prefer `"serial"` for heterogeneous groups.
+ */
+export type NixImagePushStrategy = "serial" | "primer";
+
+export interface NixImagePushGroupArgs {
+	/** Ordering strategy for the group. Defaults to `"serial"`. */
+	strategy?: NixImagePushStrategy;
+}
+
+/**
+ * Coordinates the push phase of multiple {@link NixImage} builds so they do not
+ * upload a shared layer concurrently.
+ *
+ * Images built from the same repository routinely share a large base layer
+ * (e.g. the nix runtime closure) but differ only in a small top layer. When
+ * Pulumi pushes those images concurrently, each push races to upload the same
+ * base blob: the registry's per-blob existence check (`HEAD .../blobs/<digest>`)
+ * returns 404 for all of them before any has finished, so the identical base is
+ * uploaded several times over. Serializing — or priming — the pushes lets the
+ * first upload populate the blob so the rest skip it.
+ *
+ * A group is a plain in-memory coordinator: it records the push commands as
+ * they are constructed and hands each new push the resources it should depend
+ * on. It carries no Pulumi state of its own and never affects correctness —
+ * push order is irrelevant to the result, so the worst case of mis-grouping is
+ * extra (or insufficient) serialization, never a broken deployment.
+ *
+ * Consumers rarely construct this directly: a {@link NixImage} with no explicit
+ * `pushGroup` joins an internal default group keyed on its `artifactRegistryUrl`
+ * (see {@link NixImage}). Construct one explicitly to widen, narrow, or
+ * re-strategize that coordination — for example to opt into `"primer"` for a
+ * set of images known to share a base:
+ *
+ * ```ts
+ * const group = new NixImagePushGroup({ strategy: "primer" });
+ * new NixImage("api", { ...args, pushGroup: group });
+ * new NixImage("worker", { ...args, pushGroup: group });
+ * ```
+ */
+export class NixImagePushGroup {
+	private readonly strategy: NixImagePushStrategy;
+	private primer: pulumi.Resource | undefined;
+	private previous: pulumi.Resource | undefined;
+
+	constructor(args: NixImagePushGroupArgs = {}) {
+		this.strategy = args.strategy ?? "serial";
+	}
+
+	/**
+	 * Resources the next push should depend on. Call this *before* constructing
+	 * the push command and pass the result into the command's `dependsOn`.
+	 *
+	 * Returns an empty array for the first push in the group (it has nothing to
+	 * wait for). For `"serial"` it returns the most recently registered push;
+	 * for `"primer"` it returns the first push registered in the group.
+	 */
+	dependencies(): pulumi.Resource[] {
+		if (this.strategy === "primer") {
+			return this.primer ? [this.primer] : [];
+		}
+		return this.previous ? [this.previous] : [];
+	}
+
+	/**
+	 * Record a freshly-constructed push command as the most recent member of
+	 * the group (and as the primer if it is the first). Call this *after*
+	 * constructing the push command.
+	 */
+	register(push: pulumi.Resource): void {
+		if (this.primer === undefined) {
+			this.primer = push;
+		}
+		this.previous = push;
+	}
+}

--- a/packages/sector7/tests/nix-image-push-group.test.ts
+++ b/packages/sector7/tests/nix-image-push-group.test.ts
@@ -1,0 +1,67 @@
+import type * as pulumi from "@pulumi/pulumi";
+import { describe, expect, it } from "vitest";
+import { NixImagePushGroup } from "../nix-image/push-group";
+
+/**
+ * The group only stores and returns resource references, so plain sentinels
+ * standing in for `pulumi.Resource` are sufficient to exercise its logic.
+ */
+function fakeResource(label: string): pulumi.Resource {
+	return { __label: label } as unknown as pulumi.Resource;
+}
+
+describe("NixImagePushGroup", () => {
+	it("has no dependencies before anything is registered", () => {
+		const group = new NixImagePushGroup();
+		expect(group.dependencies()).toEqual([]);
+	});
+
+	it("serial strategy chains each push onto the previous one", () => {
+		const group = new NixImagePushGroup({ strategy: "serial" });
+		const a = fakeResource("a");
+		const b = fakeResource("b");
+		const c = fakeResource("c");
+
+		// First push waits for nothing, then becomes the dependency.
+		expect(group.dependencies()).toEqual([]);
+		group.register(a);
+		expect(group.dependencies()).toEqual([a]);
+
+		// Second waits for the first, then supersedes it.
+		group.register(b);
+		expect(group.dependencies()).toEqual([b]);
+
+		// Third waits for the second.
+		group.register(c);
+		expect(group.dependencies()).toEqual([c]);
+	});
+
+	it("defaults to the serial strategy", () => {
+		const group = new NixImagePushGroup();
+		const a = fakeResource("a");
+		const b = fakeResource("b");
+		group.register(a);
+		group.register(b);
+		// Serial: latest registered push is the next dependency.
+		expect(group.dependencies()).toEqual([b]);
+	});
+
+	it("primer strategy makes every later push depend on the first", () => {
+		const group = new NixImagePushGroup({ strategy: "primer" });
+		const primer = fakeResource("primer");
+		const second = fakeResource("second");
+		const third = fakeResource("third");
+
+		expect(group.dependencies()).toEqual([]);
+		group.register(primer);
+		expect(group.dependencies()).toEqual([primer]);
+
+		// Later registrations do not move the dependency off the primer, so the
+		// second and third pushes both wait only for the primer and thus run
+		// concurrently with each other.
+		group.register(second);
+		expect(group.dependencies()).toEqual([primer]);
+		group.register(third);
+		expect(group.dependencies()).toEqual([primer]);
+	});
+});

--- a/packages/sector7/tests/nix-image.test.ts
+++ b/packages/sector7/tests/nix-image.test.ts
@@ -2,6 +2,7 @@ import * as command from "@pulumi/command";
 import * as pulumi from "@pulumi/pulumi";
 import { beforeAll, beforeEach, describe, expect, it } from "vitest";
 import { NixImage } from "../nix-image/nix-image";
+import { NixImagePushGroup } from "../nix-image/push-group";
 
 type MockResource = {
 	type: string;
@@ -297,5 +298,60 @@ describe("NixImage", () => {
 		expect(pushCmds).toHaveLength(1);
 		const env = pushCmds[0].inputs.environment as Record<string, unknown>;
 		expect(env.STORE_PATH).toBe("/nix/store/abc123-my-image");
+	});
+
+	it("registers its push into an explicit push group (build mode)", async () => {
+		const group = new NixImagePushGroup();
+		expect(group.dependencies()).toHaveLength(0);
+
+		const img = new NixImage("group-build", {
+			nixAttr: "packages.x86_64-linux.my-image",
+			imageName: "build-img",
+			imageTag: "dev",
+			artifactRegistryUrl: "us-east1-docker.pkg.dev/my-project/my-repo",
+			repoRoot: "/home/user/my-repo",
+			pushGroup: group,
+		});
+		await resolveOutput(img.digest);
+
+		// The push command was registered, so the group now hands the next push
+		// a dependency. (Serial/primer chaining across multiple pushes is
+		// covered by the unit tests in nix-image-push-group.test.ts.)
+		expect(group.dependencies()).toHaveLength(1);
+	});
+
+	it("does not register resolve-mode images into a push group", async () => {
+		const group = new NixImagePushGroup();
+
+		const img = new NixImage("group-resolve", {
+			nixAttr: "packages.x86_64-linux.my-image",
+			imageName: "resolve-only",
+			imageTag: "v1.0.0",
+			artifactRegistryUrl: "us-east1-docker.pkg.dev/my-project/my-repo",
+			repoRoot: "/home/user/my-repo",
+			mode: "resolve",
+			pushGroup: group,
+		});
+		await resolveOutput(img.digest);
+
+		// Resolve mode performs no upload, so it never joins the group.
+		expect(group.dependencies()).toHaveLength(0);
+	});
+
+	it("still produces a working push when coordination is opted out (pushGroup: false)", async () => {
+		const img = new NixImage("group-optout", {
+			nixAttr: "packages.x86_64-linux.my-image",
+			imageName: "optout",
+			imageTag: "dev",
+			artifactRegistryUrl: "us-east1-docker.pkg.dev/my-project/my-repo",
+			repoRoot: "/home/user/my-repo",
+			pushGroup: false,
+		});
+
+		const digest = await resolveOutput(img.digest);
+		expect(digest).toBe("sha256:abc123def456");
+
+		const pushCmds = byName("group-optout-push");
+		expect(pushCmds).toHaveLength(1);
 	});
 });


### PR DESCRIPTION
## Summary

Images built from one monorepo share a large nix base layer but differ only in a small top layer. Pulumi pushes independent `NixImage`s **concurrently**, so every push races to upload the same base blob — the per-blob existence check (`HEAD /v2/<name>/blobs/<digest>`) returns 404 for all of them before any finishes, and the identical multi-hundred-MB base is uploaded once per image. Observed in yard's cron stack, where `discovery-runner`, `dbt`, and `pipeline-runner` each re-push the same `sha256:…` base on every rebuild.

This adds a **push-coordination** layer that serializes the push phase while keeping the `nix build` phase parallel.

Implements **ADR-029** (`docs/internal/designs/029-nix-image-push-coordination.md`).

## Design

**`NixImagePushGroup`** — a tiny in-memory coordinator (no Pulumi state). `NixImage` calls `group.dependencies()` before constructing its push `Command` (feeding the result into `dependsOn`) and `group.register(cmd)` after.

- `"serial"` (default): each push waits for the previous one — correct regardless of which layers are shared.
- `"primer"`: only the first push runs alone; later pushes wait for it then run concurrently (optimal when all images share a base — the primer uploads it once, the rest skip it and upload unique layers in parallel).

**`pushGroup?: NixImagePushGroup | false`** on `NixImageArgs`:

- **omitted (default):** the image joins an internal group **keyed on `artifactRegistryUrl`**. Same-registry pushes serialize (shared layer uploaded once, the rest skip via `HEAD`); different-registry pushes stay parallel. **Zero consumer changes** — the "just works" path.
- **a `NixImagePushGroup`:** join an explicit group to widen/narrow the set or opt into `"primer"`.
- **`false`:** opt out; push runs unordered (pre-PR behavior).

### Why this beats a consumer-side `dependsOn`

Only the push `Command` gets the added `dependsOn`, so **builds stay parallel**. A consumer-level `dependsOn` between whole `NixImage`s (the current yard workaround) also serializes the `nix build`s. This lets those consumers delete the workaround.

### Dedup boundary (why key on registry)

Layer blobs dedupe **within a registry** — for GCP Artifact Registry, within one repository resource. A layer present anywhere in that repo satisfies the `HEAD` check, so a later same-registry push skips it. Across different registries nothing is shared (skopeo doesn't implement the OCI cross-repo `mount` API). So coordination only needs to group pushes destined for the same registry.

## Notable implementation detail

The coordinator is deliberately kept out of the args passed to `super(...)`. Once `register()` stores a push `Command`, the group transitively references this component's own child → leaking it into the registered inputs creates a registration cycle (manifested as a hang). Destructuring `pushGroup` out before `super` avoids it. Regression-covered by the build-mode integration test.

## Test plan

- [x] `tsc -p packages/sector7/tsconfig.build.json --noEmit` — clean.
- [x] `vitest run` — **173 passed** (4 new pure unit tests for `NixImagePushGroup` serial/primer/empty; 3 new `NixImage` integration tests: build-mode registration, resolve-mode non-registration, `false` opt-out).
- [x] `just fmt` + `just lint` — clean.

## Follow-ups (not in this PR)

- Minor version bump + release (`just cut minor`) so consumers can pick it up.
- yard: once released, replace the `dependsOn` workaround (addendalabs/yard#1563) with the default coordination.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Default behavior serializes same-registry pushes (deploy timing change) but only affects performance, not correctness; no auth or push-script changes.
> 
> **Overview**
> Adds **push coordination** to `NixImage` so concurrent registry pushes no longer race to re-upload the same shared nix base layer. A new in-memory **`NixImagePushGroup`** (`serial` or `primer`) wires `dependsOn` only on push `Command`s, leaving **`nix build` parallel**.
> 
> By default, images sharing the same **`artifactRegistryUrl`** join an internal serial group (zero config); callers can pass an explicit group, or **`pushGroup: false`** for the old unordered behavior. **`resolve`** mode never coordinates. **`pushGroup`** is omitted from component inputs passed to `super()` to avoid a registration cycle.
> 
> **ADR-029** documents the design. **`barrel-guard-gateway.ts`** is tightened to a type-only guard that fails the build if `gateway` is re-exported from the main barrel. New unit and integration tests cover group strategies and `NixImage` wiring.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6cc182ffc433b3dc459e7a6c3c46df740115f158. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->