### PR TITLE
feat(renovate): combine loose npm minor/patch into one JS/TS group

### DIFF
--- a/renovate/minor-patch-automerge.json
+++ b/renovate/minor-patch-automerge.json
@@ -4,6 +4,14 @@
 	"addLabels": ["renovate"],
 	"packageRules": [
 		{
+			"description": "Catch-all: combine loose npm minor/patch/pin updates (single libraries and monorepos) into one automerged PR. Placed first so the more-specific groups below (TypeScript, Node.js Core, Pulumi, etc.) override it for their packages.",
+			"groupName": "JS/TS Dependencies",
+			"matchManagers": ["npm"],
+			"matchUpdateTypes": ["minor", "patch", "pin"],
+			"automerge": true,
+			"addLabels": ["deps/npm"]
+		},
+		{
 			"groupName": "Rust Dependencies",
 			"matchManagers": ["cargo"],
 			"matchDatasources": ["crate"],


### PR DESCRIPTION
## What

Adds a single catch-all **`JS/TS Dependencies`** group to `renovate/minor-patch-automerge.json` covering `npm` `minor`/`patch`/`pin` updates, placed **first** in `packageRules`.

```json
{
  "groupName": "JS/TS Dependencies",
  "matchManagers": ["npm"],
  "matchUpdateTypes": ["minor", "patch", "pin"],
  "automerge": true,
  "addLabels": ["deps/npm"]
}
```

## Why

Consumer repos (e.g. `zeus`) currently get a long tail of **one-PR-per-package** npm updates — every loose dependency that doesn't happen to match a named group (`echarts`, `vite`, `tar`, `lightweight-charts`, …) opens its own PR, alongside the per-monorepo PRs (`react`, `react-router`, `vitest`, `aws-sdk`). On `zeus` this was a big chunk of ~19 simultaneously-open Renovate PRs.

This sweeps that tail (and the monorepo minor/patch updates) into one automerged PR.

## Precedence

Renovate applies all matching `packageRules` in order; later rules win on `groupName`. The catch-all is placed **before** the specific groups, so they still override it for their packages:

| Package | Resolves to |
|---|---|
| `typescript`, `@types/*` | **TypeScript Dependencies** (unchanged) |
| `node`, `ts-node` | **Node.js Core** (unchanged) |
| `@pulumi/*`, `pulumi*` | **Pulumi Dependencies** (unchanged) |
| `jest`, `@types/jest` | **Testing Dependencies** (unchanged) |
| everything else npm (echarts, vite, tar, react, vitest, aws-sdk, …) | **JS/TS Dependencies** (new) |

- **Majors** are untouched — `major-updates.json` matches `major` only and keeps `groupName: null` (individual, manual review).
- Non-npm ecosystems (Rust, Python, Nix, Docker, GitHub Actions) are unaffected.
- The existing pnpm-dedupe rule for Pulumi npm packages still applies (no `groupName`, so it only contributes `postUpdateOptions`).

## Validation

`renovate-config-validator --strict` passes against both `minor-patch-automerge.json` and the aggregate `all.json`.

## Follow-up (not in this PR)

The `@types/node` / `@pulumi` duplication seen in zeus (root `package.json` deps showing up in both a root-file group *and* the ecosystem groups) is caused by a **zeus-local** `matchFileNames: ['package.json']` rule that is appended after these presets — sector7 defaults can't override it. That will be removed in a separate zeus PR so root deps flow into these shared groups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)