### PR TITLE
feat(gateway): optional pathPrefix on createServiceHttpRoute

### DIFF
--- a/packages/sector7/gateway/index.ts
+++ b/packages/sector7/gateway/index.ts
@@ -27,6 +27,14 @@ export interface ServiceHttpRouteArgs {
 	 * "private-gateway" for the private gateway.
 	 */
 	gatewayName?: string;
+	/**
+	 * Optional path-prefix match. When set, the route only forwards requests
+	 * whose path starts with this prefix (Gateway API `PathPrefix`), instead of
+	 * the whole host. Use this to expose a single endpoint publicly (e.g.
+	 * "/webhook") rather than every route the backend serves. Omit to match all
+	 * paths for the hostname (the default).
+	 */
+	pathPrefix?: string;
 	/** Kubernetes provider. */
 	provider: k8s.Provider;
 	/** Resources this HTTPRoute depends on. */
@@ -64,6 +72,13 @@ export function createServiceHttpRoute(
 				hostnames: args.hostnames,
 				rules: [
 					{
+						...(args.pathPrefix
+							? {
+									matches: [
+										{ path: { type: "PathPrefix", value: args.pathPrefix } },
+									],
+								}
+							: {}),
 						backendRefs: [
 							{
 								name: args.serviceName,

--- a/packages/sector7/gateway/index.ts
+++ b/packages/sector7/gateway/index.ts
@@ -53,6 +53,15 @@ export function createServiceHttpRoute(
 	args: ServiceHttpRouteArgs,
 ): k8s.apiextensions.CustomResource {
 	const gatewayName = args.gatewayName ?? "public-gateway";
+	// Validate the prefix up front so misconfiguration fails fast (at preview)
+	// with a clear message rather than producing an invalid manifest at apply.
+	// Note: check `!== undefined`, NOT truthiness — an empty string is invalid,
+	// not "match everything" (which would silently expose the whole service).
+	if (args.pathPrefix !== undefined && !args.pathPrefix.startsWith("/")) {
+		throw new Error(
+			`createServiceHttpRoute: pathPrefix must be an absolute path starting with "/" (got ${JSON.stringify(args.pathPrefix)})`,
+		);
+	}
 	return new k8s.apiextensions.CustomResource(
 		`${args.name}-route`,
 		{
@@ -72,7 +81,7 @@ export function createServiceHttpRoute(
 				hostnames: args.hostnames,
 				rules: [
 					{
-						...(args.pathPrefix
+						...(args.pathPrefix !== undefined
 							? {
 									matches: [
 										{ path: { type: "PathPrefix", value: args.pathPrefix } },

--- a/packages/sector7/tests/gateway.test.ts
+++ b/packages/sector7/tests/gateway.test.ts
@@ -39,6 +39,19 @@ describe("gateway module surface", () => {
 		expect(args.gatewayName).toBeUndefined();
 	});
 
+	it("ServiceHttpRouteArgs accepts an optional pathPrefix", () => {
+		const args: ServiceHttpRouteArgs = {
+			name: "test",
+			namespace: "test-ns",
+			hostnames: ["test.example.com"],
+			serviceName: "test-svc",
+			port: 80,
+			pathPrefix: "/webhook",
+			provider: {} as any,
+		};
+		expect(args.pathPrefix).toBe("/webhook");
+	});
+
 	it("has correct defaults in SharedGatewayReferenceGrantArgs type", () => {
 		const args: SharedGatewayReferenceGrantArgs = {
 			name: "allow-test",

--- a/packages/sector7/tests/gateway.test.ts
+++ b/packages/sector7/tests/gateway.test.ts
@@ -52,6 +52,34 @@ describe("gateway module surface", () => {
 		expect(args.pathPrefix).toBe("/webhook");
 	});
 
+	it("rejects a pathPrefix without a leading slash", () => {
+		expect(() =>
+			createServiceHttpRoute({
+				name: "t",
+				namespace: "ns",
+				hostnames: ["h.example.com"],
+				serviceName: "svc",
+				port: 80,
+				pathPrefix: "webhook",
+				provider: {} as any,
+			}),
+		).toThrow(/absolute path/);
+	});
+
+	it("rejects an empty pathPrefix (would otherwise match all paths)", () => {
+		expect(() =>
+			createServiceHttpRoute({
+				name: "t",
+				namespace: "ns",
+				hostnames: ["h.example.com"],
+				serviceName: "svc",
+				port: 80,
+				pathPrefix: "",
+				provider: {} as any,
+			}),
+		).toThrow();
+	});
+
 	it("has correct defaults in SharedGatewayReferenceGrantArgs type", () => {
 		const args: SharedGatewayReferenceGrantArgs = {
 			name: "allow-test",


### PR DESCRIPTION
### **User description**
## Summary

Adds an optional `pathPrefix` to `createServiceHttpRoute` (`ServiceHttpRouteArgs`). When set, the generated HTTPRoute matches only requests whose path starts with the prefix (Gateway API `PathPrefix`), instead of forwarding **all** paths for the hostname.

Motivation: webhook-style services should expose only their webhook endpoint publicly, not their entire route surface (health, `/docs`, future admin/debug handlers). Today the helper routes by hostname only, so consumers (pr-agent, project-bot) over-expose. This was flagged by pr-agent's own review on garden#781.

```ts
createServiceHttpRoute({
  name: "project-bot-public",
  hostnames: ["project-bot.roomofrequirement.xyz"],
  serviceName, port, gatewayName: "public-gateway",
  pathPrefix: "/webhook",   // <- new: only /webhook is public
  provider,
});
```

**Backward compatible:** omitting `pathPrefix` keeps the current match-all rule, so existing callers are unchanged.

## Validation
- `pnpm --filter @jmmaloney4/sector7 build` (tsc) clean
- `vitest run` — 183 tests pass (incl. a new pathPrefix surface test)
- `nix fmt` clean

## Follow-up
After release, garden consumers (project-bot, pr-agent) can drop their raw path-restricted HTTPRoutes and pass `pathPrefix: "/webhook"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Add optional `pathPrefix` route matching

- Restrict public exposure to path prefixes

- Validate absolute `pathPrefix` inputs early

- Cover new API surface and errors


___

### Diagram Walkthrough


```mermaid
flowchart LR
  args["ServiceHttpRouteArgs.pathPrefix added"]
  validate["Validate prefix starts with /"]
  route["Generate HTTPRoute matches.path rule"]
  tests["Add acceptance and rejection tests"]
  args -- "passed into" --> validate
  validate -- "enables" --> route
  validate -- "verified by" --> tests
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.ts</strong><dd><code>Add validated path-prefix HTTPRoute support</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/sector7/gateway/index.ts

<ul><li>Add optional <code>pathPrefix</code> to <code>ServiceHttpRouteArgs</code><br> <li> Document prefix-based public endpoint exposure<br> <li> Reject undefined-relative values without leading <code>/</code><br> <li> Add <code>PathPrefix</code> HTTPRoute match when provided</ul>


</details>


  </td>
  <td><a href="https://github.com/jmmaloney4/sector7/pull/255/files#diff-eb6b71518b9d3bcbadf7c2dd4c59f996b9256f4c7f4db2aa556eedaa2b9c5466">+24/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>gateway.test.ts</strong><dd><code>Cover `pathPrefix` typing and validation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/sector7/tests/gateway.test.ts

<ul><li>Add surface test for optional <code>pathPrefix</code><br> <li> Verify valid <code>"/webhook"</code> assignment<br> <li> Reject relative <code>pathPrefix</code> values<br> <li> Reject empty <code>pathPrefix</code> to avoid over-exposure</ul>


</details>


  </td>
  <td><a href="https://github.com/jmmaloney4/sector7/pull/255/files#diff-56598ea7e5643fb6de121d7a5e2eb840809edc15ef8fa9308032722f75d8392a">+41/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

