### PR TITLE
feat(ci): mint GitHub App token in add-to-project workflow

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -12,6 +12,11 @@ on:
         required: false
         default: 'https://github.com/orgs/ergodicsystems/projects/1'
         type: string
+      owner:
+        description: 'Account that owns the GitHub App installation and the project. Passed to create-github-app-token so the token is minted against this installation regardless of which repo triggers the workflow. Must match where the app is installed.'
+        required: false
+        default: 'ergodicsystems'
+        type: string
       labeled:
         description: 'Optional comma-separated labels; omit or leave empty to add all matching events. When set, items are filtered per label-operator.'
         required: false
@@ -23,19 +28,48 @@ on:
         default: OR
         type: string
     secrets:
+      app-id:
+        description: 'GitHub App ID with org Projects read/write (preferred auth). Pair with private-key.'
+        required: false
+      private-key:
+        description: 'GitHub App private key (PEM) matching app-id (preferred auth).'
+        required: false
       github-token:
-        description: 'GitHub personal access token with project write access'
-        required: true
+        description: 'Fallback PAT with project write access (legacy). Used only when app-id/private-key are not provided.'
+        required: false
 permissions:
   contents: read
 jobs:
   add-to-project:
     runs-on: ${{ inputs.runs-on }}
+    env:
+      # Mapped to job env so they can be referenced in step-level `if` (the
+      # secrets context is not available in conditionals). app-id is not
+      # sensitive; the private key is referenced directly in `with:` below and
+      # is intentionally not exposed as a job env var.
+      APP_ID: ${{ secrets.app-id }}
+      GH_FALLBACK_TOKEN: ${{ secrets.github-token }}
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        if: ${{ env.APP_ID != '' }}
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.app-id }}
+          private-key: ${{ secrets.private-key }}
+          owner: ${{ inputs.owner }}
+
+      - name: Verify auth provided
+        if: ${{ steps.app-token.outputs.token == '' && env.GH_FALLBACK_TOKEN == '' }}
+        shell: bash
+        run: |
+          echo "::error::add-to-project: no credentials provided. Pass app-id + private-key (preferred) or a github-token fallback to this reusable workflow. See docs/internal/designs/022-github-app-auth-add-to-project.md."
+          exit 1
+
       - name: Add issue or PR to project
         uses: jmmaloney4/sector7/.github/actions/add-to-project@main
         with:
           project-url: ${{ inputs.project_url }}
-          github-token: ${{ secrets.github-token }}
+          github-token: ${{ steps.app-token.outputs.token || secrets.github-token }}
           labeled: ${{ inputs.labeled }}
           label-operator: ${{ inputs.label-operator }}

--- a/docs/internal/designs/022-github-app-auth-add-to-project.md
+++ b/docs/internal/designs/022-github-app-auth-add-to-project.md
@@ -73,6 +73,12 @@ on:
       project_url:
         default: 'https://github.com/orgs/ergodicsystems/projects/1'
         type: string
+      owner:
+        # Account that owns the app installation AND the project. Passed to
+        # create-github-app-token so the token is minted against this
+        # installation regardless of which repo triggers the workflow.
+        default: 'ergodicsystems'
+        type: string
       labeled:
         default: ''
         type: string
@@ -94,43 +100,45 @@ permissions:
 jobs:
   add-to-project:
     runs-on: ${{ inputs.runs-on }}
+    env:
+      # Mapped to job env so they can be referenced in step-level `if` (the
+      # secrets context is not available in conditionals).
+      APP_ID: ${{ secrets.app-id }}
+      GH_FALLBACK_TOKEN: ${{ secrets.github-token }}
     steps:
       - name: Generate GitHub App token
-        id: gen_token
-        if: inputs.app-id != '' && inputs.private-key != ''
-        uses: actions/create-github-app-token@v2
+        id: app-token
+        if: ${{ env.APP_ID != '' }}
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ inputs.app-id }}
-          private-key: ${{ inputs.private-key }}
+          app-id: ${{ secrets.app-id }}
+          private-key: ${{ secrets.private-key }}
+          owner: ${{ inputs.owner }}
 
-      - name: Set fallback token
-        id: fallback
-        if: inputs.app-id == '' || inputs.private-key == ''
-        run: echo "token=${{ secrets.github-token }}" >> "$GITHUB_OUTPUT"
+      - name: Verify auth provided
+        if: ${{ steps.app-token.outputs.token == '' && env.GH_FALLBACK_TOKEN == '' }}
         shell: bash
+        run: |
+          echo "::error::add-to-project: no credentials provided. Pass app-id + private-key (preferred) or a github-token fallback."
+          exit 1
 
-      - name: Use app token or fallback
-        id: token
-        if: inputs.app-id != '' && inputs.private-key != ''
-        run: echo "token=${{ steps.gen_token.outputs.token }}" >> "$GITHUB_OUTPUT"
-        shell: bash
-
-      - name: Add issue or PR to project (no label filter)
-        if: inputs.labeled == ''
-        uses: actions/add-to-project@244f685bbc3b7adfa8466e08b698b5577571133e
+      - name: Add issue or PR to project
+        uses: jmmaloney4/sector7/.github/actions/add-to-project@main
         with:
           project-url: ${{ inputs.project_url }}
-          github-token: ${{ steps.token.outputs.token }}
-
-      - name: Add issue or PR to project (label filter)
-        if: inputs.labeled != ''
-        uses: actions/add-to-project@244f685bbc3b7adfa8466e08b698b5577571133e
-        with:
-          project-url: ${{ inputs.project_url }}
-          github-token: ${{ steps.token.outputs.token }}
+          github-token: ${{ steps.app-token.outputs.token || secrets.github-token }}
           labeled: ${{ inputs.labeled }}
           label-operator: ${{ inputs.label-operator }}
 ```
+
+The `owner` input is the critical detail: `create-github-app-token` defaults
+to minting a token for the **caller repo's account**, which only has an
+installation if the caller lives in the same org as the app. Cross-org callers
+(`jmmaloney4/garden`, `cavinsresearch/zeus`, ...) would otherwise fail with
+"installation not found". Setting `owner` to the account that owns the app
+installation makes token minting work from any repo. The actual workflow uses
+the local `jmmaloney4/sector7/.github/actions/add-to-project` composite action
+(gh CLI based) rather than `actions/add-to-project` directly.
 
 ## GitHub App registration
 
@@ -138,14 +146,21 @@ The app should be registered in the target org with these settings:
 
 | Field                                 | Value                 |
 | ------------------------------------- | --------------------- |
-| Name                                  | `sector7-project-bot` |
-| Permissions → Organization → Projects | Read and write        |
-| Permissions → Repository → Metadata   | Read-only             |
-| Webhook                               | Active: unchecked     |
+| Name                                  | `sector7-project-bot`              |
+| Permissions → Organization → Projects | Read and write                     |
+| Permissions → Repository → Metadata   | Read-only                          |
+| Webhook                               | Active: unchecked                  |
+| Where can this app be installed?      | Only on this account (`ergodicsystems`) |
 
-The app only needs an org-level installation -- it does not need to be installed
-on individual consumer repos. Its permission to touch org projects comes from the
-org installation itself.
+Register it as **"Only on this account"** -- least privilege. The single
+`ergodicsystems` installation is the only one that grants write access to the
+org project; cross-org callers never need their own installation, they only need
+the `app-id`/`private-key` to mint a token that targets the `ergodicsystems`
+installation (via the `owner` input above).
+
+The app only needs that one org-level installation -- it does not need to be
+installed on individual consumer repos. Its permission to touch org projects
+comes from the org installation itself.
 
 ## Required secrets
 


### PR DESCRIPTION
## Summary

Implements **step 3** of the GitHub App auth plan (`docs/internal/plans/2026-05-02-github-app-add-to-project.md`, ADR-022) and the **`owner` companion fix** flagged in #165.

The reusable `add-to-project.yml` workflow now mints a GitHub App installation token internally via `actions/create-github-app-token@v3.2.0`. Callers pass `app-id` + `private-key` instead of a user PAT. Changes:

- **New `owner` input** (default `ergodicsystems`) passed to `create-github-app-token`. This is the companion fix: without it the action mints a token for the *caller repo's account*, so cross-org callers (`jmmaloney4/garden`, `cavinsresearch/zeus`, …) fail with *installation not found*. With it, the token is always minted against the account that owns the app installation, regardless of which repo triggers the run.
- **New `app-id` / `private-key` secrets** (optional, preferred auth).
- **`github-token` demoted** to an optional legacy fallback (`required: false`). This alone stops the org-wide "Secret github-token is required, but not provided" validation failures once callers stop passing it.
- **Guard step** fails with a clear error when neither app creds nor a fallback token are provided.
- Secrets mapped to job `env` so they can be used in step-level `if` (the `secrets` context isn't available in conditionals); the private key is referenced directly in `with:` and not exposed as a job env var.
- **ADR-022 updated**: target-state YAML synced to the real workflow (it had drifted and omitted `owner`); registration guidance set to **"Only on this account"** with the `owner` rationale.

## Test plan

- [x] `actionlint` passes clean on the workflow.
- [ ] End-to-end (blocked on plan steps 1–2, which are manual): register `sector7-project-bot` on ergodicsystems (Only on this account), store `SECTOR7_PROJECT_BOT_APP_ID` / `SECTOR7_PROJECT_BOT_PRIVATE_KEY`, then open a test issue/PR and confirm it lands on ergodicsystems/projects/1.

## Risks

- App auth is untested until the app exists and secrets are wired; the `github-token` fallback path preserves prior behavior in the meantime.
- `create-github-app-token` bumped to v3.2.0 (ADR mentioned v2); `owner` works identically.

## Remaining work (not in this PR — tracked in #165)

1. Register the GitHub App on ergodicsystems (**Only on this account**).
2. Store `SECTOR7_PROJECT_BOT_APP_ID` / `_PRIVATE_KEY` as ergodicsystems org secret + cavinsresearch org secret + repo secrets on each jmmaloney4 caller.
3. Update + re-pin caller workflows to pass `app-id`/`private-key` (garden, jackpkgs, zeus×2, hq — and fix hq's stale `toolbox` path).
4. Verify end-to-end.

Refs: #165
ADR: `docs/internal/designs/022-github-app-auth-add-to-project.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)