### PR TITLE
feat(onepassword): OnePasswordItem dynamic write resource (ADR 031)

### DIFF
--- a/docs/internal/designs/031-onepassword-item-write-resource.md
+++ b/docs/internal/designs/031-onepassword-item-write-resource.md
@@ -64,6 +64,7 @@ port-forward**.
 ## Type token & package surface
 
 - Type token: `sector7:onepassword:Item`.
+
 - Subpath export (not the root barrel — it pulls in `@kubernetes/client-node`):
 
   ```ts

--- a/docs/internal/designs/031-onepassword-item-write-resource.md
+++ b/docs/internal/designs/031-onepassword-item-write-resource.md
@@ -1,0 +1,258 @@
+---
+id: ADR-031
+title: OnePassword Item Write Resource
+status: Proposed
+date: 2026-06-10
+deciders: [jmmaloney4]
+consulted: []
+tags: [design, adr, pulumi, kubernetes, onepassword, secrets]
+supersedes: []
+superseded_by: []
+links:
+  - garden ADR 091 (docs/internal/decisions/091-pulumi-writes-litellm-keys-to-1password.md)
+  - sector7#258 (LiteLLM Team/ApiKey as dynamic resources)
+---
+
+# Context
+
+We need a way to **write** (create and update) a 1Password item from Pulumi —
+i.e. to publish a value Pulumi already holds into 1Password so that downstream
+read paths (the 1Password operator's `OnePasswordItem` CR → k8s Secret, or a
+`op read` on a workstation) can distribute it. The triggering consumer is
+**garden ADR 091**: the garden LiteLLM stack mints virtual keys (e.g.
+`personalHermesAgentApiKey`) and wants to store one in 1Password instead of
+leaving it in Pulumi state and hand-copied plaintext.
+
+The forces that shape this:
+
+- **1Password Connect is `ClusterIP`-only** in the target clusters
+  (garden's `deploy/platform/1password/`). We MUST NOT add tailnet/public ingress
+  to Connect (garden ADR 088 keeps these surfaces private). The Connect **server**
+  REST API is full CRUD; the **operator** only syncs items *out* to Secrets, so it
+  cannot create or update items.
+- **Pulumi runs out of cluster.** garden deploys from GitHub Actions runners that
+  reach the kube-apiserver over the tailnet via an mTLS kubeconfig pulled from
+  stack state. They can port-forward to a pod *through* that apiserver, but cannot
+  reach a `ClusterIP` Service directly.
+- **A bridged provider can't help here.** `@pulumiverse/onepassword` is an
+  out-of-process Terraform-bridged plugin that owns its own network connection and
+  exposes only `url`/`token`; it cannot reach `ClusterIP` Connect from outside the
+  cluster and offers no seam to insert a port-forward.
+- **We already have the transport.** sector7#258 reaches the LiteLLM admin API
+  from this exact out-of-cluster CI by opening a short-lived **in-process
+  Kubernetes port-forward** (`@kubernetes/client-node` `PortForward` +
+  `net.createServer`) and `fetch`-ing over `localhost`. And dynamic resources are
+  a **house pattern** here: `r2/r2object.ts`, `d1/d1-query.ts`, and (via #258)
+  `litellm/admin.ts`.
+
+**In scope:** a generic, reusable Pulumi dynamic resource in sector7 that
+creates/updates a 1Password item via the Connect REST API over an in-process
+port-forward, plus extracting the shared port-forward transport helper, plus
+tests.
+
+**Out of scope:** the garden consumer wiring (owned by garden ADR 091); the read
+path (the operator and `OnePasswordItem` CRs already exist); provisioning of the
+Connect write token and the target vault (operator/IaC concern); a 1Password
+*cloud-API* variant (see Alternatives).
+
+# Decision
+
+Create a Sector7 Pulumi **dynamic resource** `OnePasswordItem` that manages a
+1Password item through 1Password Connect, reached over an **in-process Kubernetes
+port-forward**.
+
+## Type token & package surface
+
+- Type token: `sector7:onepassword:Item`.
+- Subpath export (not the root barrel — it pulls in `@kubernetes/client-node`):
+
+  ```ts
+  import { OnePasswordItem } from "@jmmaloney4/sector7/onepassword";
+  ```
+
+  Package wiring mirrors `./litellm` (ADR 026): an `exports["./onepassword"]`
+  entry pointing at `./dist/onepassword/index.d.ts` / `index.js`.
+
+> **Naming.** This is the 1Password *noun* "item" and lives in Pulumi's type
+> namespace. It is **distinct from** the operator's read-only
+> `onepassword.com/v1 OnePasswordItem` **CRD**, which lives in the Kubernetes API
+> namespace. They sit on opposite ends of the same item (this writes it; the CR
+> reads it into a Secret). The design accepts the shared noun deliberately;
+> code/docs MUST disambiguate "Pulumi resource" vs "operator CR" wherever both
+> appear.
+
+## Provider lifecycle
+
+The resource MUST be a `pulumi.dynamic.ResourceProvider` with a full
+`check`/`diff`/`create`/`update`/`delete` lifecycle (the #258 / `r2object.ts`
+shape):
+
+- `create()` MUST be **find-or-create**: if an item with the target title already
+  exists in the vault, **adopt** it and reconcile its fields in place
+  (`PUT /v1/vaults/{vault}/items/{id}`); otherwise `POST /v1/vaults/{vault}/items`.
+  This is what makes a safe cutover from a hand-created or previously-unmanaged
+  item possible (the same property #258 relies on).
+- `diff()` MUST route a changed field value to an **in-place update**, and MUST
+  reserve replacement for an identity change (vault, or the stable title/key the
+  item is matched on). It MUST NOT delete-and-recreate on a value change —
+  consumers reference the item by path, and a new UUID would break them.
+- `delete()` deletes the item. Callers that want the item to outlive the stack
+  SHOULD use `pulumi.RetainOnDelete` or model it as adopt-only (a `protect` knob
+  MAY be added later; not required for v1).
+- All `@kubernetes/client-node` / `node:net` / 1Password-client imports MUST be
+  lazy `await import()` **inside** the callbacks, so the provider closure
+  serializes (the rule `r2object.ts` and `litellm/admin.ts` document).
+
+## Transport: extract and generalize the port-forward helper
+
+The in-process port-forward in `litellm/admin.ts` SHOULD be **factored out** into a
+shared sector7 util (e.g. `@jmmaloney4/sector7/k8s` `portForward()` or an internal
+module both call sites import), so the LiteLLM admin providers and this resource
+share one implementation. The extraction MUST generalize two things the current
+helper hardcodes:
+
+1. **Kubeconfig source.** #258 does `kc.loadFromDefault()`. The shared helper MUST
+   accept an explicit kubeconfig (string or `KubeConfig`) so callers whose creds
+   come from Pulumi stack state (garden's `getK8sProvider()` kubeconfig) can pass
+   it in. `loadFromDefault()` becomes the fallback when none is supplied.
+2. **Target.** The helper MUST accept the target Service/pod selector, namespace,
+   and port (admin.ts targets the LiteLLM proxy Deployment; this resource targets
+   the Connect Service, default `onepassword-connect.1password.svc.cluster.local`
+   on port `8080` — confirm against the deployed `connect` Helm release).
+
+The **Connect REST client** (auth header `Authorization: Bearer <connectToken>`,
+the `/v1/vaults/{vault}/items` create/update/get/delete calls, and item-field
+JSON shaping) is the only genuinely new code; `adminRequest()` in #258 is
+LiteLLM-specific and is NOT shared.
+
+## Inputs / outputs (interface sketch)
+
+Inputs (exact names settled in implementation):
+
+- `kubeconfig` (secret) — for the port-forward.
+- `connectToken` (secret) — Connect access token with **write** scope on the
+  target vault.
+- `connectService` — `{ namespace, name, port }` (or a resolved `url`) for the
+  Connect Service to forward to.
+- `vault` — vault id.
+- `title` — stable match key for adoption.
+- `category` — e.g. `password` / `api_credential`.
+- `fields` — map of field label → `{ value (secret), type }`; optional `sections`.
+
+Outputs:
+
+- `uuid` — the created/adopted item id.
+- `itemPath` — `vaults/{vault}/items/{uuid}` (the form the operator's
+  `OnePasswordItem` CR `spec.itemPath` and `op read` consume).
+
+Field values MUST be treated as Pulumi **secrets** on both input and output.
+
+## Tests
+
+Mirror `tests/litellm-admin.test.ts`: mock Pulumi + the transport + `fetch`, and
+assert `diff` (in-place vs replace), `create` (adopt-vs-new), `update`, and
+`delete`. The transport extraction SHOULD keep `litellm/admin.ts`'s existing tests
+green (a refactor, not a behavior change).
+
+# Consequences
+
+## Positive
+
+- A **reusable** "Pulumi writes a 1Password item" primitive for any stack/repo,
+  not a garden one-off. First consumer: garden ADR 091.
+- **No new network exposure** — Connect stays `ClusterIP`-only; the write tunnels
+  through the apiserver the runner already authenticates to.
+- **DRY transport** — one in-process port-forward implementation shared with the
+  LiteLLM admin providers, and the same closure-serialization discipline.
+- No new third-party provider/plugin; stays inside the established
+  `pulumi.dynamic` house pattern with mock-based tests.
+- Typed inputs/outputs and explicit `diff()` control over in-place vs replace.
+
+## Negative
+
+- Net-new code (a dynamic provider + Connect REST client) and a transport
+  refactor of `litellm/admin.ts` — more than instantiating a bridged
+  `onepassword.Item`.
+- Carries the closure-serialization constraint and needs kubeconfig + Connect
+  token plumbed in by every consumer.
+- Shared noun with the operator's `OnePasswordItem` CRD invites confusion if not
+  disambiguated.
+- The write path's reachability depends on the apiserver and a ready Connect pod
+  at deploy time.
+
+# Alternatives
+
+- **Bridged `@pulumiverse/onepassword` + `ClusterIP` Connect** — can't reach
+  `ClusterIP` from out-of-cluster Pulumi; no port-forward seam. Rejected.
+- **Bridged provider + tailnet-expose Connect** — adds the Connect ingress we
+  explicitly avoid. Rejected.
+- **Bridged provider + 1Password service-account token → cloud API** — bypasses
+  Connect and k8s entirely; lowest-effort and not a worse data boundary (the
+  secret lives in 1Password's cloud regardless). Rejected as the default to avoid
+  a *second* 1Password auth mechanism alongside Connect — but this is a natural
+  **future variant** of this same resource (swap the transport: cloud API instead
+  of port-forward+Connect) and is the documented escape hatch if the port-forward
+  proves fiddly in CI.
+- **A garden-local dynamic provider** (don't put it in sector7) — would copy
+  #258's transport rather than reuse it and wouldn't be available to other
+  stacks/repos. Rejected.
+- **Bake the write into `@jmmaloney4/sector7/litellm`** (the package that mints
+  the keys) instead of a generic resource — simplest for the one caller, but not
+  reusable for non-LiteLLM secrets. Rejected in favor of the generic resource;
+  the LiteLLM stack composes the two.
+
+# Security / Privacy / Compliance
+
+- **Connect write token** MUST be write-scoped to the target vault only (least
+  privilege), distinct from the operator's read token, and supplied as a Pulumi
+  secret. It is a long-lived credential — treat like the existing
+  `1password:connectToken`.
+- **Kubeconfig** grants apiserver access; it is the same credential stacks already
+  use for their k8s provider, passed as a secret. The port-forward rides that
+  authenticated, audited channel; Connect gains no new ingress.
+- **Item field values are secrets** end to end — mark secret on input and output
+  so they never land in plaintext state or logs.
+- Connect remains private (`ClusterIP`); this resource does not change its
+  exposure (consistent with garden ADR 088).
+
+# Operational Notes
+
+- Out-of-cluster runs require apiserver reachability and a **ready Connect pod** at
+  deploy time; surface a clear error if the port-forward can't bind or Connect is
+  unready.
+- The port-forward is **short-lived per operation** and torn down after — no
+  lingering tunnels.
+- Idempotent adoption avoids duplicate items on re-runs and on cutover from a
+  hand-created item.
+- Ordering for the first consumer (garden ADR 091): publish runs after the
+  key-minting resource reconciles; do not entangle with #258's state-delete
+  cutover (deleting a LiteLLM team cascades to its keys).
+
+# Status Transitions
+
+- New design; does not amend or supersede an existing ADR. Reuses the transport
+  pattern established in sector7#258.
+
+# Implementation Notes
+
+- Extract `portForward()` from `litellm/admin.ts` into a shared util; generalize
+  kubeconfig source and target Service/port; keep admin.ts tests green.
+- Add the `./onepassword` subpath export and package wiring (mirror ADR 026).
+- Implement the Connect REST client (`/v1/vaults/{vault}/items` CRUD) and the
+  `sector7:onepassword:Item` dynamic provider with find-or-create + in-place diff.
+- Add `tests/onepassword-item.test.ts` mirroring `litellm-admin.test.ts`.
+- Coordinate with sector7#258: the transport helper originates there, so either
+  land after #258 merges or carry the extraction in the same change set.
+- First consumer and acceptance: garden ADR 091 wiring (garden's litellm stack
+  publishes `personalHermesAgentApiKey`).
+
+# References
+
+- garden ADR 091 — `docs/internal/decisions/091-pulumi-writes-litellm-keys-to-1password.md`
+- sector7#258 — LiteLLM Team/ApiKey as dynamic resources (in-process port-forward
+  transport; `packages/sector7/litellm/admin.ts`)
+- `packages/sector7/r2/r2object.ts`, `packages/sector7/d1/d1-query.ts` — dynamic
+  provider + closure-serialization precedent
+- ADR 026 — LiteLLM Proxy ComponentResource (subpath-export / package-wiring
+  precedent)
+- 1Password Connect REST API — `POST/PUT/GET/DELETE /v1/vaults/{vaultId}/items`

--- a/packages/sector7/barrel-guard.ts
+++ b/packages/sector7/barrel-guard.ts
@@ -5,3 +5,6 @@ void root.litellm;
 
 // @ts-expect-error Cloud SQL helpers live on the ./cloudsql subpath, not the root barrel
 void root.cloudsql;
+
+// @ts-expect-error OnePassword write resource lives on the ./onepassword subpath, not the root barrel
+void root.onepassword;

--- a/packages/sector7/onepassword/index.ts
+++ b/packages/sector7/onepassword/index.ts
@@ -1,0 +1,6 @@
+export {
+	type DynamicResourceOptions,
+	OnePasswordItem,
+	type OnePasswordItemArgs,
+	type OnePasswordItemFieldArgs,
+} from "./item.ts";

--- a/packages/sector7/onepassword/item.ts
+++ b/packages/sector7/onepassword/item.ts
@@ -3,6 +3,7 @@ import {
 	dynamic,
 	type Input,
 	type Output,
+	secret,
 } from "@pulumi/pulumi";
 
 /**
@@ -297,12 +298,22 @@ async function findItemIdByTitle(
 		"GET",
 	);
 	if (!Array.isArray(items) || items.length === 0) return undefined;
-	// Connect's filter is server-side, but re-check title exactly to avoid
-	// adopting a near-match if a backend ever loosens the filter semantics.
+	// Re-check the title exactly (don't trust the server filter to be strict).
+	// Titles are NOT unique within a vault, so adopting an arbitrary match could
+	// overwrite or later delete an unrelated, manually-created secret in a shared
+	// vault. Refuse to adopt ambiguously: exactly one match adopts, zero creates,
+	// more than one is a hard error the operator must resolve. (Same authorization
+	// reasoning sector7#258 applies to LiteLLM team aliases.)
 	// biome-ignore lint/suspicious/noExplicitAny: item overview is loosely typed
-	const match = items.find((it: any) => it?.title === title);
+	const matches = items.filter((it: any) => it?.title === title);
+	if (matches.length > 1) {
+		throw new Error(
+			`1Password vault ${vault} contains ${matches.length} items titled "${title}"; ` +
+				"refusing to adopt ambiguously. Remove the duplicate(s) or give this item a unique title.",
+		);
+	}
 	// biome-ignore lint/suspicious/noExplicitAny: item overview is loosely typed
-	return (match as any)?.id;
+	return (matches[0] as any)?.id;
 }
 
 async function computeContentHash(
@@ -395,7 +406,7 @@ const onePasswordItemProvider: dynamic.ResourceProvider = {
 			});
 		} else {
 			news.fields.forEach((f, idx) => {
-				if (!f || !f.label)
+				if (!f?.label)
 					failures.push({
 						property: `fields[${idx}].label`,
 						reason: "field label is required",
@@ -411,9 +422,7 @@ const onePasswordItemProvider: dynamic.ResourceProvider = {
 		news: OnePasswordItemProviderInputs,
 	): Promise<dynamic.DiffResult> {
 		// Identity = vault + title (the adoption key). A change there is a
-		// different item, so it forces replacement; everything else is an
-		// in-place update. Transport inputs (kubeconfig, token, namespace,
-		// deployment, port) never force replacement — they don't change the item.
+		// different item, so it forces replacement.
 		const replaces: string[] = [];
 		if (olds.vault !== news.vault) replaces.push("vault");
 		if (olds.title !== news.title) replaces.push("title");
@@ -422,7 +431,23 @@ const onePasswordItemProvider: dynamic.ResourceProvider = {
 			news.category ?? DEFAULT_CATEGORY,
 			news.fields,
 		);
-		const changed = replaces.length > 0 || contentHash !== olds.contentHash;
+
+		// Transport inputs (token, kubeconfig, namespace, deployment, port) don't
+		// change the item, so they never force replacement — but they MUST still
+		// trigger an in-place update, otherwise a token rotation or cluster move is
+		// dropped and the stale value persists in state, breaking a later
+		// update()/delete(). Compare against the resolved values stored in state.
+		const transportChanged =
+			olds.connectToken !== news.connectToken ||
+			(olds.kubeconfig ?? undefined) !== (news.kubeconfig ?? undefined) ||
+			olds.namespace !== news.namespace ||
+			olds.deploymentName !== (news.deploymentName ?? DEFAULT_DEPLOYMENT) ||
+			olds.connectPort !== (news.connectPort ?? DEFAULT_PORT);
+
+		const changed =
+			replaces.length > 0 ||
+			contentHash !== olds.contentHash ||
+			transportChanged;
 
 		// Never delete-before-replace: a value/identity change must not drop the
 		// item out from under consumers that reference it by path mid-update.
@@ -542,9 +567,11 @@ const rejectCloudProviderOptions = (
  * (find-or-create by title); a field-value change is an in-place `PUT`; only a
  * vault/title change forces replacement.
  *
- * `connectToken` and `kubeconfig` are stored as secret outputs so they are
- * encrypted in Pulumi state. Field values are not echoed into state; drift is
- * tracked via a `contentHash`.
+ * Sensitive inputs (`connectToken`, `kubeconfig`, and every field `value`) are
+ * wrapped in `pulumi.secret()` so they are encrypted in state even if the caller
+ * forgets to — and the same names are marked `additionalSecretOutputs`. Field
+ * values are never echoed back into the output state; drift is tracked via a
+ * `contentHash`.
  */
 export class OnePasswordItem extends dynamic.Resource {
 	/** The created/adopted 1Password item id. */
@@ -568,10 +595,25 @@ export class OnePasswordItem extends dynamic.Resource {
 				...(opts?.additionalSecretOutputs ?? []),
 			],
 		};
+		// Force every sensitive input to a secret so values are encrypted in state
+		// even when the caller passes plain strings.
+		const securedArgs = {
+			...args,
+			connectToken: secret(args.connectToken),
+			...(args.kubeconfig !== undefined
+				? { kubeconfig: secret(args.kubeconfig) }
+				: {}),
+			fields: args.fields.map((f) => ({ ...f, value: secret(f.value) })),
+		};
 		super(
 			onePasswordItemProvider,
 			name,
-			{ uuid: undefined, itemPath: undefined, contentHash: undefined, ...args },
+			{
+				uuid: undefined,
+				itemPath: undefined,
+				contentHash: undefined,
+				...securedArgs,
+			},
 			mergedOpts,
 		);
 	}

--- a/packages/sector7/onepassword/item.ts
+++ b/packages/sector7/onepassword/item.ts
@@ -268,26 +268,79 @@ async function connectRequest(
 	}
 }
 
-/** Build the Connect item body for create/update. */
-function buildItemBody(
+// biome-ignore lint/suspicious/noExplicitAny: Connect field objects are loosely typed
+function managedField(f: ResolvedField): Record<string, any> {
+	return {
+		label: f.label,
+		type: f.type ?? DEFAULT_FIELD_TYPE,
+		value: f.value,
+		...(f.purpose ? { purpose: f.purpose } : {}),
+	};
+}
+
+/** Build the Connect item body for a fresh create (no pre-existing item). */
+function buildNewItemBody(
 	vault: string,
 	title: string,
 	category: string,
 	fields: ResolvedField[],
-	id?: string,
 ): Record<string, unknown> {
 	return {
-		...(id ? { id } : {}),
 		vault: { id: vault },
 		title,
 		category,
-		fields: fields.map((f) => ({
-			label: f.label,
-			type: f.type ?? DEFAULT_FIELD_TYPE,
-			value: f.value,
-			...(f.purpose ? { purpose: f.purpose } : {}),
-		})),
+		fields: fields.map(managedField),
 	};
+}
+
+/**
+ * Build the update body for an existing item by merging the managed fields into
+ * whatever the item already has. Managed fields are upserted by label; any
+ * unmanaged fields, sections, urls, tags, and other metadata on the existing
+ * item are preserved (a blind rebuild would silently drop them — important when
+ * adopting a pre-existing item).
+ */
+function buildMergedItemBody(
+	// biome-ignore lint/suspicious/noExplicitAny: existing item is loosely typed
+	existing: any,
+	vault: string,
+	title: string,
+	category: string,
+	fields: ResolvedField[],
+	id: string,
+): Record<string, unknown> {
+	// biome-ignore lint/suspicious/noExplicitAny: Connect field objects are loosely typed
+	const byLabel = new Map<string, any>();
+	for (const f of (existing?.fields ?? []) as Array<{ label?: string }>) {
+		if (f?.label) byLabel.set(f.label, f);
+	}
+	for (const f of fields) {
+		byLabel.set(f.label, { ...byLabel.get(f.label), ...managedField(f) });
+	}
+	return {
+		...existing,
+		id,
+		vault: { id: vault },
+		title,
+		category,
+		fields: [...byLabel.values()],
+	};
+}
+
+/** Fetch a full item (fields + sections + metadata) for a merge-preserving update. */
+async function getItem(
+	baseUrl: string,
+	token: string,
+	vault: string,
+	id: string,
+	// biome-ignore lint/suspicious/noExplicitAny: Connect item is loosely typed
+): Promise<any> {
+	return connectRequest(
+		baseUrl,
+		token,
+		`/v1/vaults/${vault}/items/${id}`,
+		"GET",
+	);
 }
 
 /** Find an existing item id in a vault by exact title, for idempotent adoption. */
@@ -478,12 +531,20 @@ const onePasswordItemProvider: dynamic.ResourceProvider = {
 				inputs.title,
 			);
 			if (existing) {
+				// Fetch the full item and merge so unmanaged fields/sections survive.
+				const current = await getItem(
+					baseUrl,
+					inputs.connectToken,
+					inputs.vault,
+					existing,
+				);
 				await connectRequest(
 					baseUrl,
 					inputs.connectToken,
 					`/v1/vaults/${inputs.vault}/items/${existing}`,
 					"PUT",
-					buildItemBody(
+					buildMergedItemBody(
+						current,
 						inputs.vault,
 						inputs.title,
 						category,
@@ -498,7 +559,7 @@ const onePasswordItemProvider: dynamic.ResourceProvider = {
 				inputs.connectToken,
 				`/v1/vaults/${inputs.vault}/items`,
 				"POST",
-				buildItemBody(inputs.vault, inputs.title, category, inputs.fields),
+				buildNewItemBody(inputs.vault, inputs.title, category, inputs.fields),
 			);
 			const id: string | undefined = created?.id;
 			if (!id) throw new Error("1Password Connect create returned no item id");
@@ -516,12 +577,21 @@ const onePasswordItemProvider: dynamic.ResourceProvider = {
 		const target = resolveTarget(news);
 		const category = news.category ?? DEFAULT_CATEGORY;
 		await withConnectBaseUrl(target, async (baseUrl) => {
+			// Merge into the live item so unmanaged fields/sections are preserved.
+			const current = await getItem(baseUrl, news.connectToken, news.vault, id);
 			await connectRequest(
 				baseUrl,
 				news.connectToken,
 				`/v1/vaults/${news.vault}/items/${id}`,
 				"PUT",
-				buildItemBody(news.vault, news.title, category, news.fields, id),
+				buildMergedItemBody(
+					current,
+					news.vault,
+					news.title,
+					category,
+					news.fields,
+					id,
+				),
 			);
 		});
 		const contentHash = await computeContentHash(category, news.fields);
@@ -607,6 +677,10 @@ export class OnePasswordItem extends dynamic.Resource {
 			additionalSecretOutputs: [
 				"connectToken",
 				"kubeconfig",
+				// contentHash is a sha256 of the secret field values; encrypt it so
+				// stack state can't be used as an offline oracle for low-entropy
+				// secrets or to detect secret reuse across items.
+				"contentHash",
 				...(opts?.additionalSecretOutputs ?? []),
 			],
 		};

--- a/packages/sector7/onepassword/item.ts
+++ b/packages/sector7/onepassword/item.ts
@@ -171,20 +171,23 @@ async function withConnectBaseUrl<T>(
 	});
 	// biome-ignore lint/suspicious/noExplicitAny: k8s client response is loosely typed across majors
 	const pods: any[] = ((podResp as any)?.body ?? podResp)?.items ?? [];
-	const ready =
-		pods.find(
-			// biome-ignore lint/suspicious/noExplicitAny: pod object is loosely typed
-			(p: any) =>
-				p?.status?.phase === "Running" &&
-				(p?.status?.conditions ?? []).some(
-					// biome-ignore lint/suspicious/noExplicitAny: condition object is loosely typed
-					(c: any) => c?.type === "Ready" && c?.status === "True",
-				),
-		) ?? pods[0];
+	// Require a genuinely Ready pod — do NOT fall back to an arbitrary pod.
+	// Forwarding to a terminating/unready Connect pod (during a rollout or
+	// crashloop) turns a clear readiness failure into opaque connection errors.
+	const ready = pods.find(
+		// biome-ignore lint/suspicious/noExplicitAny: pod object is loosely typed
+		(p: any) =>
+			p?.status?.phase === "Running" &&
+			(p?.status?.conditions ?? []).some(
+				// biome-ignore lint/suspicious/noExplicitAny: condition object is loosely typed
+				(c: any) => c?.type === "Ready" && c?.status === "True",
+			),
+	);
 	const podName: string | undefined = ready?.metadata?.name;
 	if (!podName) {
 		throw new Error(
-			`no running pod found for deployment ${target.namespace}/${target.deploymentName}`,
+			`no ready pod found for deployment ${target.namespace}/${target.deploymentName} ` +
+				"(1Password Connect not ready?)",
 		);
 	}
 
@@ -248,9 +251,14 @@ async function connectRequest(
 
 	const text = await response.text();
 	if (!response.ok) {
-		throw new Error(
-			`1Password Connect ${method} ${path} failed: ${response.status} ${response.statusText}\n${text}`,
+		// Deliberately omit the response body: Connect can echo item content /
+		// validation details on failure, which would leak secret field values
+		// into Pulumi logs. The status + method + path are enough to diagnose.
+		const err = new Error(
+			`1Password Connect ${method} ${path} failed: ${response.status} ${response.statusText}`,
 		);
+		(err as { status?: number }).status = response.status;
+		throw err;
 	}
 	if (!text) return {};
 	try {
@@ -523,12 +531,19 @@ const onePasswordItemProvider: dynamic.ResourceProvider = {
 	async delete(id: string, props: OnePasswordItemState): Promise<void> {
 		const target = resolveTarget(props);
 		await withConnectBaseUrl(target, async (baseUrl) => {
-			await connectRequest(
-				baseUrl,
-				props.connectToken,
-				`/v1/vaults/${props.vault}/items/${id}`,
-				"DELETE",
-			);
+			try {
+				await connectRequest(
+					baseUrl,
+					props.connectToken,
+					`/v1/vaults/${props.vault}/items/${id}`,
+					"DELETE",
+				);
+			} catch (error) {
+				// A 404 means the item is already gone (manually removed, or an
+				// adopted pre-existing item that was deleted externally). Treat that
+				// as a successful delete so `pulumi destroy` is idempotent.
+				if ((error as { status?: number })?.status !== 404) throw error;
+			}
 		});
 	},
 };

--- a/packages/sector7/onepassword/item.ts
+++ b/packages/sector7/onepassword/item.ts
@@ -1,0 +1,578 @@
+import {
+	type CustomResourceOptions,
+	dynamic,
+	type Input,
+	type Output,
+} from "@pulumi/pulumi";
+
+/**
+ * Resource options accepted by sector7 dynamic resources.
+ *
+ * Pulumi dynamic resources are executed by the Node.js dynamic provider runtime,
+ * not by a cloud provider plugin. Passing `provider` or `providers` makes Pulumi
+ * route the resource through the wrong provider bridge, which fails with a
+ * misleading `pulumi-nodejs:dynamic:Resource` unknown-token error.
+ */
+export type DynamicResourceOptions = Omit<
+	CustomResourceOptions,
+	"provider" | "providers"
+>;
+
+const DEFAULT_DEPLOYMENT = "onepassword-connect";
+const DEFAULT_PORT = 8080;
+const DEFAULT_CATEGORY = "PASSWORD";
+const DEFAULT_FIELD_TYPE = "CONCEALED";
+
+// ---------------------------------------------------------------------------
+// Public input types
+// ---------------------------------------------------------------------------
+
+/** A field to write into the 1Password item. Values are treated as secrets. */
+export interface OnePasswordItemFieldArgs {
+	/** Field label (e.g. `password`). Combined with the item title this is how
+	 * consumers address the value: `op://<vault>/<title>/<label>`. */
+	label: Input<string>;
+	/** Field value. Pass a `pulumi.secret(...)` for anything sensitive. */
+	value: Input<string>;
+	/** Connect field type. Defaults to `CONCEALED`. */
+	type?: Input<string>;
+	/** Optional field purpose (`PASSWORD` | `USERNAME` | `NOTES`). */
+	purpose?: Input<string>;
+}
+
+export interface OnePasswordItemArgs {
+	/**
+	 * Kubeconfig (YAML) used to open the port-forward to Connect. Falls back to
+	 * the ambient default config when omitted. Out-of-cluster callers (whose
+	 * credentials come from a Pulumi stack output) should pass it explicitly.
+	 */
+	kubeconfig?: Input<string>;
+	/** Connect access token with **write** scope on the target vault. */
+	connectToken: Input<string>;
+	/** Namespace the Connect server runs in (e.g. `1password`). */
+	namespace: Input<string>;
+	/** Connect Deployment to port-forward to. Defaults to `onepassword-connect`. */
+	deploymentName?: Input<string>;
+	/** Connect REST port. Defaults to `8080`. */
+	connectPort?: Input<number>;
+	/** Target vault id. */
+	vault: Input<string>;
+	/** Item title; also the stable key used to adopt a pre-existing item. */
+	title: Input<string>;
+	/** 1Password category. Defaults to `PASSWORD`. */
+	category?: Input<string>;
+	/** Fields to write. At least one is required. */
+	fields: OnePasswordItemFieldArgs[];
+}
+
+// ---------------------------------------------------------------------------
+// Resolved provider shapes (what the dynamic runtime hands the callbacks)
+// ---------------------------------------------------------------------------
+
+interface ResolvedField {
+	label: string;
+	value: string;
+	type?: string;
+	purpose?: string;
+}
+
+interface OnePasswordItemProviderInputs {
+	kubeconfig?: string;
+	connectToken: string;
+	namespace: string;
+	deploymentName?: string;
+	connectPort?: number;
+	vault: string;
+	title: string;
+	category?: string;
+	fields: ResolvedField[];
+}
+
+interface OnePasswordItemState {
+	kubeconfig?: string;
+	connectToken: string;
+	namespace: string;
+	deploymentName: string;
+	connectPort: number;
+	vault: string;
+	title: string;
+	category: string;
+	uuid: string;
+	itemPath: string;
+	contentHash: string;
+}
+
+// ---------------------------------------------------------------------------
+// Transport: in-process Kubernetes port-forward to the Connect server
+//
+// Every Node/k8s import is a lazy `await import()` *inside* these functions so
+// the provider closure that references them serializes — the same rule
+// `r2/r2object.ts` and the litellm admin providers document. The transport and
+// REST client are kept in this module (mirroring `litellm/admin.ts`) so the
+// serialized closure stays self-contained; factoring the port-forward into a
+// shared sector7 util (deduping with `litellm/admin.ts`) is follow-up once both
+// land (see ADR 031 / sector7#258).
+// ---------------------------------------------------------------------------
+
+interface ConnectTarget {
+	kubeconfig?: string;
+	namespace: string;
+	deploymentName: string;
+	port: number;
+}
+
+/**
+ * Open a short-lived in-process port-forward to a ready Connect pod, invoke
+ * `fn` with a `http://127.0.0.1:<port>` base URL, then tear the forward down.
+ * Reaches Connect wherever kube credentials work (through the apiserver), so
+ * Connect needs no tailnet/public ingress.
+ */
+async function withConnectBaseUrl<T>(
+	target: ConnectTarget,
+	fn: (baseUrl: string) => Promise<T>,
+): Promise<T> {
+	const k8s = await import("@kubernetes/client-node");
+	const net = await import("node:net");
+
+	const kc = new k8s.KubeConfig();
+	if (target.kubeconfig) {
+		kc.loadFromString(target.kubeconfig);
+	} else {
+		kc.loadFromDefault();
+	}
+
+	const apps = kc.makeApiClient(k8s.AppsV1Api);
+	const core = kc.makeApiClient(k8s.CoreV1Api);
+
+	// Resolve the deployment's pod selector at runtime (no hardcoded labels),
+	// then pick a ready pod.
+	const depResp = await apps.readNamespacedDeployment({
+		name: target.deploymentName,
+		namespace: target.namespace,
+	});
+	// client-node 1.x returns the body directly; tolerate the 0.x {body} shape.
+	// biome-ignore lint/suspicious/noExplicitAny: k8s client response is loosely typed across majors
+	const dep: any = (depResp as any)?.body ?? depResp;
+	const matchLabels: Record<string, string> =
+		dep?.spec?.selector?.matchLabels ?? {};
+	const labelSelector = Object.entries(matchLabels)
+		.map(([k, v]) => `${k}=${v}`)
+		.join(",");
+	if (!labelSelector) {
+		throw new Error(
+			`deployment ${target.namespace}/${target.deploymentName} has no spec.selector.matchLabels`,
+		);
+	}
+
+	const podResp = await core.listNamespacedPod({
+		namespace: target.namespace,
+		labelSelector,
+	});
+	// biome-ignore lint/suspicious/noExplicitAny: k8s client response is loosely typed across majors
+	const pods: any[] = ((podResp as any)?.body ?? podResp)?.items ?? [];
+	const ready =
+		pods.find(
+			// biome-ignore lint/suspicious/noExplicitAny: pod object is loosely typed
+			(p: any) =>
+				p?.status?.phase === "Running" &&
+				(p?.status?.conditions ?? []).some(
+					// biome-ignore lint/suspicious/noExplicitAny: condition object is loosely typed
+					(c: any) => c?.type === "Ready" && c?.status === "True",
+				),
+		) ?? pods[0];
+	const podName: string | undefined = ready?.metadata?.name;
+	if (!podName) {
+		throw new Error(
+			`no running pod found for deployment ${target.namespace}/${target.deploymentName}`,
+		);
+	}
+
+	const forward = new k8s.PortForward(kc);
+	const server = net.createServer((socket) => {
+		forward
+			.portForward(
+				target.namespace,
+				podName,
+				[target.port],
+				socket,
+				null,
+				socket,
+			)
+			.catch((err: unknown) =>
+				socket.destroy(err instanceof Error ? err : new Error(String(err))),
+			);
+	});
+
+	await new Promise<void>((resolve, reject) => {
+		server.once("error", reject);
+		server.listen(0, "127.0.0.1", () => resolve());
+	});
+
+	const address = server.address();
+	const localPort =
+		address && typeof address === "object" ? address.port : undefined;
+	if (!localPort) {
+		await new Promise<void>((resolve) => server.close(() => resolve()));
+		throw new Error("failed to bind a local port for the Connect port-forward");
+	}
+
+	try {
+		return await fn(`http://127.0.0.1:${localPort}`);
+	} finally {
+		await new Promise<void>((resolve) => server.close(() => resolve()));
+	}
+}
+
+// ---------------------------------------------------------------------------
+// 1Password Connect REST client
+// ---------------------------------------------------------------------------
+
+/** Issue an authenticated request against the Connect REST API. */
+async function connectRequest(
+	baseUrl: string,
+	token: string,
+	path: string,
+	method: "GET" | "POST" | "PUT" | "DELETE",
+	body?: unknown,
+	// biome-ignore lint/suspicious/noExplicitAny: Connect responses are dynamic JSON
+): Promise<any> {
+	const response = await fetch(`${baseUrl}${path}`, {
+		method,
+		headers: {
+			Authorization: `Bearer ${token}`,
+			...(body !== undefined ? { "Content-Type": "application/json" } : {}),
+		},
+		body: body !== undefined ? JSON.stringify(body) : undefined,
+	});
+
+	const text = await response.text();
+	if (!response.ok) {
+		throw new Error(
+			`1Password Connect ${method} ${path} failed: ${response.status} ${response.statusText}\n${text}`,
+		);
+	}
+	if (!text) return {};
+	try {
+		return JSON.parse(text);
+	} catch {
+		return text;
+	}
+}
+
+/** Build the Connect item body for create/update. */
+function buildItemBody(
+	vault: string,
+	title: string,
+	category: string,
+	fields: ResolvedField[],
+	id?: string,
+): Record<string, unknown> {
+	return {
+		...(id ? { id } : {}),
+		vault: { id: vault },
+		title,
+		category,
+		fields: fields.map((f) => ({
+			label: f.label,
+			type: f.type ?? DEFAULT_FIELD_TYPE,
+			value: f.value,
+			...(f.purpose ? { purpose: f.purpose } : {}),
+		})),
+	};
+}
+
+/** Find an existing item id in a vault by exact title, for idempotent adoption. */
+async function findItemIdByTitle(
+	baseUrl: string,
+	token: string,
+	vault: string,
+	title: string,
+): Promise<string | undefined> {
+	const escaped = title.replace(/"/g, '\\"');
+	const filter = encodeURIComponent(`title eq "${escaped}"`);
+	const items = await connectRequest(
+		baseUrl,
+		token,
+		`/v1/vaults/${vault}/items?filter=${filter}`,
+		"GET",
+	);
+	if (!Array.isArray(items) || items.length === 0) return undefined;
+	// Connect's filter is server-side, but re-check title exactly to avoid
+	// adopting a near-match if a backend ever loosens the filter semantics.
+	// biome-ignore lint/suspicious/noExplicitAny: item overview is loosely typed
+	const match = items.find((it: any) => it?.title === title);
+	// biome-ignore lint/suspicious/noExplicitAny: item overview is loosely typed
+	return (match as any)?.id;
+}
+
+async function computeContentHash(
+	category: string,
+	fields: ResolvedField[],
+): Promise<string> {
+	const nodeCrypto = (await import(
+		"node:crypto"
+	)) as typeof import("node:crypto");
+	const canonical = JSON.stringify({
+		category,
+		fields: [...fields]
+			.map((f) => ({
+				label: f.label,
+				value: f.value,
+				type: f.type ?? DEFAULT_FIELD_TYPE,
+				purpose: f.purpose ?? null,
+			}))
+			.sort((a, b) => a.label.localeCompare(b.label)),
+	});
+	return nodeCrypto.createHash("sha256").update(canonical).digest("hex");
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function resolveTarget(i: {
+	kubeconfig?: string;
+	namespace: string;
+	deploymentName?: string;
+	connectPort?: number;
+}): ConnectTarget {
+	return {
+		kubeconfig: i.kubeconfig,
+		namespace: i.namespace,
+		deploymentName: i.deploymentName ?? DEFAULT_DEPLOYMENT,
+		port: i.connectPort ?? DEFAULT_PORT,
+	};
+}
+
+function stateOuts(
+	i: OnePasswordItemProviderInputs,
+	uuid: string,
+	contentHash: string,
+): OnePasswordItemState {
+	return {
+		kubeconfig: i.kubeconfig,
+		connectToken: i.connectToken,
+		namespace: i.namespace,
+		deploymentName: i.deploymentName ?? DEFAULT_DEPLOYMENT,
+		connectPort: i.connectPort ?? DEFAULT_PORT,
+		vault: i.vault,
+		title: i.title,
+		category: i.category ?? DEFAULT_CATEGORY,
+		uuid,
+		itemPath: `vaults/${i.vault}/items/${uuid}`,
+		contentHash,
+	};
+}
+
+// ---------------------------------------------------------------------------
+// Provider
+// ---------------------------------------------------------------------------
+
+const onePasswordItemProvider: dynamic.ResourceProvider = {
+	async check(
+		_olds: OnePasswordItemState,
+		news: OnePasswordItemProviderInputs,
+	): Promise<dynamic.CheckResult> {
+		const failures: dynamic.CheckFailure[] = [];
+		if (!news.connectToken)
+			failures.push({
+				property: "connectToken",
+				reason: "connectToken is required",
+			});
+		if (!news.namespace)
+			failures.push({ property: "namespace", reason: "namespace is required" });
+		if (!news.vault)
+			failures.push({ property: "vault", reason: "vault is required" });
+		if (!news.title || news.title.trim().length === 0)
+			failures.push({
+				property: "title",
+				reason: "title must be a non-empty string",
+			});
+		if (!Array.isArray(news.fields) || news.fields.length === 0) {
+			failures.push({
+				property: "fields",
+				reason: "at least one field is required",
+			});
+		} else {
+			news.fields.forEach((f, idx) => {
+				if (!f || !f.label)
+					failures.push({
+						property: `fields[${idx}].label`,
+						reason: "field label is required",
+					});
+			});
+		}
+		return { inputs: news, failures };
+	},
+
+	async diff(
+		_id: string,
+		olds: OnePasswordItemState,
+		news: OnePasswordItemProviderInputs,
+	): Promise<dynamic.DiffResult> {
+		// Identity = vault + title (the adoption key). A change there is a
+		// different item, so it forces replacement; everything else is an
+		// in-place update. Transport inputs (kubeconfig, token, namespace,
+		// deployment, port) never force replacement — they don't change the item.
+		const replaces: string[] = [];
+		if (olds.vault !== news.vault) replaces.push("vault");
+		if (olds.title !== news.title) replaces.push("title");
+
+		const contentHash = await computeContentHash(
+			news.category ?? DEFAULT_CATEGORY,
+			news.fields,
+		);
+		const changed = replaces.length > 0 || contentHash !== olds.contentHash;
+
+		// Never delete-before-replace: a value/identity change must not drop the
+		// item out from under consumers that reference it by path mid-update.
+		return { changes: changed, replaces, deleteBeforeReplace: false };
+	},
+
+	async create(
+		inputs: OnePasswordItemProviderInputs,
+	): Promise<dynamic.CreateResult> {
+		const target = resolveTarget(inputs);
+		const category = inputs.category ?? DEFAULT_CATEGORY;
+		const uuid = await withConnectBaseUrl(target, async (baseUrl) => {
+			// Find-or-create: adopt a pre-existing item by title and reconcile its
+			// fields in place, else create a fresh one. Adoption is what makes a
+			// safe cutover from a hand-created/unmanaged item possible.
+			const existing = await findItemIdByTitle(
+				baseUrl,
+				inputs.connectToken,
+				inputs.vault,
+				inputs.title,
+			);
+			if (existing) {
+				await connectRequest(
+					baseUrl,
+					inputs.connectToken,
+					`/v1/vaults/${inputs.vault}/items/${existing}`,
+					"PUT",
+					buildItemBody(
+						inputs.vault,
+						inputs.title,
+						category,
+						inputs.fields,
+						existing,
+					),
+				);
+				return existing;
+			}
+			const created = await connectRequest(
+				baseUrl,
+				inputs.connectToken,
+				`/v1/vaults/${inputs.vault}/items`,
+				"POST",
+				buildItemBody(inputs.vault, inputs.title, category, inputs.fields),
+			);
+			const id: string | undefined = created?.id;
+			if (!id) throw new Error("1Password Connect create returned no item id");
+			return id;
+		});
+		const contentHash = await computeContentHash(category, inputs.fields);
+		return { id: uuid, outs: stateOuts(inputs, uuid, contentHash) };
+	},
+
+	async update(
+		id: string,
+		_olds: OnePasswordItemState,
+		news: OnePasswordItemProviderInputs,
+	): Promise<dynamic.UpdateResult> {
+		const target = resolveTarget(news);
+		const category = news.category ?? DEFAULT_CATEGORY;
+		await withConnectBaseUrl(target, async (baseUrl) => {
+			await connectRequest(
+				baseUrl,
+				news.connectToken,
+				`/v1/vaults/${news.vault}/items/${id}`,
+				"PUT",
+				buildItemBody(news.vault, news.title, category, news.fields, id),
+			);
+		});
+		const contentHash = await computeContentHash(category, news.fields);
+		return { outs: stateOuts(news, id, contentHash) };
+	},
+
+	async delete(id: string, props: OnePasswordItemState): Promise<void> {
+		const target = resolveTarget(props);
+		await withConnectBaseUrl(target, async (baseUrl) => {
+			await connectRequest(
+				baseUrl,
+				props.connectToken,
+				`/v1/vaults/${props.vault}/items/${id}`,
+				"DELETE",
+			);
+		});
+	},
+};
+
+// ---------------------------------------------------------------------------
+// Guard
+// ---------------------------------------------------------------------------
+
+const rejectCloudProviderOptions = (
+	resourceName: string,
+	opts?: CustomResourceOptions,
+): void => {
+	if (!opts) return;
+
+	const hasProvider =
+		Object.hasOwn(opts, "provider") && opts.provider !== undefined;
+	const hasProviders =
+		Object.hasOwn(opts, "providers") &&
+		(opts as Record<string, unknown>).providers !== undefined;
+	if (!hasProvider && !hasProviders) return;
+
+	throw new Error(
+		`${resourceName} is a Pulumi dynamic resource; do not pass provider/providers. ` +
+			"Pass provider options only to cloud provider resources, and use parent/dependsOn for dynamic resource ordering.",
+	);
+};
+
+// ---------------------------------------------------------------------------
+// Public resource
+// ---------------------------------------------------------------------------
+
+/**
+ * A 1Password item managed as a first-class Pulumi resource, written through
+ * the in-cluster 1Password Connect server over an in-process Kubernetes
+ * port-forward (Connect stays `ClusterIP`-only). Create is idempotent
+ * (find-or-create by title); a field-value change is an in-place `PUT`; only a
+ * vault/title change forces replacement.
+ *
+ * `connectToken` and `kubeconfig` are stored as secret outputs so they are
+ * encrypted in Pulumi state. Field values are not echoed into state; drift is
+ * tracked via a `contentHash`.
+ */
+export class OnePasswordItem extends dynamic.Resource {
+	/** The created/adopted 1Password item id. */
+	public readonly uuid!: Output<string>;
+	/** `vaults/<vault>/items/<uuid>` — the form `OnePasswordItem` CRs / `op read` consume. */
+	public readonly itemPath!: Output<string>;
+	/** Hash of the written content; used to detect drift without storing values. */
+	public readonly contentHash!: Output<string>;
+
+	constructor(
+		name: string,
+		args: OnePasswordItemArgs,
+		opts?: DynamicResourceOptions,
+	) {
+		rejectCloudProviderOptions("OnePasswordItem", opts);
+		const mergedOpts: DynamicResourceOptions = {
+			...opts,
+			additionalSecretOutputs: [
+				"connectToken",
+				"kubeconfig",
+				...(opts?.additionalSecretOutputs ?? []),
+			],
+		};
+		super(
+			onePasswordItemProvider,
+			name,
+			{ uuid: undefined, itemPath: undefined, contentHash: undefined, ...args },
+			mergedOpts,
+		);
+	}
+}

--- a/packages/sector7/onepassword/item.ts
+++ b/packages/sector7/onepassword/item.ts
@@ -101,6 +101,9 @@ interface OnePasswordItemState {
 	uuid: string;
 	itemPath: string;
 	contentHash: string;
+	/** Labels this resource manages, so a later update can remove ones that were
+	 * dropped from input without touching unmanaged fields. */
+	managedLabels: string[];
 }
 
 // ---------------------------------------------------------------------------
@@ -308,12 +311,21 @@ function buildMergedItemBody(
 	category: string,
 	fields: ResolvedField[],
 	id: string,
+	priorManagedLabels: string[],
 ): Record<string, unknown> {
 	// biome-ignore lint/suspicious/noExplicitAny: Connect field objects are loosely typed
 	const byLabel = new Map<string, any>();
 	for (const f of (existing?.fields ?? []) as Array<{ label?: string }>) {
 		if (f?.label) byLabel.set(f.label, f);
 	}
+	// Remove fields we previously managed but that are no longer declared, so the
+	// item reconciles to the declared state. Fields we never managed (and prior
+	// managed fields that are still declared) are left untouched here.
+	const declared = new Set(fields.map((f) => f.label));
+	for (const label of priorManagedLabels) {
+		if (!declared.has(label)) byLabel.delete(label);
+	}
+	// Upsert the declared managed fields.
 	for (const f of fields) {
 		byLabel.set(f.label, { ...byLabel.get(f.label), ...managedField(f) });
 	}
@@ -433,6 +445,7 @@ function stateOuts(
 		uuid,
 		itemPath: `vaults/${i.vault}/items/${uuid}`,
 		contentHash,
+		managedLabels: i.fields.map((f) => f.label),
 	};
 }
 
@@ -466,12 +479,22 @@ const onePasswordItemProvider: dynamic.ResourceProvider = {
 				reason: "at least one field is required",
 			});
 		} else {
+			const seen = new Set<string>();
 			news.fields.forEach((f, idx) => {
 				if (!f?.label)
 					failures.push({
 						property: `fields[${idx}].label`,
 						reason: "field label is required",
 					});
+				else if (seen.has(f.label))
+					// Fields are keyed by label when written to / merged into the item,
+					// so duplicate labels would silently collapse (last write wins) and
+					// corrupt drift detection. Reject them up front.
+					failures.push({
+						property: `fields[${idx}].label`,
+						reason: `duplicate field label: ${f.label}`,
+					});
+				else seen.add(f.label);
 			});
 		}
 		return { inputs: news, failures };
@@ -550,6 +573,9 @@ const onePasswordItemProvider: dynamic.ResourceProvider = {
 						category,
 						inputs.fields,
 						existing,
+						// First reconcile of an adopted item: we have no record of what
+						// we managed before, so remove nothing — only upsert.
+						[],
 					),
 				);
 				return existing;
@@ -571,13 +597,14 @@ const onePasswordItemProvider: dynamic.ResourceProvider = {
 
 	async update(
 		id: string,
-		_olds: OnePasswordItemState,
+		olds: OnePasswordItemState,
 		news: OnePasswordItemProviderInputs,
 	): Promise<dynamic.UpdateResult> {
 		const target = resolveTarget(news);
 		const category = news.category ?? DEFAULT_CATEGORY;
 		await withConnectBaseUrl(target, async (baseUrl) => {
-			// Merge into the live item so unmanaged fields/sections are preserved.
+			// Merge into the live item so unmanaged fields/sections are preserved,
+			// while removing fields we previously managed but that were dropped.
 			const current = await getItem(baseUrl, news.connectToken, news.vault, id);
 			await connectRequest(
 				baseUrl,
@@ -591,6 +618,7 @@ const onePasswordItemProvider: dynamic.ResourceProvider = {
 					category,
 					news.fields,
 					id,
+					olds.managedLabels ?? [],
 				),
 			);
 		});

--- a/packages/sector7/package.json
+++ b/packages/sector7/package.json
@@ -59,6 +59,10 @@
 			"types": "./dist/litellm/index.d.ts",
 			"default": "./dist/litellm/index.js"
 		},
+		"./onepassword": {
+			"types": "./dist/onepassword/index.d.ts",
+			"default": "./dist/onepassword/index.js"
+		},
 		"./pulumi-config": {
 			"types": "./dist/pulumi-config/index.d.ts",
 			"default": "./dist/pulumi-config/index.js"

--- a/packages/sector7/tests/onepassword-item.test.ts
+++ b/packages/sector7/tests/onepassword-item.test.ts
@@ -1,0 +1,305 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Mocks
+//
+// OnePasswordItem is a dynamic.Resource. We mock @pulumi/pulumi to capture the
+// ResourceProvider passed to super() (the same capture pattern as the r2 / d1 /
+// litellm-admin provider tests), then exercise the provider directly.
+//
+// withConnectBaseUrl() loads kube credentials and opens a port-forward; we stub
+// @kubernetes/client-node and node:net so it yields a local base URL without a
+// real cluster, and stub global fetch to capture the Connect REST calls.
+// node:crypto is NOT mocked — the content hash is computed for real.
+// ---------------------------------------------------------------------------
+
+type Provider = {
+	check: (
+		olds: Record<string, unknown>,
+		news: Record<string, unknown>,
+	) => Promise<{
+		inputs: Record<string, unknown>;
+		failures: Array<{ property: string; reason: string }>;
+	}>;
+	diff: (
+		id: string,
+		olds: Record<string, unknown>,
+		news: Record<string, unknown>,
+	) => Promise<{
+		changes: boolean;
+		replaces?: string[];
+		deleteBeforeReplace?: boolean;
+	}>;
+	create: (
+		inputs: Record<string, unknown>,
+	) => Promise<{ id: string; outs: Record<string, unknown> }>;
+	update: (
+		id: string,
+		olds: Record<string, unknown>,
+		news: Record<string, unknown>,
+	) => Promise<{ outs: Record<string, unknown> }>;
+	delete: (id: string, props: Record<string, unknown>) => Promise<void>;
+};
+
+const capturedProviders: Provider[] = [];
+
+vi.mock("@pulumi/pulumi", () => ({
+	dynamic: {
+		Resource: class {
+			constructor(provider: Provider) {
+				capturedProviders.push(provider);
+			}
+		},
+	},
+}));
+
+const apiStubs = {
+	readNamespacedDeployment: vi.fn().mockResolvedValue({
+		spec: { selector: { matchLabels: { app: "onepassword-connect" } } },
+	}),
+	listNamespacedPod: vi.fn().mockResolvedValue({
+		items: [
+			{
+				metadata: { name: "connect-pod-1" },
+				status: {
+					phase: "Running",
+					conditions: [{ type: "Ready", status: "True" }],
+				},
+			},
+		],
+	}),
+};
+
+vi.mock("@kubernetes/client-node", () => ({
+	KubeConfig: class {
+		loadFromDefault() {}
+		loadFromString(_s: string) {}
+		makeApiClient() {
+			return apiStubs;
+		}
+	},
+	AppsV1Api: class AppsV1Api {},
+	CoreV1Api: class CoreV1Api {},
+	PortForward: class {
+		portForward() {
+			return Promise.resolve();
+		}
+	},
+}));
+
+vi.mock("node:net", () => ({
+	createServer: () => {
+		const server = {
+			once: (_event: string, _cb: unknown) => server,
+			listen: (_port: number, _host: string, cb: () => void) => {
+				cb();
+				return server;
+			},
+			address: () => ({ port: 41000 }),
+			close: (cb?: () => void) => {
+				cb?.();
+				return server;
+			},
+		};
+		return server;
+	},
+}));
+
+// Trigger provider capture by constructing the resource once.
+import { OnePasswordItem } from "../onepassword/item.ts";
+
+new OnePasswordItem("capture", {
+	connectToken: "tok",
+	namespace: "1password",
+	vault: "vault-1",
+	title: "My Item",
+	fields: [{ label: "password", value: "sk-abc" }],
+});
+const provider = capturedProviders[0] as Provider;
+
+// ---------------------------------------------------------------------------
+// fetch harness
+// ---------------------------------------------------------------------------
+
+interface FetchCall {
+	method: string;
+	url: string;
+	// biome-ignore lint/suspicious/noExplicitAny: request bodies are dynamic JSON
+	body?: any;
+}
+
+let fetchCalls: FetchCall[] = [];
+// biome-ignore lint/suspicious/noExplicitAny: Connect item overviews are dynamic JSON
+let listResult: any[] = [];
+
+function makeResponse(bodyObj: unknown, ok = true, status = 200) {
+	const text =
+		bodyObj === undefined
+			? ""
+			: typeof bodyObj === "string"
+				? bodyObj
+				: JSON.stringify(bodyObj);
+	return {
+		ok,
+		status,
+		statusText: ok ? "OK" : "Error",
+		text: async () => text,
+	};
+}
+
+function baseInputs(): Record<string, unknown> {
+	return {
+		connectToken: "tok",
+		namespace: "1password",
+		deploymentName: "onepassword-connect",
+		connectPort: 8080,
+		vault: "vault-1",
+		title: "My Item",
+		category: "PASSWORD",
+		fields: [
+			{
+				label: "password",
+				value: "sk-abc",
+				type: "CONCEALED",
+				purpose: "PASSWORD",
+			},
+		],
+	};
+}
+
+beforeEach(() => {
+	fetchCalls = [];
+	listResult = [];
+	apiStubs.readNamespacedDeployment.mockClear();
+	apiStubs.listNamespacedPod.mockClear();
+	// biome-ignore lint/suspicious/noExplicitAny: test fetch stub
+	global.fetch = vi.fn(async (url: any, init: any) => {
+		const method: string = init?.method ?? "GET";
+		const u = String(url);
+		const body = init?.body ? JSON.parse(init.body) : undefined;
+		fetchCalls.push({ method, url: u, body });
+		if (method === "GET" && u.includes("/items?filter=")) {
+			return makeResponse(listResult);
+		}
+		if (method === "POST" && /\/items$/.test(u)) {
+			return makeResponse({ id: "new-item-id" });
+		}
+		if (method === "PUT") {
+			return makeResponse({ id: u.split("/items/")[1] });
+		}
+		if (method === "DELETE") {
+			return makeResponse("");
+		}
+		return makeResponse({});
+		// biome-ignore lint/suspicious/noExplicitAny: assigning the global fetch stub
+	}) as any;
+});
+
+describe("OnePasswordItem provider", () => {
+	it("check passes for valid inputs", async () => {
+		const result = await provider.check({}, baseInputs());
+		expect(result.failures).toHaveLength(0);
+	});
+
+	it("check flags missing required fields", async () => {
+		const result = await provider.check(
+			{},
+			{ connectToken: "", namespace: "", vault: "", title: "", fields: [] },
+		);
+		const props = result.failures.map((f) => f.property);
+		expect(props).toContain("connectToken");
+		expect(props).toContain("namespace");
+		expect(props).toContain("vault");
+		expect(props).toContain("title");
+		expect(props).toContain("fields");
+	});
+
+	it("create POSTs a new item when none exists", async () => {
+		listResult = [];
+		const res = await provider.create(baseInputs());
+		expect(res.id).toBe("new-item-id");
+		expect(res.outs.itemPath).toBe("vaults/vault-1/items/new-item-id");
+
+		const post = fetchCalls.find((c) => c.method === "POST");
+		expect(post).toBeDefined();
+		expect(post?.url).toMatch(/\/v1\/vaults\/vault-1\/items$/);
+		expect(post?.body.title).toBe("My Item");
+		expect(post?.body.category).toBe("PASSWORD");
+		expect(post?.body.fields[0]).toMatchObject({
+			label: "password",
+			type: "CONCEALED",
+			value: "sk-abc",
+			purpose: "PASSWORD",
+		});
+		// No PUT when creating fresh.
+		expect(fetchCalls.find((c) => c.method === "PUT")).toBeUndefined();
+	});
+
+	it("create adopts an existing item by title (PUT, no POST)", async () => {
+		listResult = [{ id: "existing-1", title: "My Item" }];
+		const res = await provider.create(baseInputs());
+		expect(res.id).toBe("existing-1");
+
+		expect(fetchCalls.find((c) => c.method === "POST")).toBeUndefined();
+		const put = fetchCalls.find((c) => c.method === "PUT");
+		expect(put?.url).toMatch(/\/v1\/vaults\/vault-1\/items\/existing-1$/);
+		expect(put?.body.id).toBe("existing-1");
+	});
+
+	it("diff reports no change when content is identical", async () => {
+		const inputs = baseInputs();
+		const created = await provider.create(inputs);
+		const res = await provider.diff(created.id, created.outs, inputs);
+		expect(res.changes).toBe(false);
+		expect(res.replaces ?? []).toHaveLength(0);
+	});
+
+	it("diff reports an in-place change when a field value changes", async () => {
+		const inputs = baseInputs();
+		const created = await provider.create(inputs);
+		const changed = {
+			...inputs,
+			fields: [{ label: "password", value: "sk-rotated", type: "CONCEALED" }],
+		};
+		const res = await provider.diff(created.id, created.outs, changed);
+		expect(res.changes).toBe(true);
+		expect(res.replaces ?? []).toHaveLength(0);
+		expect(res.deleteBeforeReplace).toBe(false);
+	});
+
+	it("diff forces replacement when the vault changes", async () => {
+		const inputs = baseInputs();
+		const created = await provider.create(inputs);
+		const moved = { ...inputs, vault: "vault-2" };
+		const res = await provider.diff(created.id, created.outs, moved);
+		expect(res.replaces).toContain("vault");
+	});
+
+	it("diff forces replacement when the title changes", async () => {
+		const inputs = baseInputs();
+		const created = await provider.create(inputs);
+		const renamed = { ...inputs, title: "Renamed Item" };
+		const res = await provider.diff(created.id, created.outs, renamed);
+		expect(res.replaces).toContain("title");
+	});
+
+	it("update PUTs the existing item id in place", async () => {
+		const res = await provider.update("item-9", {}, baseInputs());
+		expect(res.outs.uuid).toBe("item-9");
+		expect(res.outs.itemPath).toBe("vaults/vault-1/items/item-9");
+		const put = fetchCalls.find((c) => c.method === "PUT");
+		expect(put?.url).toMatch(/\/v1\/vaults\/vault-1\/items\/item-9$/);
+	});
+
+	it("delete DELETEs the item", async () => {
+		await provider.delete("item-9", {
+			connectToken: "tok",
+			namespace: "1password",
+			deploymentName: "onepassword-connect",
+			connectPort: 8080,
+			vault: "vault-1",
+		});
+		const del = fetchCalls.find((c) => c.method === "DELETE");
+		expect(del?.url).toMatch(/\/v1\/vaults\/vault-1\/items\/item-9$/);
+	});
+});

--- a/packages/sector7/tests/onepassword-item.test.ts
+++ b/packages/sector7/tests/onepassword-item.test.ts
@@ -133,6 +133,7 @@ interface FetchCall {
 let fetchCalls: FetchCall[] = [];
 // biome-ignore lint/suspicious/noExplicitAny: Connect item overviews are dynamic JSON
 let listResult: any[] = [];
+let deleteStatus = 200;
 
 function makeResponse(bodyObj: unknown, ok = true, status = 200) {
 	const text =
@@ -172,6 +173,7 @@ function baseInputs(): Record<string, unknown> {
 beforeEach(() => {
 	fetchCalls = [];
 	listResult = [];
+	deleteStatus = 200;
 	apiStubs.readNamespacedDeployment.mockClear();
 	apiStubs.listNamespacedPod.mockClear();
 	// biome-ignore lint/suspicious/noExplicitAny: test fetch stub
@@ -190,7 +192,8 @@ beforeEach(() => {
 			return makeResponse({ id: u.split("/items/")[1] });
 		}
 		if (method === "DELETE") {
-			return makeResponse("");
+			if (deleteStatus === 200) return makeResponse("");
+			return makeResponse("error body", false, deleteStatus);
 		}
 		return makeResponse({});
 		// biome-ignore lint/suspicious/noExplicitAny: assigning the global fetch stub
@@ -322,5 +325,56 @@ describe("OnePasswordItem provider", () => {
 		});
 		const del = fetchCalls.find((c) => c.method === "DELETE");
 		expect(del?.url).toMatch(/\/v1\/vaults\/vault-1\/items\/item-9$/);
+	});
+
+	const deleteProps = {
+		connectToken: "tok",
+		namespace: "1password",
+		deploymentName: "onepassword-connect",
+		connectPort: 8080,
+		vault: "vault-1",
+	};
+
+	it("delete treats a 404 as success (idempotent destroy)", async () => {
+		deleteStatus = 404;
+		await expect(
+			provider.delete("item-9", deleteProps),
+		).resolves.toBeUndefined();
+	});
+
+	it("delete rethrows non-404 errors", async () => {
+		deleteStatus = 500;
+		await expect(provider.delete("item-9", deleteProps)).rejects.toThrow();
+	});
+
+	it("create throws a clear error when no Connect pod is ready", async () => {
+		apiStubs.listNamespacedPod.mockResolvedValueOnce({
+			items: [
+				{
+					metadata: { name: "p" },
+					status: { phase: "Pending", conditions: [] },
+				},
+			],
+		});
+		await expect(provider.create(baseInputs())).rejects.toThrow(/no ready pod/);
+	});
+
+	it("does not leak the Connect response body into thrown errors", async () => {
+		// biome-ignore lint/suspicious/noExplicitAny: test fetch stub
+		global.fetch = vi.fn(async (_url: any, init: any) => {
+			const method: string = init?.method ?? "GET";
+			if (method === "GET") return makeResponse([]); // empty list -> create path
+			return makeResponse("super-secret-value-leak", false, 422);
+			// biome-ignore lint/suspicious/noExplicitAny: assigning the global fetch stub
+		}) as any;
+		await provider.create(baseInputs()).then(
+			() => {
+				throw new Error("expected create to reject");
+			},
+			(e: Error) => {
+				expect(e.message).toContain("422");
+				expect(e.message).not.toContain("super-secret-value-leak");
+			},
+		);
 	});
 });

--- a/packages/sector7/tests/onepassword-item.test.ts
+++ b/packages/sector7/tests/onepassword-item.test.ts
@@ -44,6 +44,8 @@ type Provider = {
 const capturedProviders: Provider[] = [];
 
 vi.mock("@pulumi/pulumi", () => ({
+	// biome-ignore lint/suspicious/noExplicitAny: identity secret() stand-in for tests
+	secret: (v: any) => v,
 	dynamic: {
 		Resource: class {
 			constructor(provider: Provider) {
@@ -244,6 +246,25 @@ describe("OnePasswordItem provider", () => {
 		const put = fetchCalls.find((c) => c.method === "PUT");
 		expect(put?.url).toMatch(/\/v1\/vaults\/vault-1\/items\/existing-1$/);
 		expect(put?.body.id).toBe("existing-1");
+	});
+
+	it("create refuses to adopt when multiple items share the title", async () => {
+		listResult = [
+			{ id: "dup-1", title: "My Item" },
+			{ id: "dup-2", title: "My Item" },
+		];
+		await expect(provider.create(baseInputs())).rejects.toThrow(/ambiguously/);
+		expect(fetchCalls.find((c) => c.method === "POST")).toBeUndefined();
+		expect(fetchCalls.find((c) => c.method === "PUT")).toBeUndefined();
+	});
+
+	it("diff reports an in-place change when a transport input changes", async () => {
+		const inputs = baseInputs();
+		const created = await provider.create(inputs);
+		const rotated = { ...inputs, connectToken: "rotated-token" };
+		const res = await provider.diff(created.id, created.outs, rotated);
+		expect(res.changes).toBe(true);
+		expect(res.replaces ?? []).toHaveLength(0);
 	});
 
 	it("diff reports no change when content is identical", async () => {

--- a/packages/sector7/tests/onepassword-item.test.ts
+++ b/packages/sector7/tests/onepassword-item.test.ts
@@ -225,6 +225,22 @@ describe("OnePasswordItem provider", () => {
 		expect(props).toContain("fields");
 	});
 
+	it("check rejects duplicate field labels", async () => {
+		const result = await provider.check(
+			{},
+			{
+				...baseInputs(),
+				fields: [
+					{ label: "password", value: "a" },
+					{ label: "password", value: "b" },
+				],
+			},
+		);
+		expect(
+			result.failures.some((f) => /duplicate field label/.test(f.reason)),
+		).toBe(true);
+	});
+
 	it("create POSTs a new item when none exists", async () => {
 		listResult = [];
 		const res = await provider.create(baseInputs());
@@ -279,6 +295,31 @@ describe("OnePasswordItem provider", () => {
 		const pwd = put?.body.fields.find((f: any) => f.label === "password");
 		expect(pwd.value).toBe("sk-abc"); // managed value wins
 		expect(put?.body.sections).toEqual([{ id: "s1", label: "extra" }]); // preserved
+	});
+
+	it("update removes a previously-managed field dropped from input", async () => {
+		existingItem = {
+			id: "item-9",
+			title: "My Item",
+			category: "PASSWORD",
+			fields: [
+				{ label: "password", type: "CONCEALED", value: "v" },
+				{ label: "old", type: "CONCEALED", value: "gone" },
+				{ label: "unmanaged", type: "STRING", value: "keep" },
+			],
+		};
+		// Previously managed password + old; now input only declares password.
+		await provider.update(
+			"item-9",
+			{ managedLabels: ["password", "old"] },
+			baseInputs(),
+		);
+		const put = fetchCalls.find((c) => c.method === "PUT");
+		// biome-ignore lint/suspicious/noExplicitAny: test body is dynamic JSON
+		const labels = put?.body.fields.map((f: any) => f.label);
+		expect(labels).toContain("password"); // still declared
+		expect(labels).not.toContain("old"); // dropped managed field removed
+		expect(labels).toContain("unmanaged"); // never managed -> preserved
 	});
 
 	it("create refuses to adopt when multiple items share the title", async () => {

--- a/packages/sector7/tests/onepassword-item.test.ts
+++ b/packages/sector7/tests/onepassword-item.test.ts
@@ -133,6 +133,8 @@ interface FetchCall {
 let fetchCalls: FetchCall[] = [];
 // biome-ignore lint/suspicious/noExplicitAny: Connect item overviews are dynamic JSON
 let listResult: any[] = [];
+// biome-ignore lint/suspicious/noExplicitAny: full Connect item is dynamic JSON
+let existingItem: any = {};
 let deleteStatus = 200;
 
 function makeResponse(bodyObj: unknown, ok = true, status = 200) {
@@ -173,6 +175,7 @@ function baseInputs(): Record<string, unknown> {
 beforeEach(() => {
 	fetchCalls = [];
 	listResult = [];
+	existingItem = {};
 	deleteStatus = 200;
 	apiStubs.readNamespacedDeployment.mockClear();
 	apiStubs.listNamespacedPod.mockClear();
@@ -184,6 +187,9 @@ beforeEach(() => {
 		fetchCalls.push({ method, url: u, body });
 		if (method === "GET" && u.includes("/items?filter=")) {
 			return makeResponse(listResult);
+		}
+		if (method === "GET" && /\/items\/[^/?]+$/.test(u)) {
+			return makeResponse(existingItem);
 		}
 		if (method === "POST" && /\/items$/.test(u)) {
 			return makeResponse({ id: "new-item-id" });
@@ -249,6 +255,30 @@ describe("OnePasswordItem provider", () => {
 		const put = fetchCalls.find((c) => c.method === "PUT");
 		expect(put?.url).toMatch(/\/v1\/vaults\/vault-1\/items\/existing-1$/);
 		expect(put?.body.id).toBe("existing-1");
+	});
+
+	it("preserves unmanaged fields/sections when adopting an item", async () => {
+		listResult = [{ id: "existing-1", title: "My Item" }];
+		existingItem = {
+			id: "existing-1",
+			title: "My Item",
+			category: "PASSWORD",
+			fields: [
+				{ label: "notes", type: "STRING", value: "keep me" },
+				{ label: "password", type: "CONCEALED", value: "old-value" },
+			],
+			sections: [{ id: "s1", label: "extra" }],
+		};
+		await provider.create(baseInputs());
+		const put = fetchCalls.find((c) => c.method === "PUT");
+		// biome-ignore lint/suspicious/noExplicitAny: test body is dynamic JSON
+		const labels = put?.body.fields.map((f: any) => f.label);
+		expect(labels).toContain("notes"); // unmanaged field preserved
+		expect(labels).toContain("password"); // managed field upserted
+		// biome-ignore lint/suspicious/noExplicitAny: test body is dynamic JSON
+		const pwd = put?.body.fields.find((f: any) => f.label === "password");
+		expect(pwd.value).toBe("sk-abc"); // managed value wins
+		expect(put?.body.sections).toEqual([{ id: "s1", label: "extra" }]); // preserved
 	});
 
 	it("create refuses to adopt when multiple items share the title", async () => {


### PR DESCRIPTION
## Summary

Adds a generic Pulumi **dynamic resource** that **writes** a 1Password item through the in-cluster 1Password **Connect** server, reached over an **in-process Kubernetes port-forward**. This lets out-of-cluster Pulumi runs (e.g. GitHub Actions over the tailnet apiserver) create/update 1Password items **without exposing Connect** beyond `ClusterIP`.

Design: `docs/internal/designs/031-onepassword-item-write-resource.md` (included in this PR). First consumer: garden ADR 091 (publish a LiteLLM virtual key into 1Password).

## What's here

- **`packages/sector7/onepassword/item.ts`** — `OnePasswordItem` (`sector7:onepassword:Item`), a `pulumi.dynamic.ResourceProvider` with full `check`/`diff`/`create`/`update`/`delete`:
  - **Transport:** short-lived in-process port-forward (`@kubernetes/client-node` `PortForward` + `net.createServer`) to a ready Connect pod (pod selector resolved from the Deployment at runtime), then `fetch` over `localhost`. Same model as `litellm/admin.ts` (sector7#258); accepts an explicit `kubeconfig` (falls back to `loadFromDefault()`) so callers whose creds come from a Pulumi stack output can pass it in.
  - **Lifecycle:** `create()` is find-or-create (adopt an existing item by title and reconcile in place, else POST). `diff()` sends a field-value change to an in-place `PUT` and forces replacement **only** on a vault/title (identity) change; never delete-before-replace. `delete()` removes the item.
  - **Secrets:** `connectToken` and `kubeconfig` are marked `additionalSecretOutputs` (encrypted in state); field **values are not echoed into state** — drift is tracked via a `contentHash`.
  - All Node/k8s imports are lazy `await import()` inside the callbacks (closure-serialization rule, per `r2object.ts` / `admin.ts`).
- **`packages/sector7/onepassword/index.ts`** — barrel (explicit named re-exports).
- **`package.json`** — new `./onepassword` subpath export; **`barrel-guard.ts`** asserts it stays off the root barrel (AGENTS.md).
- **`tests/onepassword-item.test.ts`** — mock-based lifecycle tests mirroring `litellm-admin.test.ts` (Pulumi + k8s client + `node:net` + `fetch` stubbed): check (valid / missing), create (new POST vs adopt PUT), diff (no-change / in-place value change / vault & title replacement), update, delete.

## Scope / follow-ups

- The port-forward transport is intentionally kept **in-module** (mirroring `admin.ts`) so the serialized provider closure stays self-contained. Factoring a shared port-forward util shared with `litellm/admin.ts` is a follow-up once both land (noted in ADR 031; `#258` is the other half).
- v1 stores arbitrary fields; the first consumer needs a single `password` field readable as `op://<vault>/<title>/password`.

## Test plan

- `tsc -p tsconfig.json --noEmit` — clean.
- `pnpm run build` — emits `dist/onepassword/`.
- `pnpm test` — **218 passed** (11 new).
- `biome check` — new files formatted.

CI gates here are `tsc` + `vitest` (`flake.nix` `jackpkgs.checks`); both pass locally.

## Risks

- Low-to-moderate: new dynamic provider; no existing code paths changed. The transport depends on apiserver reachability + a ready Connect pod at deploy time (clear errors otherwise). Real `pulumi up` against Connect is exercised by the garden ADR 091 consumer, not this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)