### PR TITLE
refactor(monitor)!: store UptimeMonitor alert state in D1, drop KV

### DIFF
--- a/docs/internal/designs/020-cloudflare-worker-uptime-monitor.md
+++ b/docs/internal/designs/020-cloudflare-worker-uptime-monitor.md
@@ -1,13 +1,14 @@
 ---
 id: ADR-020
 title: Cloudflare Worker Uptime Monitor
-status: Accepted
+status: Amended # amended by ADR-030 (alert state moved from KV to D1)
 date: 2026-05-13
 deciders: [platform]
 consulted: []
 tags: [design, adr, cloudflare, workers, d1, kv, monitoring]
 supersedes: []
 superseded_by: []
+amended_by: [ADR-030]
 links:
   - cloudflare-workers: https://developers.cloudflare.com/workers/
   - cloudflare-d1: https://developers.cloudflare.com/d1/
@@ -94,6 +95,13 @@ Free-tier capacity at probe scale (validated against Cloudflare docs as of 2026-
 All within free-tier bounds. Storage, reads, and writes are independent quotas.
 
 ## State tracking: KV
+
+> **Amended by [ADR-030](030-uptime-monitor-state-in-d1.md) (2026-06-03):** Alert
+> state has been moved out of KV into a D1 `monitor_state` table, and the KV
+> dependency removed entirely. Even one batched KV write per minute (1,440/day)
+> exceeds the KV free tier (1,000 writes/day), so KV was never viable for a
+> 1-minute cron at free-tier cost. The rest of this section is retained for
+> historical context; see ADR-030 for the current design.
 
 Failure streak state lives in KV, not D1. Each monitor gets one key with a JSON blob:
 
@@ -201,6 +209,10 @@ Why dlt over custom scripts:
 # Status Transitions
 
 - This is a new ADR. No prior ADR is amended or superseded.
+- **Amended by ADR-030 (2026-06-03):** the "State tracking: KV" decision is
+  superseded — alert state now lives in a D1 `monitor_state` table and the KV
+  dependency is removed. The rest of this ADR (architecture, probe logic, D1
+  history schema, webhook alerting, dlt export) still stands.
 
 # Implementation Notes
 

--- a/docs/internal/designs/030-uptime-monitor-state-in-d1.md
+++ b/docs/internal/designs/030-uptime-monitor-state-in-d1.md
@@ -1,15 +1,193 @@
 ---
 id: ADR-030
-title: "Uptime Monitor State In D1"
-status: proposed
+title: UptimeMonitor — Move Alert State from KV to D1
+status: Accepted
 date: 2026-06-03
+deciders: [platform]
+consulted: []
+tags: [design, adr, cloudflare, workers, d1, kv, monitoring]
+supersedes: []
+superseded_by: []
+links:
+  - kv-pricing: https://developers.cloudflare.com/kv/platform/pricing/
+  - kv-limits: https://developers.cloudflare.com/kv/platform/limits/
+  - d1-pricing: https://developers.cloudflare.com/d1/platform/pricing/
+  - d1-limits: https://developers.cloudflare.com/d1/platform/limits/
 ---
 
-# ADR 030: Uptime Monitor State In D1
-*Date:* 2026-06-03
-*Status:* proposed
+# Context
 
-**Related PR:** https://github.com/jmmaloney4/sector7/pull/246
+ADR-020 built the `UptimeMonitor` component on two Cloudflare storage backends:
 
-This ADR is currently being developed in linked pull request above.
-Please refer to that PR for current content and discussion.
+- **D1** for probe-result history (`probe_results` table, one batch `INSERT` per cron run).
+- **KV** for the failure-streak alert state machine, stored in per-monitor keys
+  (`streak:<monitor_id>`) holding a JSON blob of `consecutive_failures`,
+  `consecutive_successes`, `last_status`, `last_ts`.
+
+The KV free tier allows only **1,000 `put` operations/day**. The component's
+default cron schedule is `*/1 * * * *` (every minute), and `checkAndAlert()`
+writes the streak state on **every** probe of **every** monitor. Even a single
+monitor produces 1,440 KV writes/day, which exceeds the free tier and surfaces
+the runtime error:
+
+> You have exceeded the daily Cloudflare Workers KV free tier limit of 1000
+> Workers KV put operations.
+
+ADR-020 anticipated this and recommended batching all monitor state into one KV
+key. But the math does not save us: one batched write per minute is still
+1,440 writes/day — over the 1,000/day cap on its own. The shipped implementation
+also never batched; it used per-monitor keys, so the problem worsens linearly
+with monitor count. Avoiding it would have required Workers Paid ($5/mo), purely
+to keep an ephemeral state machine alive.
+
+D1's free tier allows **100,000 rows written/day** and **5,000,000 rows
+read/day**, which comfortably absorbs both probe history and alert state at this
+scale. The Worker already binds D1 (`env.DB`).
+
+In scope: remove the KV namespace, binding, and all KV reads/writes from both the
+generated Worker script and the Pulumi component; move alert state into a new D1
+`monitor_state` table. Out of scope: the read API (`handleStats`), the dlt export
+pipeline, and the downstream `garden` stack config (which needs a follow-up
+`pulumi up`).
+
+# Decision
+
+`UptimeMonitor` MUST use **D1 only**. KV is removed entirely — not retained as an
+optional backend.
+
+## State table
+
+Alert state lives in a `monitor_state` table appended to `DEFAULT_D1_SCHEMA` in
+the same D1 database as `probe_results`. No second database, no Durable Objects.
+
+```sql
+CREATE TABLE IF NOT EXISTS monitor_state (
+    monitor_id TEXT PRIMARY KEY,
+    consecutive_failures INTEGER NOT NULL DEFAULT 0,
+    consecutive_successes INTEGER NOT NULL DEFAULT 0,
+    last_status TEXT NOT NULL DEFAULT 'healthy',
+    last_ts TEXT,
+    updated_at TEXT NOT NULL
+);
+```
+
+There is exactly one row per monitor and lookups are always by `monitor_id`, so
+the primary key is the only index needed.
+
+## Alert logic
+
+`checkAndAlert()` in `monitor-script.ts` reads and writes state via SQL instead
+of KV:
+
+- **Read:** `SELECT ... FROM monitor_state WHERE monitor_id = ?`, falling back to
+  a zeroed `healthy` default when no row exists (first run, or after the table is
+  created).
+- **Write:** an `INSERT ... ON CONFLICT(monitor_id) DO UPDATE` UPSERT, kept inside
+  `ctx.waitUntil()` for consistency and future-proofing (it is a cron handler, so
+  `waitUntil` is not strictly required, but it matches the webhook calls and stays
+  correct if the logic is ever reused in a `fetch` handler).
+
+The streak-update and threshold-transition logic is otherwise unchanged.
+
+## Component API
+
+`UptimeMonitorArgs` MUST drop `kvNamespaceTitle` and `kvNamespaceId`. The
+component MUST stop creating/referencing a `WorkersKvNamespace`, MUST drop the
+`{ name: "KV", type: "kv_namespace" }` Worker binding, and MUST drop the
+`kvNamespace` / `kvNamespaceId` outputs.
+
+This is a **breaking change** to the component interface. Removing the args from
+the TypeScript interface makes a stale config a compile-time error for typed
+consumers, which is the cleanest signal; at runtime, extra properties are
+ignored by JavaScript as usual. We intentionally do **not** add a runtime throw
+for the removed args — the type-level error is sufficient and avoids carrying
+dead validation code.
+
+# Consequences
+
+## Positive
+
+- Fits the free tier: removes the KV 1,000-writes/day ceiling that made
+  1-minute monitoring impossible without Workers Paid.
+- One storage backend instead of two — simpler mental model, one schema, one
+  binding.
+- Alert state is now queryable alongside probe history in the same database.
+
+## Negative
+
+- More D1 queries per cron run: per monitor, 1 `SELECT` + 1 UPSERT on top of the
+  existing batch `INSERT`. At 1 monitor/minute that is ~4,320 D1 queries/day,
+  well within the 100K-rows-written/day and 5M-rows-read/day free tiers. D1
+  allows 50 queries per Worker invocation on the free tier, so monitor count per
+  run must stay well under 25 (2 queries each) — fine at homelab scale, worth
+  noting before scaling to dozens of monitors in a single component.
+- Loss of KV's implicit TTL cleanup: `monitor_state` rows persist indefinitely.
+  The table is tiny and static (one row per monitor), so no cleanup mechanism is
+  added.
+- Breaking API change for consumers that passed `kvNamespace*` args (none do
+  today; `garden`'s uptime stack uses defaults).
+
+## Migration / data loss
+
+The KV streak state is ephemeral and rebuildable. After the `garden` stack runs
+`pulumi up` against this release:
+
+1. The removed KV namespace resource is destroyed.
+2. The Worker is updated to drop the KV binding and use D1 state.
+3. The `monitor_state` table is created via the existing `D1Query` schema apply.
+
+All monitors restart from `healthy` with zero streaks on the next cron run. The
+only "loss" is in-flight streak counters, which re-accumulate within
+`ALERT_THRESHOLD` (3) ticks.
+
+# Alternatives
+
+- **Batch all state into one KV key (ADR-020's suggestion):** still 1,440
+  writes/day at 1-minute cadence — over the 1,000/day free cap. Rejected.
+- **Workers Paid ($5/mo) for KV:** pays recurring money to keep an ephemeral
+  state machine that D1 already stores for free. Rejected.
+- **Durable Objects for state:** ~$0.50/mo per instance, solves a consistency
+  problem the serial cron execution does not have. Rejected (consistent with
+  ADR-020).
+
+# Security / Privacy / Compliance
+
+No change from ADR-020. The D1 query endpoint and apply token are unchanged; the
+new table holds the same synthetic streak counters previously held in KV. No
+PII.
+
+# Operational Notes
+
+- D1 query metrics (`rows_read`, `rows_written`, `duration`) appear in each
+  query's `meta` and in the Cloudflare dashboard/GraphQL analytics.
+- Free-tier headroom (validated 2026-06-03): KV 1,000 writes/day vs. D1 100,000
+  rows written/day. The move trades one over-budget backend for one with ~100×
+  the write headroom.
+
+# Status Transitions
+
+- This ADR amends **ADR-020**. ADR-020's "State tracking: KV" section is
+  superseded by the `monitor_state` D1 table described here. ADR-020 remains the
+  source of truth for the overall architecture, probe logic, D1 history schema,
+  webhook alerting, and dlt export.
+
+# Implementation Notes
+
+- `packages/sector7/monitor/monitor-script.ts` — `checkAndAlert()` rewritten to
+  D1 `SELECT` + UPSERT; all `env.KV` references removed.
+- `packages/sector7/monitor/uptime-monitor.ts` — `monitor_state` added to
+  `DEFAULT_D1_SCHEMA` (now exported for tests); KV namespace creation, binding,
+  args, and outputs removed.
+- `packages/sector7/tests/uptime-monitor.test.ts` — KV assertions replaced with
+  KV-absence assertions; tests added for the `monitor_state` schema and for the
+  generated script using D1 (not `env.KV`) for state.
+- Follow-up (separate task): bump the `garden` `@jmmaloney4/sector7` dependency
+  and run `pulumi up` in `deploy/services/uptime/`.
+
+# References
+
+- [Cloudflare KV Pricing](https://developers.cloudflare.com/kv/platform/pricing/) — 1,000 writes/day free
+- [Cloudflare KV Limits](https://developers.cloudflare.com/kv/platform/limits/)
+- [Cloudflare D1 Pricing](https://developers.cloudflare.com/d1/platform/pricing/) — 100K rows written/day free
+- [Cloudflare D1 Limits](https://developers.cloudflare.com/d1/platform/limits/) — 50 queries/invocation free tier
+- ADR-020: `020-cloudflare-worker-uptime-monitor.md`

--- a/docs/internal/designs/030-uptime-monitor-state-in-d1.md
+++ b/docs/internal/designs/030-uptime-monitor-state-in-d1.md
@@ -76,18 +76,30 @@ the primary key is the only index needed.
 
 ## Alert logic
 
-`checkAndAlert()` in `monitor-script.ts` reads and writes state via SQL instead
-of KV:
+`checkAndAlertBatch()` in `monitor-script.ts` reads and writes state via SQL
+instead of KV, batched across all monitors so a cron run costs a fixed **2 D1
+queries** regardless of monitor count:
 
-- **Read:** `SELECT ... FROM monitor_state WHERE monitor_id = ?`, falling back to
-  a zeroed `healthy` default when no row exists (first run, or after the table is
-  created).
-- **Write:** an `INSERT ... ON CONFLICT(monitor_id) DO UPDATE` UPSERT, kept inside
-  `ctx.waitUntil()` for consistency and future-proofing (it is a cron handler, so
-  `waitUntil` is not strictly required, but it matches the webhook calls and stays
-  correct if the logic is ever reused in a `fetch` handler).
+- **Read:** one `SELECT ... FROM monitor_state WHERE monitor_id IN (?, ?, ...)`
+  for all monitors. Missing rows fall back to a zeroed `healthy` default (first
+  run, or after the table is created). On a read error we log and abort the run
+  without writing — falling back to defaults would clear active streaks and
+  overwrite real rows on the UPSERT, silently dropping alerts.
+- **Write:** one `env.DB.batch([...])` of per-monitor
+  `INSERT ... ON CONFLICT(monitor_id) DO UPDATE` UPSERTs. The write is **awaited
+  before any webhook fires**: a transient write failure would otherwise leave
+  stale state and re-fire the same alert next run (duplicate alerts), so on write
+  failure we log and skip alerting. Webhooks then fire via `ctx.waitUntil()`,
+  only after the state is durably persisted.
 
 The streak-update and threshold-transition logic is otherwise unchanged.
+
+Why batch: D1's free tier allows only **50 queries per Worker invocation**, so a
+per-monitor `SELECT` + `UPSERT` (`2N` queries) would fail past ~24 monitors —
+ironic for a change whose point is fitting the free tier. `db.batch()` sends all
+statements in a single subrequest, counting as one query toward that limit. The
+per-statement bound-parameter cap (100) bounds a single run to ~100 monitors, far
+above realistic homelab scale.
 
 ## Component API
 
@@ -115,12 +127,14 @@ dead validation code.
 
 ## Negative
 
-- More D1 queries per cron run: per monitor, 1 `SELECT` + 1 UPSERT on top of the
-  existing batch `INSERT`. At 1 monitor/minute that is ~4,320 D1 queries/day,
-  well within the 100K-rows-written/day and 5M-rows-read/day free tiers. D1
-  allows 50 queries per Worker invocation on the free tier, so monitor count per
-  run must stay well under 25 (2 queries each) — fine at homelab scale, worth
-  noting before scaling to dozens of monitors in a single component.
+- More D1 queries per cron run: a batched `SELECT` + a batched UPSERT, on top of
+  the existing batch `INSERT` for `probe_results` — **3 D1 queries per run,
+  independent of monitor count**. At 1-minute cadence that is ~4,320 queries/day,
+  well within the 100K-rows-written/day and 5M-rows-read/day free tiers, and the
+  fixed 3 queries/invocation stay far under the 50-queries/invocation free-tier
+  limit. The 100-bound-param cap on the read `IN (...)` clause caps a single
+  component at ~100 monitors (split into multiple statements within one batch if
+  ever needed).
 - Loss of KV's implicit TTL cleanup: `monitor_state` rows persist indefinitely.
   The table is tiny and static (one row per monitor), so no cleanup mechanism is
   added.
@@ -173,8 +187,9 @@ PII.
 
 # Implementation Notes
 
-- `packages/sector7/monitor/monitor-script.ts` — `checkAndAlert()` rewritten to
-  D1 `SELECT` + UPSERT; all `env.KV` references removed.
+- `packages/sector7/monitor/monitor-script.ts` — alert logic rewritten as
+  `checkAndAlertBatch()`: one batched D1 `SELECT` + one `db.batch()` UPSERT, write
+  awaited before webhooks fire; all `env.KV` references removed.
 - `packages/sector7/monitor/uptime-monitor.ts` — `monitor_state` added to
   `DEFAULT_D1_SCHEMA` (now exported for tests); KV namespace creation, binding,
   args, and outputs removed.

--- a/packages/sector7/monitor/monitor-script.ts
+++ b/packages/sector7/monitor/monitor-script.ts
@@ -157,9 +157,11 @@ export default {${fetchHandler}
 				.run();
 		}
 
-		// Check alert conditions using D1 state. Each monitor's check is
-		// independent (keyed by monitor_id), so run them concurrently.
-		await Promise.all(results.map((result) => checkAndAlert(result, env, ctx)));
+		// Check alert conditions using D1 state. Batched into one SELECT plus one
+		// db.batch() UPSERT so the whole run costs exactly 2 D1 queries regardless
+		// of monitor count, staying well under D1's 50-queries/invocation free-tier
+		// limit (a per-monitor SELECT+UPSERT would fail past ~24 monitors).
+		await checkAndAlertBatch(results, env, ctx);
 	},
 };
 
@@ -211,61 +213,76 @@ async function probe(monitor, env) {
 	};
 }
 
-async function checkAndAlert(result, env, ctx) {
-	let state;
+async function checkAndAlertBatch(results, env, ctx) {
+	if (results.length === 0) return;
 
+	// 1. Read all monitor states in a single SELECT (1 D1 query). Bound params
+	// are capped at 100/statement, so this supports up to 100 monitors per run.
+	const ids = results.map((r) => r.monitor_id);
+	const stateById = new Map();
 	try {
-		const row = await env.DB.prepare(
-			"SELECT consecutive_failures, consecutive_successes, last_status, last_ts FROM monitor_state WHERE monitor_id = ?"
+		const placeholders = ids.map(() => "?").join(", ");
+		const rows = await env.DB.prepare(
+			"SELECT monitor_id, consecutive_failures, consecutive_successes, last_status, last_ts FROM monitor_state WHERE monitor_id IN (" + placeholders + ")"
 		)
-			.bind(result.monitor_id)
-			.first();
-		state = row ?? { consecutive_failures: 0, consecutive_successes: 0, last_status: "healthy", last_ts: null };
+			.bind(...ids)
+			.all();
+		for (const row of (rows.results ?? [])) {
+			stateById.set(row.monitor_id, row);
+		}
 	} catch (e) {
-		// On a transient read error, do NOT fall back to a default "healthy"
-		// state: doing so would clear an active failure streak and overwrite the
-		// real state on the UPSERT below, silently dropping alerts. Skip this
-		// monitor's check and leave the persisted row untouched.
-		console.error("Failed to read monitor state for " + result.monitor_id + ":", e);
+		// On a transient read error, do NOT fall back to default "healthy"
+		// states: doing so would clear active failure streaks and overwrite the
+		// real rows on the UPSERT below, silently dropping alerts. Skip this run
+		// and leave the persisted rows untouched.
+		console.error("Failed to read monitor state:", e);
 		return;
 	}
 
-	if (result.ok) {
-		state.consecutive_failures = 0;
-		state.consecutive_successes++;
-	} else {
-		state.consecutive_failures++;
-		state.consecutive_successes = 0;
-	}
+	// 2. Compute the updated state for each monitor and collect the UPSERT
+	// statements plus any pending webhook alerts.
+	const upsertSql =
+		"INSERT INTO monitor_state (monitor_id, consecutive_failures, consecutive_successes, last_status, last_ts, updated_at)" +
+		" VALUES (?, ?, ?, ?, ?, ?)" +
+		" ON CONFLICT(monitor_id) DO UPDATE SET" +
+		"   consecutive_failures = excluded.consecutive_failures," +
+		"   consecutive_successes = excluded.consecutive_successes," +
+		"   last_status = excluded.last_status," +
+		"   last_ts = excluded.last_ts," +
+		"   updated_at = excluded.updated_at";
 
-	const previousStatus = state.last_status;
+	const writes = [];
+	const alerts = [];
 
-	// Determine new status based on thresholds
-	// Only transition from healthy -> unhealthy after ALERT_THRESHOLD failures
-	// Only transition from unhealthy -> healthy after RECOVERY_THRESHOLD successes
-	if (previousStatus === "healthy" && state.consecutive_failures >= ALERT_THRESHOLD) {
-		state.last_status = "unhealthy";
-	} else if (previousStatus === "unhealthy" && state.consecutive_successes >= RECOVERY_THRESHOLD) {
-		state.last_status = "healthy";
-	}
-	state.last_ts = result.ts;
+	for (const result of results) {
+		const state = stateById.get(result.monitor_id) ?? {
+			consecutive_failures: 0,
+			consecutive_successes: 0,
+			last_status: "healthy",
+			last_ts: null,
+		};
 
-	// Persist updated state to D1 BEFORE firing any webhook. We await the write
-	// (checkAndAlert runs concurrently via Promise.all, so awaiting here does not
-	// serialize monitors) and skip alerting if it fails: a dropped write would
-	// leave stale state and re-fire the same alert on the next run.
-	try {
-		await env.DB.prepare(
-			\`INSERT INTO monitor_state (monitor_id, consecutive_failures, consecutive_successes, last_status, last_ts, updated_at)
-			 VALUES (?, ?, ?, ?, ?, ?)
-			 ON CONFLICT(monitor_id) DO UPDATE SET
-			   consecutive_failures = excluded.consecutive_failures,
-			   consecutive_successes = excluded.consecutive_successes,
-			   last_status = excluded.last_status,
-			   last_ts = excluded.last_ts,
-			   updated_at = excluded.updated_at\`
-		)
-			.bind(
+		if (result.ok) {
+			state.consecutive_failures = 0;
+			state.consecutive_successes++;
+		} else {
+			state.consecutive_failures++;
+			state.consecutive_successes = 0;
+		}
+
+		const previousStatus = state.last_status;
+
+		// Only transition healthy -> unhealthy after ALERT_THRESHOLD failures,
+		// and unhealthy -> healthy after RECOVERY_THRESHOLD successes.
+		if (previousStatus === "healthy" && state.consecutive_failures >= ALERT_THRESHOLD) {
+			state.last_status = "unhealthy";
+		} else if (previousStatus === "unhealthy" && state.consecutive_successes >= RECOVERY_THRESHOLD) {
+			state.last_status = "healthy";
+		}
+		state.last_ts = result.ts;
+
+		writes.push(
+			env.DB.prepare(upsertSql).bind(
 				result.monitor_id,
 				state.consecutive_failures,
 				state.consecutive_successes,
@@ -273,14 +290,25 @@ async function checkAndAlert(result, env, ctx) {
 				state.last_ts,
 				result.ts,
 			)
-			.run();
+		);
+
+		if (previousStatus !== state.last_status) {
+			alerts.push({ result, previousStatus, state });
+		}
+	}
+
+	// 3. Persist all updated state in one db.batch() (1 D1 query) BEFORE firing
+	// any webhook. If the write fails we skip alerting so a dropped write can't
+	// re-fire the same alert on the next run.
+	try {
+		await env.DB.batch(writes);
 	} catch (e) {
-		console.error("Failed to write monitor state for " + result.monitor_id + ":", e);
+		console.error("Failed to write monitor state:", e);
 		return;
 	}
 
-	// Fire webhook on state transitions
-	if (previousStatus !== state.last_status) {
+	// 4. Fire webhooks for transitions, now that state is durably persisted.
+	for (const { result, previousStatus, state } of alerts) {
 		if (state.last_status === "healthy") {
 			ctx.waitUntil(sendWebhook(env, {
 				type: "recovery",

--- a/packages/sector7/monitor/monitor-script.ts
+++ b/packages/sector7/monitor/monitor-script.ts
@@ -250,9 +250,12 @@ async function checkAndAlert(result, env, ctx) {
 	}
 	state.last_ts = result.ts;
 
-	// Write updated state back to D1 via UPSERT (non-blocking)
-	ctx.waitUntil(
-		env.DB.prepare(
+	// Persist updated state to D1 BEFORE firing any webhook. We await the write
+	// (checkAndAlert runs concurrently via Promise.all, so awaiting here does not
+	// serialize monitors) and skip alerting if it fails: a dropped write would
+	// leave stale state and re-fire the same alert on the next run.
+	try {
+		await env.DB.prepare(
 			\`INSERT INTO monitor_state (monitor_id, consecutive_failures, consecutive_successes, last_status, last_ts, updated_at)
 			 VALUES (?, ?, ?, ?, ?, ?)
 			 ON CONFLICT(monitor_id) DO UPDATE SET
@@ -270,9 +273,11 @@ async function checkAndAlert(result, env, ctx) {
 				state.last_ts,
 				result.ts,
 			)
-			.run()
-			.catch((e) => console.error("Failed to write monitor state for " + result.monitor_id + ":", e))
-	);
+			.run();
+	} catch (e) {
+		console.error("Failed to write monitor state for " + result.monitor_id + ":", e);
+		return;
+	}
 
 	// Fire webhook on state transitions
 	if (previousStatus !== state.last_status) {

--- a/packages/sector7/monitor/monitor-script.ts
+++ b/packages/sector7/monitor/monitor-script.ts
@@ -157,10 +157,9 @@ export default {${fetchHandler}
 				.run();
 		}
 
-		// Check alert conditions for each monitor using D1 state
-		for (const result of results) {
-			await checkAndAlert(result, env, ctx);
-		}
+		// Check alert conditions using D1 state. Each monitor's check is
+		// independent (keyed by monitor_id), so run them concurrently.
+		await Promise.all(results.map((result) => checkAndAlert(result, env, ctx)));
 	},
 };
 
@@ -269,7 +268,7 @@ async function checkAndAlert(result, env, ctx) {
 				state.consecutive_successes,
 				state.last_status,
 				state.last_ts,
-				new Date().toISOString(),
+				result.ts,
 			)
 			.run()
 			.catch((e) => console.error("Failed to write monitor state for " + result.monitor_id + ":", e))

--- a/packages/sector7/monitor/monitor-script.ts
+++ b/packages/sector7/monitor/monitor-script.ts
@@ -1,8 +1,10 @@
 /**
- * Worker script template for uptime monitoring with D1 storage, KV state
- * tracking, and webhook alerting on failure-state transitions.
+ * Worker script template for uptime monitoring with D1 storage for both probe
+ * results and failure-streak alert state, plus webhook alerting on
+ * failure-state transitions.
  *
  * ADR-020: Cloudflare Worker Uptime Monitor
+ * ADR-030: Move alert state from KV to D1 (removes the KV dependency)
  */
 
 /**
@@ -11,7 +13,7 @@
 export interface MonitorTarget {
 	/**
 	 * Unique identifier for this monitor (alphanumeric, dashes).
-	 * Used as monitor_id in D1 and as KV key prefix.
+	 * Used as monitor_id in D1 (both probe_results and monitor_state tables).
 	 */
 	id: string;
 	/** Full URL to probe (e.g., "https://grafana.example.com/healthz"). */
@@ -49,7 +51,7 @@ export interface MonitorTarget {
  * The generated script:
  * 1. Probes each configured endpoint (fetch with timing).
  * 2. Inserts a row into D1 for each probe result.
- * 3. Reads/writes failure streak state from KV.
+ * 3. Reads/writes failure streak state from the D1 monitor_state table.
  * 4. Fires webhook alerts on state transitions (healthy -> unhealthy or vice versa).
  *
  * Alert logic:
@@ -155,7 +157,7 @@ export default {${fetchHandler}
 				.run();
 		}
 
-		// Check alert conditions for each monitor using KV state
+		// Check alert conditions for each monitor using D1 state
 		for (const result of results) {
 			await checkAndAlert(result, env, ctx);
 		}
@@ -211,12 +213,15 @@ async function probe(monitor, env) {
 }
 
 async function checkAndAlert(result, env, ctx) {
-	const kvKey = \`streak:\${result.monitor_id}\`;
 	let state;
 
 	try {
-		const raw = await env.KV.get(kvKey, "json");
-		state = raw ?? { consecutive_failures: 0, consecutive_successes: 0, last_status: "healthy", last_ts: null };
+		const row = await env.DB.prepare(
+			"SELECT consecutive_failures, consecutive_successes, last_status, last_ts FROM monitor_state WHERE monitor_id = ?"
+		)
+			.bind(result.monitor_id)
+			.first();
+		state = row ?? { consecutive_failures: 0, consecutive_successes: 0, last_status: "healthy", last_ts: null };
 	} catch {
 		state = { consecutive_failures: 0, consecutive_successes: 0, last_status: "healthy", last_ts: null };
 	}
@@ -241,8 +246,28 @@ async function checkAndAlert(result, env, ctx) {
 	}
 	state.last_ts = result.ts;
 
-	// Write updated state back to KV (non-blocking)
-	ctx.waitUntil(env.KV.put(kvKey, JSON.stringify(state)));
+	// Write updated state back to D1 via UPSERT (non-blocking)
+	ctx.waitUntil(
+		env.DB.prepare(
+			\`INSERT INTO monitor_state (monitor_id, consecutive_failures, consecutive_successes, last_status, last_ts, updated_at)
+			 VALUES (?, ?, ?, ?, ?, ?)
+			 ON CONFLICT(monitor_id) DO UPDATE SET
+			   consecutive_failures = excluded.consecutive_failures,
+			   consecutive_successes = excluded.consecutive_successes,
+			   last_status = excluded.last_status,
+			   last_ts = excluded.last_ts,
+			   updated_at = excluded.updated_at\`
+		)
+			.bind(
+				result.monitor_id,
+				state.consecutive_failures,
+				state.consecutive_successes,
+				state.last_status,
+				state.last_ts,
+				new Date().toISOString(),
+			)
+			.run()
+	);
 
 	// Fire webhook on state transitions
 	if (previousStatus !== state.last_status) {

--- a/packages/sector7/monitor/monitor-script.ts
+++ b/packages/sector7/monitor/monitor-script.ts
@@ -222,8 +222,13 @@ async function checkAndAlert(result, env, ctx) {
 			.bind(result.monitor_id)
 			.first();
 		state = row ?? { consecutive_failures: 0, consecutive_successes: 0, last_status: "healthy", last_ts: null };
-	} catch {
-		state = { consecutive_failures: 0, consecutive_successes: 0, last_status: "healthy", last_ts: null };
+	} catch (e) {
+		// On a transient read error, do NOT fall back to a default "healthy"
+		// state: doing so would clear an active failure streak and overwrite the
+		// real state on the UPSERT below, silently dropping alerts. Skip this
+		// monitor's check and leave the persisted row untouched.
+		console.error("Failed to read monitor state for " + result.monitor_id + ":", e);
+		return;
 	}
 
 	if (result.ok) {
@@ -267,6 +272,7 @@ async function checkAndAlert(result, env, ctx) {
 				new Date().toISOString(),
 			)
 			.run()
+			.catch((e) => console.error("Failed to write monitor state for " + result.monitor_id + ":", e))
 	);
 
 	// Fire webhook on state transitions

--- a/packages/sector7/monitor/uptime-monitor.ts
+++ b/packages/sector7/monitor/uptime-monitor.ts
@@ -13,8 +13,8 @@ export type MonitorConfig = MonitorTarget;
  *
  * @remarks
  * Creates a Cloudflare Worker with cron trigger that probes HTTP endpoints,
- * stores results in D1, tracks failure streaks in KV, and fires webhook
- * alerts on state transitions.
+ * stores results in D1, tracks failure streaks in a D1 `monitor_state` table,
+ * and fires webhook alerts on state transitions.
  *
  * @example
  * ```typescript
@@ -82,24 +82,14 @@ export interface UptimeMonitorArgs {
 	d1DatabaseId?: pulumi.Input<string>;
 
 	/**
-	 * KV namespace title when creating a new namespace.
-	 * @default "<name>-state"
-	 */
-	kvNamespaceTitle?: pulumi.Input<string>;
-
-	/**
-	 * Existing KV namespace ID to use instead of creating one.
-	 * When set, `kvNamespaceTitle` is ignored.
-	 */
-	kvNamespaceId?: pulumi.Input<string>;
-
-	/**
 	 * D1 probe_results table CREATE statement.
 	 *
 	 * Override to customize the schema (add columns, change indexes).
 	 * The Worker script expects at minimum the columns referenced in the
 	 * default schema.
-	 * @default built-in schema with ts, monitor_id, url, ok, status, latency_ms, error, region_hint
+	 * @default built-in schema: a `probe_results` table (ts, monitor_id, url, ok,
+	 * status, latency_ms, error, region_hint) and a `monitor_state` table holding
+	 * per-monitor failure-streak alert state.
 	 *
 	 * Applied automatically during `pulumi up` via the D1 REST API.
 	 * Re-applied when the SQL content changes.
@@ -136,7 +126,13 @@ export interface UptimeMonitorArgs {
 	};
 }
 
-const DEFAULT_D1_SCHEMA = [
+/**
+ * Default D1 schema applied during `pulumi up`. Creates the `probe_results`
+ * history table and the `monitor_state` alert-state table (ADR-030).
+ *
+ * Exported for tests; not re-exported from the package barrel.
+ */
+export const DEFAULT_D1_SCHEMA = [
 	"CREATE TABLE IF NOT EXISTS probe_results (",
 	"    id INTEGER PRIMARY KEY AUTOINCREMENT,",
 	"    ts TEXT NOT NULL,",
@@ -151,23 +147,34 @@ const DEFAULT_D1_SCHEMA = [
 	"",
 	"CREATE INDEX IF NOT EXISTS idx_probe_ts ON probe_results(ts);",
 	"CREATE INDEX IF NOT EXISTS idx_probe_monitor_ts ON probe_results(monitor_id, ts);",
+	"",
+	// Per-monitor failure-streak alert state (ADR-030). Replaces the former KV
+	// `streak:<monitor_id>` keys. One row per monitor, always looked up by PK,
+	// so no additional indexes are needed beyond the primary key.
+	"CREATE TABLE IF NOT EXISTS monitor_state (",
+	"    monitor_id TEXT PRIMARY KEY,",
+	"    consecutive_failures INTEGER NOT NULL DEFAULT 0,",
+	"    consecutive_successes INTEGER NOT NULL DEFAULT 0,",
+	"    last_status TEXT NOT NULL DEFAULT 'healthy',",
+	"    last_ts TEXT,",
+	"    updated_at TEXT NOT NULL",
+	");",
 ].join("\n");
 
 /**
  * UptimeMonitor component for synthetic HTTP endpoint monitoring.
  *
  * @remarks
- * ADR-020 implementation:
+ * ADR-020 implementation (ADR-030: state in D1 instead of KV):
  * - Cloudflare Worker with cron trigger probes configured endpoints
  * - D1 stores probe results for querying and analytics
- * - KV tracks failure streak state for alerting
+ * - D1 `monitor_state` table tracks failure streak state for alerting
  * - Webhook alerts fire on healthy-to-unhealthy and unhealthy-to-healthy transitions
  *
  * The component creates:
  * 1. D1 database (or references existing)
- * 2. KV namespace (or references existing)
- * 3. Worker script with embedded monitor configuration
- * 4. Cron trigger for scheduled execution
+ * 2. Worker script with embedded monitor configuration
+ * 3. Cron trigger for scheduled execution
  *
  * @example
  * ```typescript
@@ -201,18 +208,6 @@ export class UptimeMonitor extends pulumi.ComponentResource {
 	 * The D1 database ID (either from created or referenced database).
 	 */
 	public readonly d1DatabaseId: pulumi.Output<string>;
-
-	/**
-	 * The KV namespace for failure streak state.
-	 * Present when the component creates the namespace.
-	 * Undefined when `kvNamespaceId` references an existing namespace.
-	 */
-	public readonly kvNamespace: cloudflare.WorkersKvNamespace | undefined;
-
-	/**
-	 * The KV namespace ID.
-	 */
-	public readonly kvNamespaceId: pulumi.Output<string>;
 
 	/**
 	 * The Worker script running the monitor logic.
@@ -298,27 +293,7 @@ export class UptimeMonitor extends pulumi.ComponentResource {
 			{ parent: this, dependsOn: this.d1Database ? [this.d1Database] : [] },
 		);
 
-		// 2. Create or reference KV namespace
-		if (args.kvNamespaceId) {
-			this.kvNamespaceId = pulumi.output(args.kvNamespaceId);
-			this.kvNamespace = undefined;
-		} else {
-			const kvTitle = pulumi
-				.output(args.kvNamespaceTitle ?? args.name)
-				.apply((n: string) => (n.endsWith("-state") ? n : `${n}-state`));
-
-			this.kvNamespace = new cloudflare.WorkersKvNamespace(
-				`${name}-kv`,
-				{
-					accountId: args.accountId,
-					title: kvTitle,
-				},
-				resourceOpts,
-			);
-			this.kvNamespaceId = this.kvNamespace.id;
-		}
-
-		// 3. Generate Worker script
+		// 2. Generate Worker script
 		// Resolve pulumi.Input<boolean> via .apply() so Output values are
 		// unwrapped before being passed to the synchronous script generator.
 		const scriptContent = pulumi
@@ -330,17 +305,12 @@ export class UptimeMonitor extends pulumi.ComponentResource {
 				}),
 			);
 
-		// 4. Create Worker with D1 and KV bindings
+		// 3. Create Worker with D1 binding
 		const baseBindings: Array<cloudflare.types.input.WorkersScriptBinding> = [
 			{
 				name: "DB",
 				type: "d1",
 				id: this.d1DatabaseId,
-			},
-			{
-				name: "KV",
-				type: "kv_namespace",
-				namespaceId: this.kvNamespaceId,
 			},
 		];
 
@@ -364,7 +334,7 @@ export class UptimeMonitor extends pulumi.ComponentResource {
 			{ parent: this, dependsOn: this.d1Query ? [this.d1Query] : [] },
 		);
 
-		// 5. Create cron trigger for scheduled execution
+		// 4. Create cron trigger for scheduled execution
 		this.cronTrigger = new cloudflare.WorkersCronTrigger(
 			`${name}-cron`,
 			{
@@ -382,8 +352,6 @@ export class UptimeMonitor extends pulumi.ComponentResource {
 			d1Database: this.d1Database,
 			d1DatabaseId: this.d1DatabaseId,
 			d1Query: this.d1Query,
-			kvNamespace: this.kvNamespace,
-			kvNamespaceId: this.kvNamespaceId,
 			worker: this.worker,
 			cronTrigger: this.cronTrigger,
 			workerName: this.workerName,

--- a/packages/sector7/tests/uptime-monitor.test.ts
+++ b/packages/sector7/tests/uptime-monitor.test.ts
@@ -318,10 +318,14 @@ describe("UptimeMonitor", () => {
 		const content = worker?.inputs.content as string;
 		// No KV access anywhere in the generated Worker.
 		expect(content).not.toContain("env.KV");
-		// State is read from and written to the monitor_state D1 table.
+		// State is read from and written to the monitor_state D1 table, batched
+		// into one SELECT + one db.batch() UPSERT (2 D1 queries/run) to stay under
+		// the 50-queries/invocation free-tier limit regardless of monitor count.
 		expect(content).toContain("FROM monitor_state");
+		expect(content).toContain("WHERE monitor_id IN (");
 		expect(content).toContain("INSERT INTO monitor_state");
 		expect(content).toContain("ON CONFLICT(monitor_id) DO UPDATE");
+		expect(content).toContain("env.DB.batch(");
 		// A read failure must not silently reset state (would clear active
 		// alerts), and a write failure must abort before the webhook fires
 		// (otherwise stale state would re-fire the same alert next run).

--- a/packages/sector7/tests/uptime-monitor.test.ts
+++ b/packages/sector7/tests/uptime-monitor.test.ts
@@ -323,9 +323,14 @@ describe("UptimeMonitor", () => {
 		expect(content).toContain("INSERT INTO monitor_state");
 		expect(content).toContain("ON CONFLICT(monitor_id) DO UPDATE");
 		// A read failure must not silently reset state (would clear active
-		// alerts); the write failure must not become an unhandled rejection.
+		// alerts), and a write failure must abort before the webhook fires
+		// (otherwise stale state would re-fire the same alert next run).
 		expect(content).toContain("Failed to read monitor state");
 		expect(content).toContain("Failed to write monitor state");
-		expect(content).toContain(".catch(");
+		// The state write is awaited and ordered before the webhook send.
+		const writeIdx = content.indexOf("INSERT INTO monitor_state");
+		const webhookIdx = content.indexOf("sendWebhook(env");
+		expect(writeIdx).toBeGreaterThan(-1);
+		expect(webhookIdx).toBeGreaterThan(writeIdx);
 	});
 });

--- a/packages/sector7/tests/uptime-monitor.test.ts
+++ b/packages/sector7/tests/uptime-monitor.test.ts
@@ -322,5 +322,10 @@ describe("UptimeMonitor", () => {
 		expect(content).toContain("FROM monitor_state");
 		expect(content).toContain("INSERT INTO monitor_state");
 		expect(content).toContain("ON CONFLICT(monitor_id) DO UPDATE");
+		// A read failure must not silently reset state (would clear active
+		// alerts); the write failure must not become an unhandled rejection.
+		expect(content).toContain("Failed to read monitor state");
+		expect(content).toContain("Failed to write monitor state");
+		expect(content).toContain(".catch(");
 	});
 });

--- a/packages/sector7/tests/uptime-monitor.test.ts
+++ b/packages/sector7/tests/uptime-monitor.test.ts
@@ -16,7 +16,10 @@ vi.mock("../d1/d1-query.ts", () => {
 	};
 });
 
-import { UptimeMonitor } from "../monitor/uptime-monitor.ts";
+import {
+	DEFAULT_D1_SCHEMA,
+	UptimeMonitor,
+} from "../monitor/uptime-monitor.ts";
 
 type MockResource = {
 	type: string;
@@ -69,7 +72,7 @@ const DEFAULT_ARGS = {
 } as const;
 
 describe("UptimeMonitor", () => {
-	it("creates D1, KV, Worker, cron trigger, and D1Query for a basic monitor", async () => {
+	it("creates D1, Worker, cron trigger, and D1Query for a basic monitor", async () => {
 		const monitor = new UptimeMonitor("basic", {
 			...DEFAULT_ARGS,
 			name: "basic-uptime",
@@ -82,22 +85,24 @@ describe("UptimeMonitor", () => {
 		const d1 = findResource("basic-d1");
 		expect(d1).toBeDefined();
 		expect(d1?.inputs.readReplication).toEqual({ mode: "disabled" });
-		expect(findResource("basic-kv")).toBeDefined();
 		expect(findResource("basic-worker")).toBeDefined();
 		expect(findResource("basic-cron")).toBeDefined();
 		expect(monitor.d1Query).toBeDefined();
 
+		// KV is no longer created (ADR-030: alert state moved to D1).
+		expect(findResource("basic-kv")).toBeUndefined();
+
 		const worker = findResource("basic-worker");
 		const bindings = worker?.inputs.bindings as Array<Record<string, unknown>>;
-		expect(bindings).toHaveLength(2);
+		expect(bindings).toHaveLength(1);
 
 		const d1Binding = bindings.find((b) => b.name === "DB");
 		expect(d1Binding).toBeDefined();
 		expect(d1Binding?.type).toBe("d1");
 
-		const kvBinding = bindings.find((b) => b.name === "KV");
-		expect(kvBinding).toBeDefined();
-		expect(kvBinding?.type).toBe("kv_namespace");
+		// No KV namespace binding should be present.
+		expect(bindings.find((b) => b.type === "kv_namespace")).toBeUndefined();
+		expect(bindings.find((b) => b.name === "KV")).toBeUndefined();
 	});
 
 	it("adds a webhook secret binding when webhookUrl is provided", async () => {
@@ -118,7 +123,8 @@ describe("UptimeMonitor", () => {
 			rawBindings as pulumi.Input<Array<Record<string, unknown>>>,
 		);
 
-		expect(bindings).toHaveLength(3);
+		// DB binding + webhook secret (no KV binding — ADR-030).
+		expect(bindings).toHaveLength(2);
 
 		const webhookBinding = bindings.find((b) => b.name === "WEBHOOK_URL");
 		expect(webhookBinding).toBeDefined();
@@ -178,21 +184,6 @@ describe("UptimeMonitor", () => {
 			worker?.inputs.bindings as Array<Record<string, unknown>>
 		).find((b) => b.name === "DB");
 		expect(d1Binding).toBeDefined();
-	});
-
-	it("uses existing KV namespace when kvNamespaceId is provided", async () => {
-		const monitor = new UptimeMonitor("exkv", {
-			...DEFAULT_ARGS,
-			name: "exkv-uptime",
-			monitors: [{ id: "site", url: "https://example.com/" }],
-			kvNamespaceId: "existing-kv-id",
-		});
-
-		await resolveOutput(monitor.worker.id);
-
-		expect(findResource("exkv-kv")).toBeUndefined();
-		expect(monitor.kvNamespace).toBeUndefined();
-		expect(await resolveOutput(monitor.kvNamespaceId)).toBe("existing-kv-id");
 	});
 
 	it("throws if no monitors are provided", () => {
@@ -297,5 +288,39 @@ describe("UptimeMonitor", () => {
 		const content = worker?.inputs.content as string;
 		expect(content).not.toContain("async fetch(request, env)");
 		expect(content).not.toContain("handleStats");
+	});
+
+	it("includes the monitor_state table in the default D1 schema (ADR-030)", () => {
+		expect(DEFAULT_D1_SCHEMA).toContain(
+			"CREATE TABLE IF NOT EXISTS monitor_state",
+		);
+		expect(DEFAULT_D1_SCHEMA).toContain("monitor_id TEXT PRIMARY KEY");
+		expect(DEFAULT_D1_SCHEMA).toContain("consecutive_failures INTEGER");
+		expect(DEFAULT_D1_SCHEMA).toContain("consecutive_successes INTEGER");
+		expect(DEFAULT_D1_SCHEMA).toContain("last_status TEXT");
+		expect(DEFAULT_D1_SCHEMA).toContain("updated_at TEXT NOT NULL");
+		// probe_results table must still be present.
+		expect(DEFAULT_D1_SCHEMA).toContain(
+			"CREATE TABLE IF NOT EXISTS probe_results",
+		);
+	});
+
+	it("generated script tracks alert state in D1, not KV (ADR-030)", async () => {
+		const monitor = new UptimeMonitor("nokv", {
+			...DEFAULT_ARGS,
+			name: "nokv-uptime",
+			monitors: [{ id: "api", url: "https://api.example.com/healthz" }],
+		});
+
+		await resolveOutput(monitor.worker.id);
+
+		const worker = findResource("nokv-worker");
+		const content = worker?.inputs.content as string;
+		// No KV access anywhere in the generated Worker.
+		expect(content).not.toContain("env.KV");
+		// State is read from and written to the monitor_state D1 table.
+		expect(content).toContain("FROM monitor_state");
+		expect(content).toContain("INSERT INTO monitor_state");
+		expect(content).toContain("ON CONFLICT(monitor_id) DO UPDATE");
 	});
 });


### PR DESCRIPTION
## Summary

Removes the Cloudflare Workers **KV** dependency from `UptimeMonitor` and moves the failure-streak alert state machine into a new `monitor_state` table in the existing **D1** database.

**Why:** KV's free tier allows only **1,000 `put` operations/day**. The default `*/1 * * * *` cron writes streak state on every probe of every monitor — 1,440 writes/day for a *single* monitor — exceeding the free tier with the runtime error:

> You have exceeded the daily Cloudflare Workers KV free tier limit of 1000 Workers KV put operations.

ADR-020 anticipated this and suggested batching state into one KV key, but one write/minute is still 1,440/day — over the cap. D1's free tier allows **100,000 rows written/day**, comfortably covering both probe history and alert state. The Worker already binds D1 (`env.DB`).

## Changes

- **Schema** (`uptime-monitor.ts`): add `monitor_state` table to `DEFAULT_D1_SCHEMA` (PK on `monitor_id`; one row per monitor → no extra indexes). Export the constant for tests.
- **Worker** (`monitor-script.ts`): rewrite `checkAndAlert()` to read via `SELECT … FROM monitor_state` and write via `INSERT … ON CONFLICT(monitor_id) DO UPDATE`, kept inside `ctx.waitUntil()`. All `env.KV` usage removed.
- **Component** (`uptime-monitor.ts`): remove KV namespace creation, the `{ name: "KV", type: "kv_namespace" }` binding, the `kvNamespaceTitle` / `kvNamespaceId` args, and the `kvNamespace` / `kvNamespaceId` outputs.
- **Tests**: assert no KV namespace/binding is created, assert `monitor_state` is in the schema, assert the generated script uses D1 (not `env.KV`) for state. Removed the existing-KV-namespace test.
- **Docs**: new **ADR-030** records the decision and free-tier math; **ADR-020** marked `Amended` with a pointer.

## Breaking change

`UptimeMonitorArgs` no longer accepts `kvNamespaceTitle` / `kvNamespaceId`, and the component no longer exposes `kvNamespace` / `kvNamespaceId` outputs. Removing them from the typed interface makes a stale config a **compile-time error** for typed consumers (intentional; no runtime throw added). No consumer passes these today — `garden`'s uptime stack uses defaults.

## Migration

After releasing this and bumping the dep, a follow-up `pulumi up` in `garden/deploy/services/uptime/` will: destroy the KV namespace, update the Worker to drop the KV binding, and create `monitor_state` via the existing `D1Query` schema apply. KV streak state is ephemeral — all monitors restart `healthy` with zero streaks and re-accumulate within `ALERT_THRESHOLD` (3) ticks. **This `garden`-side `pulumi up` is out of scope for this PR.**

## Test plan

- `pnpm build` — ✅ passes (tsc strict)
- `pnpm test` — ✅ 174 tests pass (17 files)
- `grep env.KV` in generated script — ✅ zero hits
- New assertions verify `monitor_state` schema and D1-based state

## Risks

- More D1 queries per cron run: +1 `SELECT` and +1 UPSERT per monitor. ~4,320 queries/day at 1 monitor/min, well within free tier. D1 allows 50 queries/invocation (free) — keep monitor count per component well under ~25; noted in ADR-030.
- `monitor_state` rows persist (no KV TTL cleanup); table is tiny/static, so no cleanup mechanism added.

## References

- ADR-030: `docs/internal/designs/030-uptime-monitor-state-in-d1.md`
- ADR-020 (amended): `docs/internal/designs/020-cloudflare-worker-uptime-monitor.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking component API and changed alerting persistence ordering; incorrect handling of D1 errors could skip or duplicate webhooks until the next successful run, though streak logic is otherwise unchanged.
> 
> **Overview**
> **UptimeMonitor** no longer uses Cloudflare KV for failure-streak alert state. Streak counters and healthy/unhealthy status move into a new D1 **`monitor_state`** table (same database as **`probe_results`**), with **ADR-030** documenting the free-tier rationale and **ADR-020** marked amended.
> 
> The generated Worker replaces per-monitor **`checkAndAlert`** / **`env.KV`** with **`checkAndAlertBatch`**: one **`SELECT … WHERE monitor_id IN (…)`**, then one **`env.DB.batch()`** of **`INSERT … ON CONFLICT` UPSERTs** so alert I/O stays at **2 D1 queries per cron run** (plus probe inserts). State writes are **awaited before** transition webhooks; read or write failures **abort the run** without defaulting streaks or firing alerts (avoids silent alert loss or duplicate webhooks).
> 
> The Pulumi component drops KV namespace creation, the **`KV`** binding, and **`kvNamespace*`** args/outputs — a **breaking** API change. Default schema and tests assert **`monitor_state`**, no KV resources/bindings, and D1-only state in the generated script.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c9901a4c47f506b08dc408851892cbf1d8ee0aec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->