### PR TITLE
release: bump sector7 to 0.13.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@jmmaloney4/sector7",
 	"private": true,
-	"version": "0.12.0",
+	"version": "0.13.0",
 	"description": "Sector7 monorepo",
 	"license": "MPL-2.0",
 	"workspaces": [

--- a/packages/sector7/package.json
+++ b/packages/sector7/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@jmmaloney4/sector7",
-	"version": "0.12.0",
+	"version": "0.13.0",
 	"description": "Reusable Pulumi components for infrastructure management",
 	"license": "MPL-2.0",
 	"publishConfig": {


### PR DESCRIPTION
## Summary

Release **v0.13.0**. Bumps `package.json` + `packages/sector7/package.json` `0.12.0` → `0.13.0`.

Tagging `v0.13.0` after this merges triggers `_dogfood-pnpm.yml` → publishes `jmmaloney4-sector7-0.13.0.tgz` to the GitHub Release.

## What's in 0.13.0
- #249 — nix-image push scripts source skopeo from `github:jmmaloney4/jackpkgs#skopeo-nix2container` (jackpkgs#296's re-export), centralizing the skopeo source; new Renovate `github-commits` manager auto-bumps the pinned jackpkgs commit.

## Follow-up
- After release, bump zeus (`package.json` + `atlas/package.json`) `v0.11.0` → `v0.13.0` to consume it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)