### PR TITLE
feat(attic): AtticCache and AtticToken dynamic resources

### DIFF
--- a/docs/internal/designs/032-attic-cache-token-resources.md
+++ b/docs/internal/designs/032-attic-cache-token-resources.md
@@ -153,8 +153,11 @@ lifecycle, reached over the shared `withPortForward` transport.
   `keypair` is always `Generate` (server generates and stores the signing keypair;
   we surface the public key).
 - **`create()`** is **find-or-create**: `POST /_api/v1/cache-config/{name}`; on
-  `400 CacheAlreadyExists`, **adopt** by `PATCH`-reconciling config and `GET`-ing
-  the current state — the same idempotency the bootstrap shell relies on. Since
+  `400 CacheAlreadyExists`, **adopt** by `GET`-ing the existing config, **verifying
+  the immutable `store_dir` matches** the declared one (refusing to adopt with a
+  clear error if it differs — otherwise state would claim a `storeDir` the remote
+  doesn't have, since `PATCH` can't change it), then `PATCH`-reconciling the mutable
+  config — the same idempotency the bootstrap shell relies on. Since
   `CreateCacheRequest` has no `retention_period` field, a requested retention is
   applied by a follow-up `PATCH`. Output: `publicKey` (non-secret signing key),
   echoed config.
@@ -167,8 +170,9 @@ lifecycle, reached over the shared `withPortForward` transport.
   pattern from #258).
 - **`update()`** `PATCH`es changed fields and re-reads `publicKey`.
 - **`delete()`** `DELETE`s the cache (soft/hard per the server's
-  `soft_delete_caches`). Callers wanting the cache to outlive the stack use
-  `pulumi.RetainOnDelete`.
+  `soft_delete_caches`). A `404` is treated as success so a cache removed out of
+  band doesn't fail `pulumi destroy`/replacement (idempotent under drift). Callers
+  wanting the cache to outlive the stack use `pulumi.RetainOnDelete`.
 - All `@kubernetes/client-node` / `node:net` / `node:crypto` imports are lazy inside
   the callbacks (the serialization rule documented in `k8s/port-forward.ts`).
 

--- a/docs/internal/designs/032-attic-cache-token-resources.md
+++ b/docs/internal/designs/032-attic-cache-token-resources.md
@@ -1,15 +1,323 @@
 ---
 id: ADR-032
-title: "Attic Cache Token Resources"
-status: proposed
+title: Attic Cache and Token Dynamic Resources
+status: Proposed
 date: 2026-06-10
+deciders: [jmmaloney4]
+consulted: []
+tags: [design, adr, pulumi, kubernetes, attic, nix, cache, secrets]
+supersedes: []
+superseded_by: []
+links:
+  - garden ADR 046 (docs/internal/decisions/046-nix-binary-cache-attic.md)
+  - garden ADR 071 (docs/internal/decisions/071-attic-ci-cache-contract.md)
+  - sector7 ADR-026 (LiteLLM Proxy ComponentResource)
+  - sector7#258 (LiteLLM Team/ApiKey as dynamic resources)
+  - sector7 ADR-031 (OnePassword Item Write Resource)
 ---
 
-# ADR 032: Attic Cache Token Resources
-*Date:* 2026-06-10
-*Status:* proposed
+# Context
 
-**Related PR:** https://github.com/jmmaloney4/sector7/pull/263
+garden runs an [Attic](https://github.com/zhaofengli/attic) Nix binary cache
+(garden `deploy/services/attic/`, ADR 046): a Deployment of
+`ghcr.io/zhaofengli/attic` backed by Cloud SQL Postgres and Cloudflare R2, fronted
+by a `ClusterIP` Service (port `80` → container `8080`) plus a Tailscale ingress.
 
-This ADR is currently being developed in linked pull request above.
-Please refer to that PR for current content and discussion.
+Today the cache and its CI token are provisioned by two
+`@pulumi/command` `local.Command` shells (garden `deploy/services/attic/index.ts`):
+
+- **`attic-cache-bootstrap`** waits for the rollout, `kubectl exec … atticadm make-token` to mint an ephemeral admin token, `kubectl port-forward`, then
+  `curl POST /_api/v1/cache-config/cache` to create one hardcoded cache named
+  `cache`, scraping `.public_key` out of the response. It special-cases a `400 CacheAlreadyExists` to stay idempotent.
+- **`attic-ci-token`** runs `kubectl exec … atticadm make-token --validity 1y --pull cache --push cache` and exports the result as a secret stack output.
+
+This is the same place the garden LiteLLM stack was before sector7#258: imperative
+shells, **one** hardcoded cache, **one** token, no update path, no multi-cache or
+multi-consumer story, and a dependency on `atticadm`/`kubectl` being present and on
+shelling out from the deployer. Adding a second cache, or a per-consumer token with
+a narrower scope, means hand-writing more `local.Command` blocks.
+
+sector7#258 (ADR-026) replaced the analogous LiteLLM shells with first-class
+`pulumi.dynamic` resources (`LiteLLMTeam`, `LiteLLMApiKey`) that reach the admin
+API over a short-lived **in-process Kubernetes port-forward**
+(`packages/sector7/k8s/port-forward.ts`), with a full
+`check`/`diff`/`create`/`update`/`delete` lifecycle, idempotent adoption, and
+secret-typed outputs. Dynamic resources are a **house pattern** here
+(`r2/r2object.ts`, `d1/d1-query.ts`, `litellm/admin.ts`,
+`onepassword/item.ts` per ADR-031). We want the same treatment for Attic.
+
+## What makes Attic different from LiteLLM
+
+Attic's control plane has two halves with **different transports**, verified
+against upstream (`zhaofengli/attic`):
+
+1. **Caches are server state.** Created/configured/destroyed over an HTTP API:
+   `GET/POST/PATCH/DELETE /_api/v1/cache-config/{cache}`. POST body is
+   `CreateCacheRequest { keypair, is_public, store_dir, priority, upstream_cache_key_names }`; GET/PATCH use `CacheConfig` (adds
+   `public_key`, `retention_period`). Each method is gated on a permission from
+   the caller's bearer token (`create_cache` for POST, `configure_cache` for
+   PATCH, `configure_cache_retention` for retention changes, `destroy_cache` for
+   DELETE, `pull` for GET). This half needs the **port-forward** transport, exactly
+   like LiteLLM.
+
+2. **Tokens are stateless JWTs — there is no token API.** Attic auth is a
+   self-contained HS256 JWT signed with the server's shared secret
+   (`ATTIC_SERVER_TOKEN_HS256_SECRET_BASE64`). `atticadm make-token` mints these
+   **locally/offline** from the secret; the server only *verifies* the signature on
+   each request and never stores tokens. The claim that carries authorization is a
+   custom namespace `https://jwt.attic.rs/v1` holding a `caches` map of
+   cache-name-pattern → permission flags (`r` pull, `w` push, `d` delete, `cc`
+   create-cache, `cr` configure-cache, `cq` configure-cache-retention, `cd`
+   destroy-cache); patterns support `*` wildcards with exact-match-wins,
+   default-deny lookup. The HMAC key is the **base64-decoded** secret bytes.
+
+Consequence (2) is the crux: **minting an Attic token needs no server and no
+port-forward** — just the HS256 secret and a JWT signer. That makes the token
+resource *simpler* than LiteLLM's DB-backed `ApiKey`, but it also means a token
+**cannot be individually revoked**: the only ways to invalidate one are to let its
+`exp` lapse or to rotate the shared secret (which invalidates *every* token).
+
+**In scope:** two reusable sector7 dynamic resources — `AtticCache` (cache-config
+HTTP API over the in-process port-forward) and `AtticToken` (local HS256 JWT mint)
+— a pure JWT-minting helper, the `./attic` subpath export, and tests.
+
+**Out of scope:** the garden consumer rewrite (garden's attic stack swapping its two
+`local.Command`s for these resources — a follow-up in garden); provisioning the
+HS256 secret (the consuming stack already generates it via `random.RandomBytes`);
+the cache's storage/DB IaC (R2 bucket, Cloud SQL — unchanged, and one R2 bucket
+backs all caches since Attic namespaces internally); a token *renewal* loop (see
+Consequences).
+
+# Decision
+
+Add a `attic` module to sector7 exposing two Pulumi **dynamic resources**:
+`AtticCache` and `AtticToken`.
+
+## Type tokens & package surface
+
+- `sector7:attic:Cache`
+- `sector7:attic:Token`
+
+Subpath export (not the root barrel — `AtticCache` pulls in
+`@kubernetes/client-node` via the shared transport), mirroring `./litellm` and
+`./onepassword`:
+
+```ts
+import { AtticCache, AtticToken } from "@jmmaloney4/sector7/attic";
+```
+
+Package wiring adds `exports["./attic"]` → `./dist/attic/index.d.ts` / `index.js`.
+
+## AtticToken — local HS256 JWT (`sector7:attic:Token`)
+
+A first-class resource whose output is a signed Attic token.
+
+- **Inputs:** `hs256SecretBase64` (secret), `sub`, `validity` (a duration string —
+  `1y`, `90d`, `12h`, or bare seconds), and `caches`: a map of cache-name pattern →
+  permission flags (`pull`/`push`/`delete`/`createCache`/`configureCache`/
+  `configureCacheRetention`/`destroyCache`). Cache names are plain string keys
+  (Pulumi cannot key an object on an `Output`); they are normally the same literals
+  passed to `AtticCache`, or wildcards like `*`.
+- **`create()`** mints the JWT in-process (`node:crypto` HMAC-SHA256 over the
+  base64-decoded secret): payload `{ sub, nbf, exp, "https://jwt.attic.rs/v1": { caches } }`, with `exp = now + validity` and `nbf = now` baked at create. It
+  returns a **random opaque id** (`crypto.randomUUID()`) as the Pulumi resource id —
+  **never** the token value, which is a bearer credential and would otherwise sit in
+  plaintext state. The token, `sub`, `expiresAt`, and `notBefore` are outputs; the
+  token is a **secret** output.
+- **`diff()`** treats every meaningful input change (`hs256SecretBase64`, `sub`,
+  `validity`, `caches`) as a **replacement** — a signed JWT is immutable, so a
+  changed claim means a new token. `caches` is compared order-insensitively. The
+  baked `exp`/`nbf`/token outputs are state, not inputs, so a no-op `pulumi up` does
+  **not** churn the token. `deleteBeforeReplace: false` (the old token can't be
+  revoked anyway, so mint-then-replace avoids a credential gap).
+- **`delete()`** is a **no-op** with a logged note: a stateless JWT has no
+  server-side record to remove. Genuine revocation is secret rotation (mass) or
+  expiry.
+- No port-forward, no cluster contact. Imports stay lazy (`await import("node:crypto")`)
+  to honor the closure-serialization contract.
+
+## AtticCache — cache-config API over port-forward (`sector7:attic:Cache`)
+
+Mirrors `LiteLLMTeam`: a `ComponentResource` wrapping a dynamic resource with full
+lifecycle, reached over the shared `withPortForward` transport.
+
+- **Admin target:** `{ namespace, deploymentName (default "attic"), port (default 8080), hs256SecretBase64 }`. The resource **mints its own short-lived admin
+  token** in-process from the HS256 secret (validity ~5 min, scoped to *this* cache
+  name with only the permissions the operation needs — `cc`+`cr`+`cq`+`r` for
+  create/update, `cd`+`r` for delete) rather than requiring the caller to pass a
+  pre-minted admin token. So the consumer provides only the secret, and the same
+  secret powers both resources.
+- **Inputs:** `cacheName`, `isPublic` (default `true`), `priority` (default `0`),
+  `storeDir` (default `/nix/store`), `upstreamCacheKeyNames` (default `[]`),
+  `retentionPeriodSeconds` (optional → server default / `Global` when unset).
+  `keypair` is always `Generate` (server generates and stores the signing keypair;
+  we surface the public key).
+- **`create()`** is **find-or-create**: `POST /_api/v1/cache-config/{name}`; on
+  `400 CacheAlreadyExists`, **adopt** by `PATCH`-reconciling config and `GET`-ing
+  the current state — the same idempotency the bootstrap shell relies on. Since
+  `CreateCacheRequest` has no `retention_period` field, a requested retention is
+  applied by a follow-up `PATCH`. Output: `publicKey` (non-secret signing key),
+  echoed config.
+- **`diff()`** routes config changes (`isPublic`, `priority`,
+  `upstreamCacheKeyNames`, `retentionPeriodSeconds`) to an **in-place** `PATCH`;
+  reserves **replacement** for `cacheName` (a different cache) and `storeDir`
+  (cache identity); and treats admin-target changes (`namespace`/`deploymentName`/
+  `port`/`hs256SecretBase64`) as in-place so a later update/delete re-targets the
+  new deployment and re-mints under the new secret (the `adminTargetChanged`
+  pattern from #258).
+- **`update()`** `PATCH`es changed fields and re-reads `publicKey`.
+- **`delete()`** `DELETE`s the cache (soft/hard per the server's
+  `soft_delete_caches`). Callers wanting the cache to outlive the stack use
+  `pulumi.RetainOnDelete`.
+- All `@kubernetes/client-node` / `node:net` / `node:crypto` imports are lazy inside
+  the callbacks (the serialization rule documented in `k8s/port-forward.ts`).
+
+## Shared JWT helper
+
+A pure `mintAtticToken({ secretBase64, sub, issuedAtSeconds, expiresAtSeconds, caches })` in `attic/token.ts`, used by both resources (`AtticToken` for the
+consumer token, `AtticCache` for its ephemeral admin token). It carries the same
+**serialization contract** as `k8s/port-forward.ts`: no top-level runtime imports;
+`node:crypto` is imported lazily inside the function. It emits the minimal claim set
+`atticadm` produces (`sub`, `nbf`, `exp`, the namespace claim with only the
+true permission flags) — no `iss`/`aud`/`iat`, which Attic does not require unless
+the server is configured with a bound issuer/audience (it is not).
+
+## Tests
+
+Mirror `tests/litellm-admin.test.ts`: mock `@pulumi/pulumi`, the transport, and
+`fetch`. Assert `AtticCache` `diff` (in-place config change vs replace on
+`cacheName`/`storeDir` vs in-place on admin-target change), `create` (new vs adopt
+on `CacheAlreadyExists`), `update`, and `delete`. For `AtticToken`, assert that a
+minted JWT verifies against the secret with the expected header/claims/permission
+short-keys, that all input changes are replacements, and that `delete` is a no-op.
+
+# Consequences
+
+## Positive
+
+- Declarative **multi-cache** creation, config reconciliation, and **per-consumer**
+  scoped tokens — replacing two hardcoded, single-cache/single-token shells with
+  typed resources that have a real `diff`/`update` path.
+- **Reuses** the #258 in-process port-forward transport: no new cluster ingress,
+  the call rides the apiserver the deployer already authenticates to (consistent
+  with garden ADR 046's `ClusterIP`-only posture; the Tailscale ingress is for
+  clients, not for IaC).
+- The token half is **simpler than LiteLLM's** — no server round-trip, no
+  port-forward — because Attic tokens are stateless. One secret drives both
+  resources.
+- Permission model maps cleanly to typed flags + wildcard patterns; least-privilege
+  per-consumer tokens become trivial to express.
+- Drops the deploy-time dependency on `atticadm`/`kubectl` shelling out.
+
+## Negative
+
+- **Tokens cannot be individually revoked.** A leaked or over-scoped token is live
+  until `exp`; the only revocation is rotating the shared HS256 secret, which
+  invalidates **all** tokens at once. Mitigations: short `validity` where feasible,
+  least-privilege `caches` scopes, and `RetainOnDelete`-free deletion that at least
+  stops *issuing* it. This is an inherent property of Attic's stateless-JWT design,
+  not of this resource.
+- **`exp` is baked at create and does not auto-renew.** A long-lived token (e.g.
+  a 1y CI token) silently lapses with no input change to trigger re-mint — same
+  behavior as today's `atticadm --validity 1y` shell. Renewal is manual (`pulumi up --replace`) or a future `renewBefore` knob; out of scope here.
+- Net-new code (two providers + a JWT signer) and the closure-serialization
+  constraint, plus a hand-rolled HS256 JWT (no `jose`/`jsonwebtoken` dependency —
+  HS256 is a 3-line `node:crypto` HMAC, and avoiding a dep keeps the provider
+  closure small and serializable).
+- The `KeypairConfig`/`RetentionPeriodConfig` enum **wire formats** (`"Generate"`
+  vs `{ "Keypair": … }`; `"Global"` vs `{ "Period": n }`) are externally-tagged
+  serde enums confirmed from source but not byte-verified against a live response;
+  implementation MUST validate with one live create→get round-trip (the existing
+  bootstrap already proves the create body).
+
+# Alternatives
+
+- **Keep the `local.Command` shells.** Status quo: no update path, single
+  cache/token, depends on `atticadm`/`kubectl` at deploy time, and every new cache
+  or scoped token is another bespoke shell. Rejected — this is exactly what #258
+  moved LiteLLM away from.
+- **A garden-local dynamic provider** (don't put it in sector7). Would copy #258's
+  transport and the JWT helper rather than reuse them and wouldn't be available to
+  other clusters/repos. Rejected, consistent with ADR-031.
+- **`AtticToken` mints inline in a `ComponentResource` via `pulumi.all().apply()`
+  instead of a dynamic resource.** Signing is pure, so this seems tempting — but an
+  `apply` recomputes every run, and baking `exp` from "now" inside an apply would
+  change the token on every `pulumi up` (perpetual diff). A dynamic resource
+  persists `exp`/token in state and only re-mints on a real input change. Rejected.
+- **`AtticCache` requires the caller to pass a pre-minted admin token** instead of
+  minting one from the secret. More explicit, but it pushes the JWT-minting burden
+  onto every consumer and means handling two secret-ish inputs. Rejected in favor of
+  "give the resource the secret, it mints what it needs"; a pre-minted-token input
+  MAY be added later for a stack that wants to withhold the raw secret from the
+  cache resource.
+- **Add `jose`/`jsonwebtoken`.** Unnecessary for HS256; a runtime dep complicates
+  the closure serialization the providers depend on. Rejected.
+
+# Security / Privacy / Compliance
+
+- **HS256 secret** is the root credential for the whole cache: anyone holding it can
+  mint a `*`-scoped admin token. It MUST be a Pulumi secret end to end and is the
+  same secret the cache server already runs on. Both resources treat it as secret on
+  input; it is never an output.
+- **Minted tokens are bearer credentials** — `AtticToken.token` is a **secret**
+  output; the resource **id** is a random UUID, never the token, so the credential
+  never lands in plaintext state or in logs.
+- **Least privilege:** consumer tokens SHOULD carry the narrowest `caches` scope and
+  shortest `validity` that works (e.g. CI: `pull`+`push` on the one cache, not `*`).
+  `AtticCache`'s self-minted admin token is scoped to the single target cache and
+  the operation's permissions, with ~5-min validity.
+- **No new network exposure** — the cache-config calls tunnel through the apiserver;
+  Attic's `ClusterIP` + Tailscale-client posture (ADR 046) is unchanged.
+- **Revocation caveat** (above) is a compliance-relevant limitation: document that
+  token rotation is all-or-nothing via the shared secret.
+
+# Operational Notes
+
+- `AtticCache` runs require apiserver reachability and a **ready Attic pod** at
+  deploy time; surface a clear error if the port-forward can't bind or the rollout
+  is unready (the transport already distinguishes "no ready pod").
+- The port-forward is **short-lived per operation** and torn down after.
+- Idempotent adoption (`CacheAlreadyExists` → reconcile) makes cutover from the
+  bootstrap-created `cache` safe: importing/adopting the existing cache MUST NOT
+  regenerate its keypair (POST is create-only; adoption goes through GET/PATCH, so
+  the signing key — and thus every client's `trusted-public-keys` — is preserved).
+- Default `port` is `8080` (Attic's container listen port; garden's Service maps
+  `80 → 8080`, but the port-forward targets the **pod** port).
+
+# Status Transitions
+
+- New design; does not supersede an existing ADR. Reuses the transport pattern from
+  sector7#258 (ADR-026) and the dynamic-resource/subpath-export precedent from
+  ADR-031. garden ADR 046/071 remain the cache's deployment and CI-contract
+  decisions; this ADR only changes *how* caches and tokens are provisioned.
+
+# Implementation Notes
+
+- Add `packages/sector7/attic/{token.ts,config-types.ts,admin.ts,index.ts}` and the
+  `./attic` subpath export (mirror ADR-026 / ADR-031 wiring).
+- `token.ts`: pure `mintAtticToken` + `parseDurationSeconds`, lazy `node:crypto`,
+  no top-level runtime imports (serialization contract).
+- `admin.ts`: `AtticCache` + `AtticToken` providers reusing `withPortForward`
+  (cache only) and `mintAtticToken` (both).
+- Validate the `KeypairConfig`/`RetentionPeriodConfig` wire format with one live
+  create→get against the deployed cache before relying on retention.
+- Add `tests/attic.test.ts` mirroring `litellm-admin.test.ts`.
+- First consumer and acceptance (follow-up, garden): garden's
+  `deploy/services/attic/index.ts` replaces `attic-cache-bootstrap` /
+  `attic-ci-token` with `AtticCache` + `AtticToken`, preserving the existing
+  `cache` cache's keypair via adoption.
+
+# References
+
+- garden ADR 046 — `docs/internal/decisions/046-nix-binary-cache-attic.md`
+- garden ADR 071 — `docs/internal/decisions/071-attic-ci-cache-contract.md`
+- sector7#258 / ADR-026 — LiteLLM Team/ApiKey dynamic resources, in-process
+  port-forward transport (`packages/sector7/litellm/admin.ts`,
+  `packages/sector7/k8s/port-forward.ts`)
+- sector7 ADR-031 — OnePassword Item Write Resource (dynamic-resource + subpath
+  precedent)
+- Attic source — `token/src/lib.rs` (claims, `CachePermission`, HS256 secret
+  decode), `server/src/api/v1/cache_config.rs` (cache-config handlers + per-method
+  permissions), `attic/src/api/v1/cache_config.rs` (`CreateCacheRequest`,
+  `CacheConfig`, `KeypairConfig`, `RetentionPeriodConfig`), `attic/src/cache.rs`
+  (`CacheName`/`CacheNamePattern` wildcards)

--- a/packages/sector7/README.md
+++ b/packages/sector7/README.md
@@ -18,6 +18,39 @@ pnpm add "git+https://github.com/jmmaloney4/sector7.git#path:/packages/sector7#v
 
 ## Components
 
+This package is organized into **subpath modules**, each exported under
+`@jmmaloney4/sector7/<name>` so a consumer only pulls in the dependency closure
+it needs. The root barrel (`@jmmaloney4/sector7`) re-exports the lighter modules
+as namespaces (`access`, `d1`, `iam`, `monitor`, `nixImage`, `nixOutput`,
+`workersite`); heavier modules — those carrying `@pulumi/kubernetes`,
+`@kubernetes/client-node`, or other large/optional type closures — are
+**subpath-only** and deliberately kept out of the root barrel (asserted by
+`barrel-guard.ts`).
+
+| Subpath                             | Key exports                                                                           | Purpose                                                                                   |
+| ----------------------------------- | ------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------- |
+| `@jmmaloney4/sector7/iam`           | `GitHubOidcResource`, `WorkloadIdentityPool`, `GitHubActionsIdentityProvider`         | GitHub Actions OIDC → GCP Workload Identity Federation ([details](#githuboidcresource))   |
+| `@jmmaloney4/sector7/access`        | `AccessGate`                                                                          | GitHub OAuth access-control gate for WorkerSite routes (ADR-016)                          |
+| `@jmmaloney4/sector7/workersite`    | `WorkerSite`, `generateWorkerScript`                                                  | Cloudflare Worker static-site deployment                                                  |
+| `@jmmaloney4/sector7/r2`            | `R2Object`, `uploadAssets`, `uploadStaticAssets`, `purgeZoneCache`                    | Cloudflare R2 object upload + zone cache purge (dynamic resources)                        |
+| `@jmmaloney4/sector7/d1`            | `D1Query`                                                                             | Cloudflare D1 query as a dynamic resource                                                 |
+| `@jmmaloney4/sector7/nix-image`     | `NixImage`, `NixImagePushGroup`                                                       | Build and push OCI images from Nix outputs (ADR-017/029)                                  |
+| `@jmmaloney4/sector7/nix-output`    | `NixOutput`                                                                           | Realize a Nix flake output as a resource (ADR-021)                                        |
+| `@jmmaloney4/sector7/monitor`       | `UptimeMonitor`                                                                       | Cloudflare Worker uptime monitor (ADR-020/028/030)                                        |
+| `@jmmaloney4/sector7/cloudsql`      | `CloudSqlAuthProxySidecar`, `rewriteDatabaseUrlForProxy`                              | Cloud SQL Auth Proxy sidecar for Kubernetes workloads (ADR-027)                           |
+| `@jmmaloney4/sector7/litellm`       | `LiteLLMProxy`, `LiteLLMTeam`, `LiteLLMApiKey`, `generateLiteLLMConfig`               | LiteLLM proxy deployment + team/virtual-key admin, dynamic (ADR-026; [details](#litellm)) |
+| `@jmmaloney4/sector7/onepassword`   | `OnePasswordItem`                                                                     | Write/update a 1Password item via Connect, dynamic (ADR-031; [details](#onepassword))     |
+| `@jmmaloney4/sector7/attic`         | `AtticCache`, `AtticToken`                                                            | Attic Nix binary cache + access-token admin, dynamic (ADR-032; [details](#attic))         |
+| `@jmmaloney4/sector7/gateway`       | `createServiceHttpRoute`, `createSharedGatewayReferenceGrant`, `createTailnetIngress` | Gateway API HTTPRoute / ReferenceGrant / Tailnet Ingress helpers (ADR-040/075)            |
+| `@jmmaloney4/sector7/pulumi-config` | `requireMixedConfig`                                                                  | Typed loader for mixed plain + secret Pulumi config                                       |
+| `@jmmaloney4/sector7/scripts`       | `getScriptPath`                                                                       | Resolve the path to a script bundled with the package                                     |
+
+> The dynamic-resource modules (`litellm`, `onepassword`, `attic`, `r2`, `d1`)
+> reach a `ClusterIP`-only service from an out-of-cluster `pulumi up` over a
+> short-lived **in-process Kubernetes port-forward** (`k8s/port-forward.ts`), so
+> the targets need no tailnet/public ingress. Their provider closures must keep
+> native imports lazy — see the serialization contract in `k8s/port-forward.ts`.
+
 ### GitHubOidcResource
 
 A component that sets up GitHub Actions OIDC authentication with Google Cloud Platform (GCP). This creates:
@@ -118,6 +151,101 @@ config:
         - your-dev-project
     limitToRef: refs/heads/main
 ```
+
+### LiteLLM
+
+`@jmmaloney4/sector7/litellm` deploys an OpenAI-compatible
+[LiteLLM](https://docs.litellm.ai) proxy and manages its teams and virtual keys.
+`LiteLLMProxy` owns the Kubernetes objects and generates `config.yaml` from a
+typed model; `LiteLLMTeam` and `LiteLLMApiKey` are **dynamic resources** that
+reconcile teams/keys through the proxy admin API over an in-process port-forward
+(idempotent adoption, in-place updates, secret-typed key outputs). See ADR-026.
+
+```typescript
+import * as pulumi from "@pulumi/pulumi";
+import { LiteLLMApiKey, LiteLLMTeam } from "@jmmaloney4/sector7/litellm";
+
+const team = new LiteLLMTeam("prod", {
+    proxyNamespace: "litellm",
+    masterKey: pulumi.secret(masterKey),
+    teamAlias: "prod-personal",
+    teamId: "personal", // explicit id → idempotent adoption
+    models: ["coding", "cheap"],
+});
+
+const key = new LiteLLMApiKey("openwebui", {
+    proxyNamespace: "litellm",
+    masterKey: pulumi.secret(masterKey),
+    teamId: team.teamId,
+    keyAlias: "prod-openwebui",
+});
+
+export const openWebuiKey = key.key; // secret Output<string>
+```
+
+### OnePassword
+
+`@jmmaloney4/sector7/onepassword` **writes** (creates/updates) a 1Password item
+via 1Password Connect, reached over an in-process Kubernetes port-forward — so
+Connect stays `ClusterIP`-only. Use it to publish a value Pulumi already holds so
+the 1Password operator (or `op read`) can distribute it. Field values are treated
+as secrets end to end. See ADR-031.
+
+```typescript
+import * as pulumi from "@pulumi/pulumi";
+import { OnePasswordItem } from "@jmmaloney4/sector7/onepassword";
+
+const item = new OnePasswordItem("hermes-key", {
+    namespace: "1password",
+    connectToken: pulumi.secret(connectToken), // write-scoped Connect token
+    vault: vaultId,
+    title: "hermes-agent-api-key",
+    category: "password",
+    fields: [
+        { label: "credential", value: pulumi.secret(apiKey), type: "concealed" },
+    ],
+});
+
+export const itemPath = item.itemPath; // vaults/<vault>/items/<uuid>
+```
+
+### Attic
+
+`@jmmaloney4/sector7/attic` manages an
+[Attic](https://github.com/zhaofengli/attic) Nix binary cache and its access
+tokens as **dynamic resources**. `AtticCache` find-or-creates and reconciles a
+cache through the cache-config HTTP API over an in-process port-forward, minting
+its own short-lived admin token from the server's signing secret; `AtticToken`
+mints a stateless HS256 access token in-process from that same secret (no server
+contact). The token is a secret output; the resource id never carries it. See
+ADR-032.
+
+```typescript
+import * as pulumi from "@pulumi/pulumi";
+import { AtticCache, AtticToken } from "@jmmaloney4/sector7/attic";
+
+const cache = new AtticCache("cache", {
+    namespace: "attic-prod",
+    hs256SecretBase64: pulumi.secret(signingSecret),
+    cacheName: "cache",
+    isPublic: true,
+});
+
+const ciToken = new AtticToken("ci", {
+    hs256SecretBase64: pulumi.secret(signingSecret),
+    sub: "github-actions-ci",
+    validity: "1y",
+    caches: { cache: { pull: true, push: true } },
+});
+
+export const cachePublicKey = cache.publicKey;
+export const atticCiToken = ciToken.token; // secret Output<string>
+```
+
+> **Token revocation caveat:** Attic tokens are stateless JWTs — `AtticToken`
+> deletion is a no-op. A token is invalidated only by its `validity` lapsing or by
+> rotating the shared signing secret (which invalidates *every* token). Prefer
+> short `validity` and least-privilege `caches` scopes.
 
 ## Development
 

--- a/packages/sector7/attic/admin.ts
+++ b/packages/sector7/attic/admin.ts
@@ -474,10 +474,17 @@ const tokenProvider: dynamic.ResourceProvider = {
 		if (!news.sub) {
 			failures.push({ property: "sub", reason: "sub is required" });
 		}
-		if (!news.validitySeconds || news.validitySeconds <= 0) {
+		if (
+			typeof news.validitySeconds !== "number" ||
+			!Number.isFinite(news.validitySeconds) ||
+			news.validitySeconds <= 0
+		) {
+			// Must be finite: a non-finite validity makes `exp = now + validity`
+			// non-finite, which JSON serializes to `null` — a token that looks minted
+			// but is invalid at runtime.
 			failures.push({
 				property: "validitySeconds",
-				reason: "validity must be a positive duration",
+				reason: "validity must be a finite positive duration",
 			});
 		}
 		return { inputs: news, failures };

--- a/packages/sector7/attic/admin.ts
+++ b/packages/sector7/attic/admin.ts
@@ -382,14 +382,21 @@ const cacheProvider: dynamic.ResourceProvider = {
 				// adopting a same-named cache that points at a different store dir would
 				// silently record the desired storeDir in state while the remote keeps
 				// its own. Fail loudly instead of misrepresenting drift.
+				//
+				// Fail *closed*: if the GET doesn't report a string store_dir we cannot
+				// confirm the immutable field, so refuse rather than adopt an unverified
+				// cache and record an assumed storeDir in state.
 				const existing = ensureOk(
 					await atticFetch(baseUrl, token, path, "GET"),
 					"GET",
 					path,
 				);
-				if (existing?.store_dir && existing.store_dir !== inputs.storeDir) {
+				if (
+					typeof existing?.store_dir !== "string" ||
+					existing.store_dir !== inputs.storeDir
+				) {
 					throw new Error(
-						`Attic cache "${inputs.cacheName}" already exists with store_dir "${existing.store_dir}", which differs from the requested "${inputs.storeDir}". store_dir is immutable — refusing to adopt; align storeDir or choose a different cacheName.`,
+						`Attic cache "${inputs.cacheName}" already exists but its store_dir (${JSON.stringify(existing?.store_dir)}) is absent or differs from the requested "${inputs.storeDir}". store_dir is immutable — refusing to adopt; align storeDir or choose a different cacheName.`,
 					);
 				}
 				ensureOk(

--- a/packages/sector7/attic/admin.ts
+++ b/packages/sector7/attic/admin.ts
@@ -1,0 +1,656 @@
+import * as pulumi from "@pulumi/pulumi";
+import {
+	type CustomResourceOptions,
+	dynamic,
+	type Output,
+} from "@pulumi/pulumi";
+import { withPortForward } from "../k8s/port-forward.ts";
+import type { AtticCacheArgs, AtticTokenArgs } from "./config-types.ts";
+import {
+	type AtticCacheGrants,
+	type AtticCachePermissionFlags,
+	mintAtticToken,
+	parseDurationSeconds,
+} from "./token.ts";
+
+/**
+ * Resource options accepted by sector7 dynamic resources.
+ *
+ * Pulumi dynamic resources are executed by the Node.js dynamic provider runtime,
+ * not by a cloud provider plugin. Passing `provider` or `providers` makes Pulumi
+ * route the resource through the wrong provider bridge, which fails with a
+ * misleading `pulumi-nodejs:dynamic:Resource` unknown-token error.
+ */
+export type DynamicResourceOptions = Omit<
+	CustomResourceOptions,
+	"provider" | "providers"
+>;
+
+// ---------------------------------------------------------------------------
+// Resolved provider input/state shapes
+//
+// Pulumi resolves every `Input<T>` before invoking the dynamic provider, so the
+// callbacks below see plain JSON values only. Optional fields are normalized to
+// sentinel empty values ("" / [] / {}) by the wrapping component so the provider
+// never has to reason about `undefined`.
+// ---------------------------------------------------------------------------
+
+/** Coordinates + signing secret for reaching the Attic cache-config API. */
+interface AdminTarget {
+	namespace: string;
+	hs256SecretBase64: string;
+	deploymentName: string;
+	port: number;
+}
+
+interface CacheProviderInputs extends AdminTarget {
+	cacheName: string;
+	isPublic: boolean;
+	priority: number;
+	storeDir: string;
+	upstreamCacheKeyNames: string[];
+	/** "" when unset (server default / `Global`). */
+	retentionPeriodSeconds: number | "";
+}
+
+interface CacheProviderState extends CacheProviderInputs {
+	/** Public NAR-signing key, read back from the cache config. */
+	publicKey: string;
+}
+
+interface TokenProviderInputs {
+	hs256SecretBase64: string;
+	sub: string;
+	validitySeconds: number;
+	caches: AtticCacheGrants;
+}
+
+interface TokenProviderState extends TokenProviderInputs {
+	/** The signed JWT (a bearer credential — kept out of the resource id). */
+	token: string;
+	/** Baked `exp`, unix seconds. */
+	expiresAt: number;
+	/** Baked `nbf`, unix seconds. */
+	notBefore: number;
+}
+
+// ---------------------------------------------------------------------------
+// Runtime helpers
+//
+// Like the LiteLLM admin providers, the in-process port-forward lives in the
+// shared `../k8s/port-forward` module (`withPortForward`), whose lazy
+// `await import()` of @kubernetes/client-node / node:net keeps the provider
+// closures serializable. The helpers below otherwise use only the global `fetch`
+// and `mintAtticToken` (whose own node:crypto import is lazy), so they hold no
+// top-level native imports either.
+// https://www.pulumi.com/docs/concepts/resources/dynamic-providers/#how-dynamic-providers-are-serialized
+// ---------------------------------------------------------------------------
+
+const ADMIN_SUB = "sector7-attic-cache";
+/** Short admin-token validity — only needs to outlive a single API call. */
+const ADMIN_TOKEN_VALIDITY_SECONDS = 300;
+
+const ADMIN_CREATE_FLAGS: AtticCachePermissionFlags = {
+	pull: true,
+	createCache: true,
+	configureCache: true,
+	configureCacheRetention: true,
+};
+const ADMIN_UPDATE_FLAGS: AtticCachePermissionFlags = {
+	pull: true,
+	configureCache: true,
+	configureCacheRetention: true,
+};
+const ADMIN_DELETE_FLAGS: AtticCachePermissionFlags = {
+	pull: true,
+	destroyCache: true,
+};
+
+/**
+ * Mint a short-lived admin token scoped to a single cache and the permissions a
+ * specific operation needs (least privilege), signed from the server's HS256
+ * secret. No server contact — the token is self-contained.
+ */
+async function mintAdminToken(
+	target: AdminTarget,
+	cacheName: string,
+	flags: AtticCachePermissionFlags,
+): Promise<string> {
+	const now = Math.floor(Date.now() / 1000);
+	return mintAtticToken({
+		secretBase64: target.hs256SecretBase64,
+		sub: ADMIN_SUB,
+		issuedAtSeconds: now,
+		expiresAtSeconds: now + ADMIN_TOKEN_VALIDITY_SECONDS,
+		caches: { [cacheName]: flags },
+	});
+}
+
+/** Open a short-lived port-forward to a ready Attic pod for `fn`. */
+async function withCacheBaseUrl<T>(
+	target: AdminTarget,
+	fn: (baseUrl: string) => Promise<T>,
+): Promise<T> {
+	return withPortForward(
+		{
+			namespace: target.namespace,
+			deploymentName: target.deploymentName,
+			port: target.port,
+		},
+		fn,
+	);
+}
+
+interface AtticResponse {
+	status: number;
+	ok: boolean;
+	text: string;
+	// biome-ignore lint/suspicious/noExplicitAny: cache-config responses are dynamic JSON
+	json: any;
+}
+
+/** Low-level cache-config request that surfaces the status so callers can branch. */
+async function atticFetch(
+	baseUrl: string,
+	token: string,
+	path: string,
+	method: "GET" | "POST" | "PATCH" | "DELETE",
+	body?: unknown,
+): Promise<AtticResponse> {
+	const response = await fetch(`${baseUrl}${path}`, {
+		method,
+		headers: {
+			Authorization: `Bearer ${token}`,
+			...(body !== undefined ? { "Content-Type": "application/json" } : {}),
+		},
+		body: body !== undefined ? JSON.stringify(body) : undefined,
+	});
+	const text = await response.text();
+	// biome-ignore lint/suspicious/noExplicitAny: cache-config responses are dynamic JSON
+	let json: any;
+	try {
+		json = text ? JSON.parse(text) : {};
+	} catch {
+		json = undefined;
+	}
+	return { status: response.status, ok: response.ok, text, json };
+}
+
+/** Throw on a non-2xx cache-config response; otherwise return the parsed body. */
+function ensureOk(
+	res: AtticResponse,
+	method: string,
+	path: string,
+	// biome-ignore lint/suspicious/noExplicitAny: cache-config responses are dynamic JSON
+): any {
+	if (!res.ok) {
+		throw new Error(
+			`Attic ${method} ${path} failed: ${res.status}\n${res.text}`,
+		);
+	}
+	return res.json;
+}
+
+/** Render the optional retention into Attic's `RetentionPeriodConfig` wire form. */
+function retentionPeriod(
+	retentionPeriodSeconds: number | "",
+): "Global" | { Period: number } {
+	return retentionPeriodSeconds === ""
+		? "Global"
+		: { Period: retentionPeriodSeconds };
+}
+
+/** `CreateCacheRequest` body (POST) — keypair is always server-generated. */
+function buildCreateBody(inputs: CacheProviderInputs): Record<string, unknown> {
+	return {
+		keypair: "Generate",
+		is_public: inputs.isPublic,
+		store_dir: inputs.storeDir,
+		priority: inputs.priority,
+		upstream_cache_key_names: inputs.upstreamCacheKeyNames,
+	};
+}
+
+/**
+ * `CacheConfig` body (PATCH) reconciling the mutable fields. Deliberately omits
+ * `keypair` (never rotate) and `store_dir` (immutable in our model — a change is
+ * a replacement), so adoption preserves the existing signing key.
+ */
+function buildPatchBody(inputs: CacheProviderInputs): Record<string, unknown> {
+	return {
+		is_public: inputs.isPublic,
+		priority: inputs.priority,
+		upstream_cache_key_names: inputs.upstreamCacheKeyNames,
+		retention_period: retentionPeriod(inputs.retentionPeriodSeconds),
+	};
+}
+
+/** GET the cache config and return its public signing key. */
+async function readPublicKey(
+	baseUrl: string,
+	token: string,
+	cacheName: string,
+): Promise<string> {
+	const path = `/_api/v1/cache-config/${cacheName}`;
+	const config = ensureOk(
+		await atticFetch(baseUrl, token, path, "GET"),
+		"GET",
+		path,
+	);
+	return config?.public_key ?? "";
+}
+
+/**
+ * True when any admin-connection field changed. Such a change does not alter the
+ * remote cache, but it must still flow into stored state so a later update/delete
+ * targets the new deployment and mints under the new secret — so diff() treats it
+ * as an in-place change.
+ */
+function adminTargetChanged(olds: AdminTarget, news: AdminTarget): boolean {
+	return (
+		olds.namespace !== news.namespace ||
+		olds.deploymentName !== news.deploymentName ||
+		olds.port !== news.port ||
+		olds.hs256SecretBase64 !== news.hs256SecretBase64
+	);
+}
+
+/** Stable JSON for order-insensitive comparison in diff(). */
+function stableJson(value: unknown): string {
+	if (Array.isArray(value)) {
+		return JSON.stringify([...value].map(stableValue).sort());
+	}
+	return JSON.stringify(stableValue(value));
+}
+
+function stableValue(value: unknown): unknown {
+	if (Array.isArray(value)) return value.map(stableValue);
+	if (value && typeof value === "object") {
+		const obj = value as Record<string, unknown>;
+		return Object.keys(obj)
+			.sort()
+			.reduce<Record<string, unknown>>((acc, key) => {
+				acc[key] = stableValue(obj[key]);
+				return acc;
+			}, {});
+	}
+	return value;
+}
+
+// ---------------------------------------------------------------------------
+// Cache provider
+// ---------------------------------------------------------------------------
+
+const cacheProvider: dynamic.ResourceProvider = {
+	async check(
+		_olds: CacheProviderState,
+		news: CacheProviderInputs,
+	): Promise<dynamic.CheckResult> {
+		const failures: dynamic.CheckFailure[] = [];
+		for (const property of [
+			"namespace",
+			"hs256SecretBase64",
+			"deploymentName",
+			"cacheName",
+		] as const) {
+			if (!news[property]) {
+				failures.push({ property, reason: `${property} is required` });
+			}
+		}
+		return { inputs: news, failures };
+	},
+
+	async diff(
+		_id: string,
+		olds: CacheProviderState,
+		news: CacheProviderInputs,
+	): Promise<dynamic.DiffResult> {
+		const replaces: string[] = [];
+		// Renaming a cache or changing its store dir is a different cache.
+		if (olds.cacheName !== news.cacheName) replaces.push("cacheName");
+		if (olds.storeDir !== news.storeDir) replaces.push("storeDir");
+		const changed =
+			replaces.length > 0 ||
+			adminTargetChanged(olds, news) ||
+			olds.isPublic !== news.isPublic ||
+			olds.priority !== news.priority ||
+			stableJson(olds.upstreamCacheKeyNames) !==
+				stableJson(news.upstreamCacheKeyNames) ||
+			(olds.retentionPeriodSeconds ?? "") !==
+				(news.retentionPeriodSeconds ?? "");
+		return { changes: changed, replaces, deleteBeforeReplace: false };
+	},
+
+	async create(inputs: CacheProviderInputs): Promise<dynamic.CreateResult> {
+		const token = await mintAdminToken(
+			inputs,
+			inputs.cacheName,
+			ADMIN_CREATE_FLAGS,
+		);
+		return withCacheBaseUrl(inputs, async (baseUrl) => {
+			const path = `/_api/v1/cache-config/${inputs.cacheName}`;
+			const res = await atticFetch(
+				baseUrl,
+				token,
+				path,
+				"POST",
+				buildCreateBody(inputs),
+			);
+			if (res.ok) {
+				// Created fresh. CreateCacheRequest has no retention field, so apply a
+				// requested retention with a follow-up PATCH.
+				if (inputs.retentionPeriodSeconds !== "") {
+					ensureOk(
+						await atticFetch(baseUrl, token, path, "PATCH", {
+							retention_period: retentionPeriod(inputs.retentionPeriodSeconds),
+						}),
+						"PATCH",
+						path,
+					);
+				}
+			} else if (
+				res.status === 400 &&
+				res.text.includes("CacheAlreadyExists")
+			) {
+				// Idempotent adoption: reconcile the existing cache's config in place.
+				// POST is create-only, so going through PATCH preserves the keypair —
+				// and thus every client's trusted-public-keys.
+				ensureOk(
+					await atticFetch(
+						baseUrl,
+						token,
+						path,
+						"PATCH",
+						buildPatchBody(inputs),
+					),
+					"PATCH",
+					path,
+				);
+			} else {
+				ensureOk(res, "POST", path);
+			}
+			const publicKey = await readPublicKey(baseUrl, token, inputs.cacheName);
+			return { id: inputs.cacheName, outs: { ...inputs, publicKey } };
+		});
+	},
+
+	async update(
+		_id: string,
+		_olds: CacheProviderState,
+		news: CacheProviderInputs,
+	): Promise<dynamic.UpdateResult> {
+		const token = await mintAdminToken(
+			news,
+			news.cacheName,
+			ADMIN_UPDATE_FLAGS,
+		);
+		return withCacheBaseUrl(news, async (baseUrl) => {
+			const path = `/_api/v1/cache-config/${news.cacheName}`;
+			ensureOk(
+				await atticFetch(baseUrl, token, path, "PATCH", buildPatchBody(news)),
+				"PATCH",
+				path,
+			);
+			const publicKey = await readPublicKey(baseUrl, token, news.cacheName);
+			return { outs: { ...news, publicKey } };
+		});
+	},
+
+	async delete(id: string, props: CacheProviderState): Promise<void> {
+		const cacheName = id || props.cacheName;
+		if (!cacheName) return;
+		const token = await mintAdminToken(props, cacheName, ADMIN_DELETE_FLAGS);
+		await withCacheBaseUrl(props, async (baseUrl) => {
+			const path = `/_api/v1/cache-config/${cacheName}`;
+			ensureOk(
+				await atticFetch(baseUrl, token, path, "DELETE"),
+				"DELETE",
+				path,
+			);
+		});
+	},
+};
+
+// ---------------------------------------------------------------------------
+// Token provider
+// ---------------------------------------------------------------------------
+
+const tokenProvider: dynamic.ResourceProvider = {
+	async check(
+		_olds: TokenProviderState,
+		news: TokenProviderInputs,
+	): Promise<dynamic.CheckResult> {
+		const failures: dynamic.CheckFailure[] = [];
+		if (!news.hs256SecretBase64) {
+			failures.push({
+				property: "hs256SecretBase64",
+				reason: "hs256SecretBase64 is required",
+			});
+		}
+		if (!news.sub) {
+			failures.push({ property: "sub", reason: "sub is required" });
+		}
+		if (!news.validitySeconds || news.validitySeconds <= 0) {
+			failures.push({
+				property: "validitySeconds",
+				reason: "validity must be a positive duration",
+			});
+		}
+		return { inputs: news, failures };
+	},
+
+	async diff(
+		_id: string,
+		olds: TokenProviderState,
+		news: TokenProviderInputs,
+	): Promise<dynamic.DiffResult> {
+		// A signed JWT is immutable: any change to a claim input mints a new token,
+		// so every meaningful change is a replacement. The baked exp/nbf/token are
+		// state (not inputs), so a no-op `up` does not churn the token.
+		const replaces: string[] = [];
+		if (olds.hs256SecretBase64 !== news.hs256SecretBase64) {
+			replaces.push("hs256SecretBase64");
+		}
+		if (olds.sub !== news.sub) replaces.push("sub");
+		if (olds.validitySeconds !== news.validitySeconds) {
+			replaces.push("validitySeconds");
+		}
+		if (stableJson(olds.caches ?? {}) !== stableJson(news.caches ?? {})) {
+			replaces.push("caches");
+		}
+		return {
+			changes: replaces.length > 0,
+			replaces,
+			deleteBeforeReplace: false,
+		};
+	},
+
+	async create(inputs: TokenProviderInputs): Promise<dynamic.CreateResult> {
+		const { randomUUID } = await import("node:crypto");
+		const now = Math.floor(Date.now() / 1000);
+		const expiresAt = now + inputs.validitySeconds;
+		const token = await mintAtticToken({
+			secretBase64: inputs.hs256SecretBase64,
+			sub: inputs.sub,
+			issuedAtSeconds: now,
+			expiresAtSeconds: expiresAt,
+			caches: inputs.caches,
+		});
+		// The resource id is a random opaque handle — NEVER the token, which is a
+		// bearer credential and would otherwise sit in plaintext in Pulumi state.
+		return {
+			id: randomUUID(),
+			outs: { ...inputs, token, expiresAt, notBefore: now },
+		};
+	},
+
+	async update(
+		_id: string,
+		_olds: TokenProviderState,
+		news: TokenProviderInputs,
+	): Promise<dynamic.UpdateResult> {
+		// Reached only if diff() ever reports a non-replace change (it does not
+		// today). Re-mint defensively so outputs stay consistent with inputs.
+		const now = Math.floor(Date.now() / 1000);
+		const expiresAt = now + news.validitySeconds;
+		const token = await mintAtticToken({
+			secretBase64: news.hs256SecretBase64,
+			sub: news.sub,
+			issuedAtSeconds: now,
+			expiresAtSeconds: expiresAt,
+			caches: news.caches,
+		});
+		return { outs: { ...news, token, expiresAt, notBefore: now } };
+	},
+
+	async delete(): Promise<void> {
+		// No-op: Attic tokens are stateless JWTs with no server-side record to
+		// remove. A token is invalidated only by its `exp` lapsing or by rotating
+		// the shared HS256 secret (which invalidates every token). Dropping the
+		// resource stops Pulumi from re-issuing it; it cannot revoke a live token.
+	},
+};
+
+// ---------------------------------------------------------------------------
+// Public dynamic resources
+// ---------------------------------------------------------------------------
+
+/** Build the normalized, fully-resolved provider inputs for a cache. */
+function cacheProviderInputs(args: AtticCacheArgs) {
+	return {
+		namespace: args.namespace,
+		hs256SecretBase64: args.hs256SecretBase64,
+		deploymentName: pulumi.output(args.deploymentName ?? "attic"),
+		port: pulumi.output(args.port ?? 8080),
+		cacheName: args.cacheName,
+		isPublic: pulumi.output(args.isPublic ?? true),
+		priority: pulumi.output(args.priority ?? 0),
+		storeDir: pulumi.output(args.storeDir ?? "/nix/store"),
+		upstreamCacheKeyNames: pulumi.output(args.upstreamCacheKeyNames ?? []),
+		retentionPeriodSeconds: pulumi
+			.output(args.retentionPeriodSeconds)
+			.apply((value) => (value === undefined ? "" : value)),
+	};
+}
+
+class AtticCacheRecord extends dynamic.Resource {
+	public readonly publicKey!: Output<string>;
+
+	constructor(
+		name: string,
+		args: ReturnType<typeof cacheProviderInputs>,
+		opts?: DynamicResourceOptions,
+	) {
+		super(cacheProvider, name, { publicKey: undefined, ...args }, opts);
+	}
+}
+
+/**
+ * An Attic binary cache, managed as a first-class Pulumi resource.
+ *
+ * Replaces the `attic-cache-bootstrap` `local.Command`: `create` is find-or-create
+ * (a pre-existing cache is adopted via PATCH, preserving its keypair), and config
+ * changes (`isPublic`, `priority`, `upstreamCacheKeyNames`, retention) reconcile
+ * in place on the next `pulumi up`. Renaming the cache or changing its store dir
+ * triggers a replacement.
+ *
+ * Transport: the provider opens a short-lived port-forward to a ready pod of the
+ * Attic deployment and calls `/_api/v1/cache-config/*` over `localhost`, minting
+ * its own short-lived admin token from the HS256 secret — the same reachability
+ * model as the old `kubectl exec`/`port-forward` script, with no tailnet dependency.
+ */
+export class AtticCache extends pulumi.ComponentResource {
+	public readonly cacheName: pulumi.Output<string>;
+	public readonly publicKey: pulumi.Output<string>;
+
+	constructor(
+		name: string,
+		args: AtticCacheArgs,
+		opts?: pulumi.ComponentResourceOptions,
+	) {
+		super("sector7:attic:Cache", name, args, opts);
+
+		const record = new AtticCacheRecord(
+			`${name}-cache`,
+			cacheProviderInputs(args),
+			{ parent: this, additionalSecretOutputs: ["hs256SecretBase64"] },
+		);
+
+		this.cacheName = pulumi.output(args.cacheName);
+		this.publicKey = record.publicKey;
+		this.registerOutputs({
+			cacheName: this.cacheName,
+			publicKey: this.publicKey,
+		});
+	}
+}
+
+/** Build the normalized, fully-resolved provider inputs for a token. */
+function tokenProviderInputs(args: AtticTokenArgs) {
+	return {
+		hs256SecretBase64: args.hs256SecretBase64,
+		sub: args.sub,
+		validitySeconds: pulumi.output(args.validity).apply(parseDurationSeconds),
+		caches: pulumi.output(args.caches).apply((value) => value ?? {}),
+	};
+}
+
+class AtticTokenRecord extends dynamic.Resource {
+	public readonly token!: Output<string>;
+	public readonly expiresAt!: Output<number>;
+	public readonly notBefore!: Output<number>;
+
+	constructor(
+		name: string,
+		args: ReturnType<typeof tokenProviderInputs>,
+		opts?: DynamicResourceOptions,
+	) {
+		super(
+			tokenProvider,
+			name,
+			{ token: undefined, expiresAt: undefined, notBefore: undefined, ...args },
+			opts,
+		);
+	}
+}
+
+/**
+ * An Attic access token, managed as a first-class Pulumi resource.
+ *
+ * Replaces the `attic-ci-token` `local.Command`. The token is a stateless HS256
+ * JWT minted in-process from the server's signing secret — no server contact and
+ * no port-forward. `exp` is baked at create from `validity`; changing `sub`,
+ * `validity`, `caches`, or the secret mints a new token (a replacement).
+ *
+ * Caveat: a stateless JWT cannot be individually revoked. `delete` is a no-op;
+ * revocation is `exp` lapsing or rotating the shared secret (which invalidates
+ * every token). Prefer short `validity` and least-privilege `caches` scopes.
+ */
+export class AtticToken extends pulumi.ComponentResource {
+	public readonly token: pulumi.Output<string>;
+	public readonly expiresAt: pulumi.Output<number>;
+	public readonly notBefore: pulumi.Output<number>;
+
+	constructor(
+		name: string,
+		args: AtticTokenArgs,
+		opts?: pulumi.ComponentResourceOptions,
+	) {
+		super("sector7:attic:Token", name, args, opts);
+
+		const record = new AtticTokenRecord(
+			`${name}-token`,
+			tokenProviderInputs(args),
+			{ parent: this, additionalSecretOutputs: ["token", "hs256SecretBase64"] },
+		);
+
+		this.token = pulumi.secret(record.token);
+		this.expiresAt = record.expiresAt;
+		this.notBefore = record.notBefore;
+		this.registerOutputs({
+			token: this.token,
+			expiresAt: this.expiresAt,
+			notBefore: this.notBefore,
+		});
+	}
+}

--- a/packages/sector7/attic/admin.ts
+++ b/packages/sector7/attic/admin.ts
@@ -355,6 +355,22 @@ const cacheProvider: dynamic.ResourceProvider = {
 				// Idempotent adoption: reconcile the existing cache's config in place.
 				// POST is create-only, so going through PATCH preserves the keypair —
 				// and thus every client's trusted-public-keys.
+				//
+				// First verify the immutable store_dir matches: buildPatchBody omits
+				// store_dir (a change is modeled as a replacement, not an update), so
+				// adopting a same-named cache that points at a different store dir would
+				// silently record the desired storeDir in state while the remote keeps
+				// its own. Fail loudly instead of misrepresenting drift.
+				const existing = ensureOk(
+					await atticFetch(baseUrl, token, path, "GET"),
+					"GET",
+					path,
+				);
+				if (existing?.store_dir && existing.store_dir !== inputs.storeDir) {
+					throw new Error(
+						`Attic cache "${inputs.cacheName}" already exists with store_dir "${existing.store_dir}", which differs from the requested "${inputs.storeDir}". store_dir is immutable — refusing to adopt; align storeDir or choose a different cacheName.`,
+					);
+				}
 				ensureOk(
 					await atticFetch(
 						baseUrl,
@@ -402,11 +418,11 @@ const cacheProvider: dynamic.ResourceProvider = {
 		const token = await mintAdminToken(props, cacheName, ADMIN_DELETE_FLAGS);
 		await withCacheBaseUrl(props, async (baseUrl) => {
 			const path = `/_api/v1/cache-config/${cacheName}`;
-			ensureOk(
-				await atticFetch(baseUrl, token, path, "DELETE"),
-				"DELETE",
-				path,
-			);
+			const res = await atticFetch(baseUrl, token, path, "DELETE");
+			// Idempotent delete: a cache already removed out of band (404) means the
+			// desired end state is reached, so don't fail `pulumi destroy`/replacement.
+			if (res.status === 404) return;
+			ensureOk(res, "DELETE", path);
 		});
 	},
 };

--- a/packages/sector7/attic/admin.ts
+++ b/packages/sector7/attic/admin.ts
@@ -237,7 +237,15 @@ async function readPublicKey(
 		"GET",
 		path,
 	);
-	return config?.public_key ?? "";
+	// Fail fast on a missing key: silently returning "" would persist an unusable
+	// signing key in state and hide a broken/incompatible Attic API response.
+	const publicKey = config?.public_key;
+	if (typeof publicKey !== "string" || publicKey.length === 0) {
+		throw new Error(
+			`Attic GET ${path} returned no public_key — cannot resolve the cache signing key`,
+		);
+	}
+	return publicKey;
 }
 
 /**
@@ -296,6 +304,19 @@ const cacheProvider: dynamic.ResourceProvider = {
 			if (!news[property]) {
 				failures.push({ property, reason: `${property} is required` });
 			}
+		}
+		// "" means "unset" (server default / Global); any provided retention must be
+		// a positive number of seconds. Catch it at preview rather than on apply.
+		if (
+			news.retentionPeriodSeconds !== "" &&
+			(typeof news.retentionPeriodSeconds !== "number" ||
+				!Number.isFinite(news.retentionPeriodSeconds) ||
+				news.retentionPeriodSeconds <= 0)
+		) {
+			failures.push({
+				property: "retentionPeriodSeconds",
+				reason: "retentionPeriodSeconds must be a positive number of seconds",
+			});
 		}
 		return { inputs: news, failures };
 	},

--- a/packages/sector7/attic/config-types.ts
+++ b/packages/sector7/attic/config-types.ts
@@ -1,0 +1,85 @@
+import type * as pulumi from "@pulumi/pulumi";
+import type { AtticCachePermissionFlags } from "./token.ts";
+
+export type { AtticCacheGrants, AtticCachePermissionFlags } from "./token.ts";
+
+/**
+ * Coordinates + credentials for reaching an Attic server's cache-config HTTP API.
+ *
+ * The `AtticCache` resource opens a short-lived in-process port-forward to a ready
+ * pod of the Attic Deployment and calls `/_api/v1/cache-config/*` over `localhost`.
+ * It mints its own short-lived admin token from `hs256SecretBase64` for those
+ * calls, so the consumer never has to pre-mint one.
+ */
+export interface AtticAdminTargetArgs {
+	/** Namespace the Attic Deployment runs in. */
+	namespace: pulumi.Input<string>;
+	/**
+	 * The Attic server's HS256 signing secret, base64-encoded
+	 * (`ATTIC_SERVER_TOKEN_HS256_SECRET_BASE64`). Pass as a Pulumi secret.
+	 */
+	hs256SecretBase64: pulumi.Input<string>;
+	/**
+	 * Deployment whose ready pod is forwarded to.
+	 * @default "attic"
+	 */
+	deploymentName?: pulumi.Input<string>;
+	/**
+	 * Attic container listen port (the pod port the forward targets — not the
+	 * Service port).
+	 * @default 8080
+	 */
+	port?: pulumi.Input<number>;
+}
+
+export interface AtticCacheArgs extends AtticAdminTargetArgs {
+	/** Cache name (`[A-Za-z0-9][A-Za-z0-9-_+]{0,49}`). */
+	cacheName: pulumi.Input<string>;
+	/**
+	 * Whether the cache is publicly pullable without a token (push still requires
+	 * one).
+	 * @default true
+	 */
+	isPublic?: pulumi.Input<boolean>;
+	/**
+	 * Substituter priority (lower = preferred); surfaced to clients via the cache
+	 * config.
+	 * @default 0
+	 */
+	priority?: pulumi.Input<number>;
+	/**
+	 * Nix store directory the cache serves. Immutable — changing it replaces the
+	 * cache.
+	 * @default "/nix/store"
+	 */
+	storeDir?: pulumi.Input<string>;
+	/** Names of upstream caches whose signing keys are trusted for this cache. */
+	upstreamCacheKeyNames?: pulumi.Input<pulumi.Input<string>[]>;
+	/**
+	 * Retention period in seconds. Omit for the server's global default
+	 * (`Global`); set to a positive number to pin a per-cache period.
+	 */
+	retentionPeriodSeconds?: pulumi.Input<number>;
+}
+
+export interface AtticTokenArgs {
+	/**
+	 * The Attic server's HS256 signing secret, base64-encoded. Pass as a Pulumi
+	 * secret — it is the root credential for the cache.
+	 */
+	hs256SecretBase64: pulumi.Input<string>;
+	/** JWT `sub`: a human-meaningful subject (e.g. "github-actions-ci"). */
+	sub: pulumi.Input<string>;
+	/**
+	 * Token validity: a duration string (`1y`, `90d`, `12h`, `300s`) or a number
+	 * of seconds. Baked into `exp` at create; changing it mints a new token.
+	 */
+	validity: pulumi.Input<string | number>;
+	/**
+	 * Per-cache grants. Keys are cache-name patterns (`*` wildcards allowed);
+	 * values are permission flags. Keys must be plain strings — Pulumi cannot key
+	 * an object on an `Output` — and are normally the same literals passed to
+	 * `AtticCache`.
+	 */
+	caches: Record<string, AtticCachePermissionFlags>;
+}

--- a/packages/sector7/attic/index.ts
+++ b/packages/sector7/attic/index.ts
@@ -1,0 +1,13 @@
+export { AtticCache, AtticToken } from "./admin.ts";
+export type {
+	AtticAdminTargetArgs,
+	AtticCacheArgs,
+	AtticCacheGrants,
+	AtticCachePermissionFlags,
+	AtticTokenArgs,
+} from "./config-types.ts";
+export {
+	ATTIC_CLAIM_NAMESPACE,
+	mintAtticToken,
+	parseDurationSeconds,
+} from "./token.ts";

--- a/packages/sector7/attic/token.ts
+++ b/packages/sector7/attic/token.ts
@@ -1,0 +1,148 @@
+// Pure Attic token (JWT) minting, shared by the AtticToken and AtticCache
+// dynamic resources.
+//
+// Attic auth is a self-contained HS256 JWT signed with the server's shared
+// secret (`ATTIC_SERVER_TOKEN_HS256_SECRET_BASE64`). `atticadm make-token` mints
+// these offline from that secret; the server only verifies the signature. So a
+// token can be produced entirely in-process — no server, no port-forward.
+//
+// SERIALIZATION CONTRACT — do not break:
+// This module MUST have no top-level *runtime* `import` statements. `mintAtticToken`
+// is referenced from the dynamic-resource provider callbacks in `admin.ts`; Pulumi
+// serializes those closures, capturing this function and its module scope. A
+// top-level `import * as crypto from "node:crypto"` would be pulled into every such
+// closure and break serialization. The only Node import is a lazy `await import()`
+// *inside* `mintAtticToken`. `import type` is fine — it is erased at compile time.
+// https://www.pulumi.com/docs/concepts/resources/dynamic-providers/#how-dynamic-providers-are-serialized
+
+/** Custom JWT claim namespace Attic reads authorization from (`token/src/lib.rs`). */
+export const ATTIC_CLAIM_NAMESPACE = "https://jwt.attic.rs/v1";
+
+/**
+ * Per-cache permission flags. Mirrors Attic's `CachePermission`
+ * (`token/src/lib.rs`); each maps to a short serde key in the JWT:
+ *   pull → r, push → w, delete → d, createCache → cc, configureCache → cr,
+ *   configureCacheRetention → cq, destroyCache → cd.
+ * Absent/false flags deny (Attic's lookup is default-deny).
+ */
+export interface AtticCachePermissionFlags {
+	pull?: boolean;
+	push?: boolean;
+	delete?: boolean;
+	createCache?: boolean;
+	configureCache?: boolean;
+	configureCacheRetention?: boolean;
+	destroyCache?: boolean;
+}
+
+/** Map of cache-name pattern (`*` wildcards allowed) → permission flags. */
+export type AtticCacheGrants = Record<string, AtticCachePermissionFlags>;
+
+export interface MintAtticTokenArgs {
+	/** The server's HS256 secret, base64-encoded (decoded to the HMAC key bytes). */
+	secretBase64: string;
+	/** JWT `sub` — a human-meaningful token subject (e.g. "github-actions-ci"). */
+	sub: string;
+	/** JWT `nbf` / not-before, unix seconds. */
+	issuedAtSeconds: number;
+	/** JWT `exp` / expiry, unix seconds. */
+	expiresAtSeconds: number;
+	/** Per-cache grants rendered into the `caches` map of the namespace claim. */
+	caches: AtticCacheGrants;
+}
+
+/** base64url (no padding) of a Buffer — the JWT segment encoding. */
+function base64url(buf: Buffer): string {
+	return buf
+		.toString("base64")
+		.replace(/\+/g, "-")
+		.replace(/\//g, "_")
+		.replace(/=+$/, "");
+}
+
+/**
+ * Render permission flags into Attic's short-key form, emitting only the flags
+ * that are `true` (matching `atticadm`'s minimal output; absent = deny).
+ */
+function permissionClaim(
+	flags: AtticCachePermissionFlags,
+): Record<string, boolean> {
+	const out: Record<string, boolean> = {};
+	if (flags.pull) out.r = true;
+	if (flags.push) out.w = true;
+	if (flags.delete) out.d = true;
+	if (flags.createCache) out.cc = true;
+	if (flags.configureCache) out.cr = true;
+	if (flags.configureCacheRetention) out.cq = true;
+	if (flags.destroyCache) out.cd = true;
+	return out;
+}
+
+/**
+ * Mint a signed Attic-compatible HS256 JWT entirely in-process.
+ *
+ * Emits the minimal claim set `atticadm` produces — `sub`, `nbf`, `exp`, and the
+ * `https://jwt.attic.rs/v1` namespace claim with a `caches` map — and signs it
+ * with HMAC-SHA256 over the **base64-decoded** secret bytes. No `iss`/`aud`/`iat`:
+ * Attic only enforces issuer/audience when the server is configured with a bound
+ * issuer/audience (garden's is not), and leaves `iat` unset itself.
+ */
+export async function mintAtticToken(
+	args: MintAtticTokenArgs,
+): Promise<string> {
+	const crypto = await import("node:crypto");
+
+	const header = { alg: "HS256", typ: "JWT" };
+	const caches: Record<string, Record<string, boolean>> = {};
+	for (const [pattern, flags] of Object.entries(args.caches)) {
+		caches[pattern] = permissionClaim(flags);
+	}
+	const payload = {
+		sub: args.sub,
+		nbf: args.issuedAtSeconds,
+		exp: args.expiresAtSeconds,
+		[ATTIC_CLAIM_NAMESPACE]: { caches },
+	};
+
+	const signingInput = `${base64url(Buffer.from(JSON.stringify(header)))}.${base64url(
+		Buffer.from(JSON.stringify(payload)),
+	)}`;
+	const key = Buffer.from(args.secretBase64, "base64");
+	const signature = crypto
+		.createHmac("sha256", key)
+		.update(signingInput)
+		.digest();
+	return `${signingInput}.${base64url(signature)}`;
+}
+
+const UNIT_SECONDS: Record<string, number> = {
+	s: 1,
+	m: 60,
+	h: 3600,
+	d: 86400,
+	w: 604800,
+	y: 31536000,
+};
+
+/**
+ * Parse a token validity into seconds. Accepts a bare number (already seconds)
+ * or a `<n><unit>` duration with unit `s`/`m`/`h`/`d`/`w`/`y` (e.g. `1y`, `90d`,
+ * `12h`, `300s`). A bare numeric string is treated as seconds.
+ */
+export function parseDurationSeconds(input: string | number): number {
+	if (typeof input === "number") {
+		if (!Number.isFinite(input) || input <= 0) {
+			throw new Error(`invalid validity: ${input}`);
+		}
+		return Math.floor(input);
+	}
+	const match = /^(\d+)\s*(s|m|h|d|w|y)?$/.exec(input.trim());
+	if (!match) {
+		throw new Error(
+			`invalid validity duration: "${input}" (expected e.g. "1y", "90d", "12h", or seconds)`,
+		);
+	}
+	const n = Number.parseInt(match[1], 10);
+	const unit = match[2] ?? "s";
+	return n * UNIT_SECONDS[unit];
+}

--- a/packages/sector7/attic/token.ts
+++ b/packages/sector7/attic/token.ts
@@ -108,6 +108,14 @@ export async function mintAtticToken(
 		Buffer.from(JSON.stringify(payload)),
 	)}`;
 	const key = Buffer.from(args.secretBase64, "base64");
+	// Fail closed on an empty/undecodable secret: Buffer.from(_, "base64") is
+	// permissive (garbage → empty/short buffer), which would otherwise mint a
+	// token signed with a bad key and hide that the root credential is invalid.
+	if (key.length === 0) {
+		throw new Error(
+			"invalid hs256 secret: decoded to empty bytes (expected a base64-encoded signing secret)",
+		);
+	}
 	const signature = crypto
 		.createHmac("sha256", key)
 		.update(signingInput)
@@ -143,12 +151,17 @@ export function parseDurationSeconds(input: string | number): number {
 		);
 	}
 	const n = Number.parseInt(match[1], 10);
-	// Reject non-positive string durations ("0", "0s") too — the numeric branch
-	// already does, and a zero/expired validity would mint an immediately-dead
-	// token anywhere this helper is used outside the provider's check().
-	if (n <= 0) {
+	// Reject non-positive / non-finite string durations ("0", "0s", or a digit
+	// string so long it overflows to Infinity) — the numeric branch already does.
+	// A zero/expired or non-finite validity mints an immediately-dead or invalid
+	// (exp → null) token anywhere this helper is used outside the provider check().
+	if (!Number.isFinite(n) || n <= 0) {
 		throw new Error(`invalid validity duration: "${input}" (must be positive)`);
 	}
 	const unit = match[2] ?? "s";
-	return n * UNIT_SECONDS[unit];
+	const seconds = n * UNIT_SECONDS[unit];
+	if (!Number.isFinite(seconds)) {
+		throw new Error(`validity duration too large: "${input}"`);
+	}
+	return seconds;
 }

--- a/packages/sector7/attic/token.ts
+++ b/packages/sector7/attic/token.ts
@@ -143,6 +143,12 @@ export function parseDurationSeconds(input: string | number): number {
 		);
 	}
 	const n = Number.parseInt(match[1], 10);
+	// Reject non-positive string durations ("0", "0s") too — the numeric branch
+	// already does, and a zero/expired validity would mint an immediately-dead
+	// token anywhere this helper is used outside the provider's check().
+	if (n <= 0) {
+		throw new Error(`invalid validity duration: "${input}" (must be positive)`);
+	}
 	const unit = match[2] ?? "s";
 	return n * UNIT_SECONDS[unit];
 }

--- a/packages/sector7/barrel-guard.ts
+++ b/packages/sector7/barrel-guard.ts
@@ -8,3 +8,6 @@ void root.cloudsql;
 
 // @ts-expect-error OnePassword write resource lives on the ./onepassword subpath, not the root barrel
 void root.onepassword;
+
+// @ts-expect-error Attic cache/token resources live on the ./attic subpath, not the root barrel
+void root.attic;

--- a/packages/sector7/package.json
+++ b/packages/sector7/package.json
@@ -70,6 +70,10 @@
 		"./gateway": {
 			"types": "./dist/gateway/index.d.ts",
 			"default": "./dist/gateway/index.js"
+		},
+		"./attic": {
+			"types": "./dist/attic/index.d.ts",
+			"default": "./dist/attic/index.js"
 		}
 	},
 	"files": [

--- a/packages/sector7/tests/attic.test.ts
+++ b/packages/sector7/tests/attic.test.ts
@@ -118,7 +118,11 @@ vi.mock("node:net", () => ({
 }));
 
 import { AtticCache, AtticToken } from "../attic/admin.ts";
-import { ATTIC_CLAIM_NAMESPACE, parseDurationSeconds } from "../attic/token.ts";
+import {
+	ATTIC_CLAIM_NAMESPACE,
+	mintAtticToken,
+	parseDurationSeconds,
+} from "../attic/token.ts";
 
 const SECRET_B64 = Buffer.from("attic-test-signing-secret").toString("base64");
 
@@ -491,6 +495,28 @@ describe("AtticToken provider", () => {
 			tokenProvider.delete("id", { ...tokenInputs, token: "x" }),
 		).resolves.toBeUndefined();
 	});
+
+	it("rejects a non-finite validity in check (would serialize exp as null)", async () => {
+		const res = await tokenProvider.check(
+			{},
+			{ ...tokenInputs, validitySeconds: Number.POSITIVE_INFINITY },
+		);
+		expect(res.failures.map((f) => f.property)).toContain("validitySeconds");
+	});
+});
+
+describe("mintAtticToken", () => {
+	it("fails closed on an empty/undecodable signing secret", async () => {
+		await expect(
+			mintAtticToken({
+				secretBase64: "",
+				sub: "x",
+				issuedAtSeconds: 0,
+				expiresAtSeconds: 1,
+				caches: {},
+			}),
+		).rejects.toThrow(/hs256 secret/);
+	});
 });
 
 describe("parseDurationSeconds", () => {
@@ -508,5 +534,6 @@ describe("parseDurationSeconds", () => {
 		expect(() => parseDurationSeconds(0)).toThrow();
 		expect(() => parseDurationSeconds("0")).toThrow();
 		expect(() => parseDurationSeconds("0s")).toThrow();
+		expect(() => parseDurationSeconds("9".repeat(400))).toThrow();
 	});
 });

--- a/packages/sector7/tests/attic.test.ts
+++ b/packages/sector7/tests/attic.test.ts
@@ -342,6 +342,49 @@ describe("AtticCache provider — lifecycle", () => {
 		).resolves.toBeUndefined();
 		expect(calls[0].method).toBe("DELETE");
 	});
+
+	it("fails fast when the cache config has no public_key", async () => {
+		installFetch((_path, method) => {
+			if (method === "POST") return { status: 200, body: {} };
+			if (method === "GET") return { body: {} }; // missing public_key
+			return {};
+		});
+		await expect(cacheProvider.create(cacheInputs())).rejects.toThrow(
+			/public_key/,
+		);
+	});
+});
+
+describe("AtticCache provider — check", () => {
+	it("rejects a non-positive retention period", async () => {
+		const res = await cacheProvider.check(
+			{},
+			{ ...cacheInputs(), retentionPeriodSeconds: 0 },
+		);
+		expect(res.failures.map((f) => f.property)).toContain(
+			"retentionPeriodSeconds",
+		);
+	});
+
+	it("accepts an unset or positive retention period", async () => {
+		const unset = await cacheProvider.check({}, cacheInputs());
+		expect(unset.failures).toEqual([]);
+		const positive = await cacheProvider.check(
+			{},
+			{ ...cacheInputs(), retentionPeriodSeconds: 86400 },
+		);
+		expect(positive.failures).toEqual([]);
+	});
+
+	it("flags missing required fields", async () => {
+		const res = await cacheProvider.check(
+			{},
+			{ ...cacheInputs(), namespace: "", cacheName: "" },
+		);
+		const props = res.failures.map((f) => f.property);
+		expect(props).toContain("namespace");
+		expect(props).toContain("cacheName");
+	});
 });
 
 describe("AtticToken provider", () => {

--- a/packages/sector7/tests/attic.test.ts
+++ b/packages/sector7/tests/attic.test.ts
@@ -268,16 +268,31 @@ describe("AtticCache provider — lifecycle", () => {
 			if (method === "POST")
 				return { status: 400, body: "Error: CacheAlreadyExists" };
 			if (method === "PATCH") return { body: {} };
-			if (method === "GET") return { body: { public_key: "pk:existing" } };
+			if (method === "GET")
+				return { body: { public_key: "pk:existing", store_dir: "/nix/store" } };
 			return {};
 		});
 		const result = await cacheProvider.create(cacheInputs());
 		expect(result.outs.publicKey).toBe("pk:existing");
 		const methods = calls.map((c) => c.method);
-		expect(methods).toEqual(["POST", "PATCH", "GET"]);
-		// Adoption must reconcile via PATCH, never re-POST (which would regenerate
-		// the keypair).
-		expect(calls[1].body).toMatchObject({ is_public: true, priority: 0 });
+		// Adoption GETs to verify the immutable store_dir, then reconciles via PATCH
+		// (never re-POST, which would regenerate the keypair), then re-reads the key.
+		expect(methods).toEqual(["POST", "GET", "PATCH", "GET"]);
+		const patch = calls.find((c) => c.method === "PATCH");
+		expect(patch?.body).toMatchObject({ is_public: true, priority: 0 });
+	});
+
+	it("refuses to adopt a cache whose immutable store_dir differs", async () => {
+		installFetch((_path, method) => {
+			if (method === "POST")
+				return { status: 400, body: "Error: CacheAlreadyExists" };
+			if (method === "GET")
+				return { body: { public_key: "pk", store_dir: "/alt/store" } };
+			return {};
+		});
+		await expect(cacheProvider.create(cacheInputs())).rejects.toThrow(
+			/store_dir/,
+		);
 	});
 
 	it("PATCHes a fresh cache's retention when requested", async () => {
@@ -318,6 +333,14 @@ describe("AtticCache provider — lifecycle", () => {
 		expect(calls).toHaveLength(1);
 		expect(calls[0].method).toBe("DELETE");
 		expect(calls[0].path).toBe("/_api/v1/cache-config/mycache");
+	});
+
+	it("treats a 404 on delete as success (idempotent under drift)", async () => {
+		const calls = installFetch(() => ({ status: 404, body: "NoSuchCache" }));
+		await expect(
+			cacheProvider.delete("mycache", { ...cacheInputs(), publicKey: "pk:1" }),
+		).resolves.toBeUndefined();
+		expect(calls[0].method).toBe("DELETE");
 	});
 });
 
@@ -425,8 +448,10 @@ describe("parseDurationSeconds", () => {
 		expect(parseDurationSeconds(300)).toBe(300);
 	});
 
-	it("rejects malformed durations", () => {
+	it("rejects malformed and non-positive durations", () => {
 		expect(() => parseDurationSeconds("soon")).toThrow();
 		expect(() => parseDurationSeconds(0)).toThrow();
+		expect(() => parseDurationSeconds("0")).toThrow();
+		expect(() => parseDurationSeconds("0s")).toThrow();
 	});
 });

--- a/packages/sector7/tests/attic.test.ts
+++ b/packages/sector7/tests/attic.test.ts
@@ -295,6 +295,18 @@ describe("AtticCache provider — lifecycle", () => {
 		);
 	});
 
+	it("refuses to adopt when the existing store_dir is unverifiable", async () => {
+		installFetch((_path, method) => {
+			if (method === "POST")
+				return { status: 400, body: "Error: CacheAlreadyExists" };
+			if (method === "GET") return { body: { public_key: "pk" } }; // no store_dir
+			return {};
+		});
+		await expect(cacheProvider.create(cacheInputs())).rejects.toThrow(
+			/store_dir/,
+		);
+	});
+
 	it("PATCHes a fresh cache's retention when requested", async () => {
 		const calls = installFetch((_path, method) => {
 			if (method === "POST") return { status: 200, body: { public_key: "pk" } };

--- a/packages/sector7/tests/attic.test.ts
+++ b/packages/sector7/tests/attic.test.ts
@@ -1,0 +1,432 @@
+import * as crypto from "node:crypto";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Mocks (same capture pattern as litellm-admin.test.ts)
+//
+// AtticCache / AtticToken are ComponentResources that each construct an inner
+// `dynamic.Resource`. We mock @pulumi/pulumi to (a) make the component
+// constructors inert and (b) capture the ResourceProvider passed to
+// dynamic.Resource's super(), then exercise the provider directly.
+//
+// The cache provider opens a port-forward and `fetch`es the cache-config API; we
+// stub @kubernetes/client-node and node:net so it yields a local base URL without
+// a real cluster, and stub global fetch to capture the calls. The token provider
+// needs neither — it mints a JWT in-process via the real node:crypto.
+// ---------------------------------------------------------------------------
+
+type Provider = {
+	check: (
+		olds: Record<string, unknown>,
+		news: Record<string, unknown>,
+	) => Promise<{
+		inputs: Record<string, unknown>;
+		failures: Array<{ property: string; reason: string }>;
+	}>;
+	diff: (
+		id: string,
+		olds: Record<string, unknown>,
+		news: Record<string, unknown>,
+	) => Promise<{ changes: boolean; replaces?: string[] }>;
+	create: (inputs: Record<string, unknown>) => Promise<{
+		id: string;
+		outs: Record<string, unknown>;
+	}>;
+	update: (
+		id: string,
+		olds: Record<string, unknown>,
+		news: Record<string, unknown>,
+	) => Promise<{ outs: Record<string, unknown> }>;
+	delete: (id: string, props: Record<string, unknown>) => Promise<void>;
+};
+
+const capturedProviders: Provider[] = [];
+
+vi.mock("@pulumi/pulumi", () => {
+	// biome-ignore lint/suspicious/noExplicitAny: minimal Output stand-in for tests
+	const output = (value: any): any => ({
+		// biome-ignore lint/suspicious/noExplicitAny: identity apply for tests
+		apply: (fn: (v: any) => any) => output(fn(value)),
+	});
+	return {
+		ComponentResource: class {
+			registerOutputs() {}
+		},
+		dynamic: {
+			Resource: class {
+				constructor(provider: Provider) {
+					capturedProviders.push(provider);
+				}
+			},
+		},
+		output,
+		// biome-ignore lint/suspicious/noExplicitAny: identity for tests
+		secret: (v: any) => v,
+	};
+});
+
+const apiStubs = {
+	readNamespacedDeployment: vi.fn().mockResolvedValue({
+		spec: { selector: { matchLabels: { app: "attic" } } },
+	}),
+	listNamespacedPod: vi.fn().mockResolvedValue({
+		items: [
+			{
+				metadata: { name: "attic-pod-1" },
+				status: {
+					phase: "Running",
+					conditions: [{ type: "Ready", status: "True" }],
+				},
+			},
+		],
+	}),
+};
+
+vi.mock("@kubernetes/client-node", () => ({
+	KubeConfig: class {
+		loadFromDefault() {}
+		makeApiClient(_ctor: { name: string }) {
+			return apiStubs;
+		}
+	},
+	AppsV1Api: class AppsV1Api {},
+	CoreV1Api: class CoreV1Api {},
+	PortForward: class {
+		portForward() {
+			return Promise.resolve();
+		}
+	},
+}));
+
+vi.mock("node:net", () => ({
+	createServer: () => {
+		const server = {
+			// biome-ignore lint/suspicious/noExplicitAny: minimal EventEmitter-ish stub
+			once: (_event: string, _cb: any) => server,
+			listen: (_port: number, _host: string, cb: () => void) => {
+				cb();
+				return server;
+			},
+			address: () => ({ port: 41000 }),
+			close: (cb?: () => void) => {
+				cb?.();
+				return server;
+			},
+		};
+		return server;
+	},
+}));
+
+import { AtticCache, AtticToken } from "../attic/admin.ts";
+import { ATTIC_CLAIM_NAMESPACE, parseDurationSeconds } from "../attic/token.ts";
+
+const SECRET_B64 = Buffer.from("attic-test-signing-secret").toString("base64");
+
+const cacheTarget = {
+	namespace: "attic-prod",
+	hs256SecretBase64: SECRET_B64,
+	deploymentName: "attic",
+	port: 8080,
+};
+
+function cacheInputs(overrides: Record<string, unknown> = {}) {
+	return {
+		...cacheTarget,
+		cacheName: "mycache",
+		isPublic: true,
+		priority: 0,
+		storeDir: "/nix/store",
+		upstreamCacheKeyNames: [] as string[],
+		retentionPeriodSeconds: "" as number | "",
+		...overrides,
+	};
+}
+
+// A mock fetch returning canned cache-config responses; responder may set a
+// status (defaults 200) and a body (object → JSON, string → raw text).
+function installFetch(
+	responder: (
+		path: string,
+		method: string,
+		body: unknown,
+	) => { status?: number; body?: unknown } | undefined,
+) {
+	const calls: Array<{ path: string; method: string; body: unknown }> = [];
+	const mock = vi.fn(async (url: string, init?: RequestInit) => {
+		const path = url.replace(/^http:\/\/127\.0\.0\.1:\d+/, "");
+		const method = init?.method ?? "GET";
+		const body = init?.body ? JSON.parse(init.body as string) : undefined;
+		calls.push({ path, method, body });
+		const r = responder(path, method, body) ?? {};
+		const status = r.status ?? 200;
+		const payload = r.body ?? {};
+		return {
+			ok: status >= 200 && status < 300,
+			status,
+			statusText: "",
+			text: async () =>
+				typeof payload === "string" ? payload : JSON.stringify(payload),
+		} as Response;
+	});
+	vi.stubGlobal("fetch", mock);
+	return calls;
+}
+
+let cacheProvider: Provider;
+let tokenProvider: Provider;
+
+beforeEach(() => {
+	capturedProviders.length = 0;
+	new AtticCache("c", {
+		...cacheTarget,
+		cacheName: "mycache",
+	});
+	new AtticToken("t", {
+		hs256SecretBase64: SECRET_B64,
+		sub: "github-actions-ci",
+		validity: "1y",
+		caches: { mycache: { pull: true, push: true } },
+	});
+	[cacheProvider, tokenProvider] = capturedProviders;
+	vi.unstubAllGlobals();
+});
+
+describe("AtticCache provider — diff", () => {
+	it("treats a config change as an in-place update (no replacement)", async () => {
+		const olds = { ...cacheInputs(), publicKey: "pk:1" };
+		const result = await cacheProvider.diff("mycache", olds, {
+			...cacheInputs(),
+			priority: 41,
+		});
+		expect(result.changes).toBe(true);
+		expect(result.replaces ?? []).toEqual([]);
+	});
+
+	it("ignores upstream-key ordering", async () => {
+		const olds = {
+			...cacheInputs({ upstreamCacheKeyNames: ["a", "b", "c"] }),
+			publicKey: "pk:1",
+		};
+		const result = await cacheProvider.diff("mycache", olds, {
+			...cacheInputs({ upstreamCacheKeyNames: ["c", "a", "b"] }),
+		});
+		expect(result.changes).toBe(false);
+	});
+
+	it("replaces when the cache name changes", async () => {
+		const olds = { ...cacheInputs(), publicKey: "pk:1" };
+		const result = await cacheProvider.diff("mycache", olds, {
+			...cacheInputs(),
+			cacheName: "othercache",
+		});
+		expect(result.replaces).toEqual(["cacheName"]);
+	});
+
+	it("replaces when the store dir changes", async () => {
+		const olds = { ...cacheInputs(), publicKey: "pk:1" };
+		const result = await cacheProvider.diff("mycache", olds, {
+			...cacheInputs(),
+			storeDir: "/alt/store",
+		});
+		expect(result.replaces).toEqual(["storeDir"]);
+	});
+
+	it("treats an admin-target change as an in-place update", async () => {
+		const olds = { ...cacheInputs(), publicKey: "pk:1" };
+		const result = await cacheProvider.diff("mycache", olds, {
+			...cacheInputs(),
+			hs256SecretBase64: Buffer.from("rotated").toString("base64"),
+			deploymentName: "attic-canary",
+		});
+		expect(result.changes).toBe(true);
+		expect(result.replaces ?? []).toEqual([]);
+	});
+});
+
+describe("AtticCache provider — lifecycle", () => {
+	it("creates a fresh cache and reads back its public key", async () => {
+		const calls = installFetch((_path, method) => {
+			if (method === "POST")
+				return { status: 200, body: { public_key: "pk:new" } };
+			if (method === "GET") return { body: { public_key: "pk:new" } };
+			return {};
+		});
+		const result = await cacheProvider.create(cacheInputs());
+		expect(result.id).toBe("mycache");
+		expect(result.outs.publicKey).toBe("pk:new");
+		const methods = calls.map((c) => c.method);
+		expect(methods).toEqual(["POST", "GET"]);
+		expect(calls[0].path).toBe("/_api/v1/cache-config/mycache");
+		expect(calls[0].body).toMatchObject({
+			keypair: "Generate",
+			is_public: true,
+		});
+	});
+
+	it("adopts an existing cache via PATCH on CacheAlreadyExists", async () => {
+		const calls = installFetch((_path, method) => {
+			if (method === "POST")
+				return { status: 400, body: "Error: CacheAlreadyExists" };
+			if (method === "PATCH") return { body: {} };
+			if (method === "GET") return { body: { public_key: "pk:existing" } };
+			return {};
+		});
+		const result = await cacheProvider.create(cacheInputs());
+		expect(result.outs.publicKey).toBe("pk:existing");
+		const methods = calls.map((c) => c.method);
+		expect(methods).toEqual(["POST", "PATCH", "GET"]);
+		// Adoption must reconcile via PATCH, never re-POST (which would regenerate
+		// the keypair).
+		expect(calls[1].body).toMatchObject({ is_public: true, priority: 0 });
+	});
+
+	it("PATCHes a fresh cache's retention when requested", async () => {
+		const calls = installFetch((_path, method) => {
+			if (method === "POST") return { status: 200, body: { public_key: "pk" } };
+			if (method === "PATCH") return { body: {} };
+			if (method === "GET") return { body: { public_key: "pk" } };
+			return {};
+		});
+		await cacheProvider.create(cacheInputs({ retentionPeriodSeconds: 86400 }));
+		const patch = calls.find((c) => c.method === "PATCH");
+		expect(patch?.body).toMatchObject({ retention_period: { Period: 86400 } });
+	});
+
+	it("updates a cache via PATCH and re-reads the public key", async () => {
+		const calls = installFetch((_path, method) => {
+			if (method === "PATCH") return { body: {} };
+			if (method === "GET") return { body: { public_key: "pk:2" } };
+			return {};
+		});
+		const olds = { ...cacheInputs(), publicKey: "pk:1" };
+		const result = await cacheProvider.update("mycache", olds, {
+			...cacheInputs(),
+			priority: 10,
+		});
+		expect(result.outs.publicKey).toBe("pk:2");
+		const methods = calls.map((c) => c.method);
+		expect(methods).toEqual(["PATCH", "GET"]);
+		expect(calls[0].body).toMatchObject({ priority: 10 });
+	});
+
+	it("deletes a cache via DELETE", async () => {
+		const calls = installFetch(() => ({ body: {} }));
+		await cacheProvider.delete("mycache", {
+			...cacheInputs(),
+			publicKey: "pk:1",
+		});
+		expect(calls).toHaveLength(1);
+		expect(calls[0].method).toBe("DELETE");
+		expect(calls[0].path).toBe("/_api/v1/cache-config/mycache");
+	});
+});
+
+describe("AtticToken provider", () => {
+	const tokenInputs = {
+		hs256SecretBase64: SECRET_B64,
+		sub: "github-actions-ci",
+		validitySeconds: 3600,
+		caches: { mycache: { pull: true, push: true } },
+	};
+
+	function decodeSegment(seg: string): Record<string, unknown> {
+		return JSON.parse(Buffer.from(seg, "base64url").toString("utf8"));
+	}
+
+	it("mints a verifiable JWT with the Attic claim shape, not leaking it into the id", async () => {
+		const result = await tokenProvider.create(tokenInputs);
+		const token = result.outs.token as string;
+		const [headerSeg, payloadSeg, signatureSeg] = token.split(".");
+
+		// id is an opaque uuid, never the token itself.
+		expect(result.id).not.toContain(token);
+		expect(result.id).toMatch(/^[0-9a-f-]{36}$/);
+
+		// Signature verifies against the base64-decoded secret.
+		const expected = crypto
+			.createHmac("sha256", Buffer.from(SECRET_B64, "base64"))
+			.update(`${headerSeg}.${payloadSeg}`)
+			.digest("base64url");
+		expect(signatureSeg).toBe(expected);
+
+		expect(decodeSegment(headerSeg)).toMatchObject({
+			alg: "HS256",
+			typ: "JWT",
+		});
+		const payload = decodeSegment(payloadSeg);
+		expect(payload.sub).toBe("github-actions-ci");
+		expect(payload.exp).toBe((payload.nbf as number) + 3600);
+		expect(result.outs.expiresAt).toBe(
+			(result.outs.notBefore as number) + 3600,
+		);
+		// Permission short-keys under the Attic namespace claim.
+		expect(payload[ATTIC_CLAIM_NAMESPACE]).toEqual({
+			caches: { mycache: { r: true, w: true } },
+		});
+	});
+
+	it("emits only the granted permission flags", async () => {
+		const result = await tokenProvider.create({
+			...tokenInputs,
+			caches: { "team-*": { pull: true, createCache: true } },
+		});
+		const payload = decodeSegment((result.outs.token as string).split(".")[1]);
+		expect(payload[ATTIC_CLAIM_NAMESPACE]).toEqual({
+			caches: { "team-*": { r: true, cc: true } },
+		});
+	});
+
+	it("replaces on any claim-affecting input change", async () => {
+		const olds = {
+			...tokenInputs,
+			token: "old",
+			expiresAt: 1,
+			notBefore: 0,
+		};
+		expect((await tokenProvider.diff("id", olds, tokenInputs)).changes).toBe(
+			false,
+		);
+		expect(
+			(await tokenProvider.diff("id", olds, { ...tokenInputs, sub: "other" }))
+				.replaces,
+		).toEqual(["sub"]);
+		expect(
+			(
+				await tokenProvider.diff("id", olds, {
+					...tokenInputs,
+					validitySeconds: 7200,
+				})
+			).replaces,
+		).toEqual(["validitySeconds"]);
+		expect(
+			(
+				await tokenProvider.diff("id", olds, {
+					...tokenInputs,
+					caches: { mycache: { pull: true } },
+				})
+			).replaces,
+		).toEqual(["caches"]);
+	});
+
+	it("delete is a no-op (stateless JWT cannot be revoked)", async () => {
+		await expect(
+			tokenProvider.delete("id", { ...tokenInputs, token: "x" }),
+		).resolves.toBeUndefined();
+	});
+});
+
+describe("parseDurationSeconds", () => {
+	it("parses duration units and bare seconds", () => {
+		expect(parseDurationSeconds("1y")).toBe(31536000);
+		expect(parseDurationSeconds("90d")).toBe(7776000);
+		expect(parseDurationSeconds("12h")).toBe(43200);
+		expect(parseDurationSeconds("300s")).toBe(300);
+		expect(parseDurationSeconds("300")).toBe(300);
+		expect(parseDurationSeconds(300)).toBe(300);
+	});
+
+	it("rejects malformed durations", () => {
+		expect(() => parseDurationSeconds("soon")).toThrow();
+		expect(() => parseDurationSeconds(0)).toThrow();
+	});
+});


### PR DESCRIPTION
## Summary

Adds two first-class Pulumi **dynamic resources** to sector7 for managing the [Attic](https://github.com/zhaofengli/attic) Nix binary cache, mirroring the LiteLLM `Team`/`ApiKey` pattern from #258 (ADR-026). This replaces garden's two brittle `@pulumi/command` `local.Command` shells (`attic-cache-bootstrap` + `attic-ci-token`) that today manage a single hardcoded cache and a single token with no update path.

Design recorded in **ADR-032** (`docs/internal/designs/032-attic-cache-token-resources.md`).

### `AtticCache` — `sector7:attic:Cache`
- **find-or-create** over the cache-config HTTP API (`GET/POST/PATCH/DELETE /_api/v1/cache-config/{cache}`), reached via the shared in-process **port-forward** transport (`k8s/port-forward.ts`) — no tailnet/public ingress, rides the apiserver the deployer already authenticates to.
- Mints its **own** short-lived, least-privilege admin token from the HS256 secret per operation (the consumer only supplies the secret).
- Adoption on `400 CacheAlreadyExists` reconciles via `PATCH` (never re-POST), so an existing cache **keeps its keypair** — and every client's `trusted-public-keys`.
- In-place config updates (`isPublic`, `priority`, `upstreamCacheKeyNames`, retention); replacement only on `cacheName` / `storeDir`. Admin-target changes flow in-place.

### `AtticToken` — `sector7:attic:Token`
- Attic tokens are **stateless HS256 JWTs** — there is no token API. The resource mints one **in-process** from the signing secret (no server contact, no port-forward), baking `exp` from `validity` at create.
- The token is a **secret** output; the resource id is a random UUID (the bearer token never lands in plaintext state).
- Any claim-affecting change (`sub`, `validity`, `caches`, secret) replaces. `delete` is a **no-op** — a stateless JWT can only be revoked by expiry or by rotating the shared secret (which invalidates *all* tokens). This caveat is documented in the ADR and code.

### Supporting
- Pure JWT helper (`attic/token.ts`) honoring the closure-serialization contract (lazy `node:crypto`, no top-level runtime imports).
- `./attic` subpath export (kept out of the root barrel — pulls in `@kubernetes/client-node`) + `barrel-guard.ts` assertion.

## Test plan
- `tsc -p tsconfig.json` — clean.
- `biome check attic tests/attic.test.ts barrel-guard.ts` — clean.
- `vitest run` — **248/248** pass (16 new attic cases in `tests/attic.test.ts`, mirroring `litellm-admin.test.ts`): cache diff (in-place vs replace vs admin-target), create-new, adopt-on-`CacheAlreadyExists`, retention PATCH, update, delete; token JWT signature/claim-shape verification, replace-on-any-change, no-op delete; duration parsing.
- `pnpm run build` — emits `dist/attic/` (`./attic` subpath resolves).

## Risks / follow-ups
- **No individual token revocation** (inherent to Attic's stateless-JWT design) — mitigated by short `validity` + least-privilege `caches` scopes; documented.
- **`exp` baked at create does not auto-renew** — same behavior as today's `atticadm --validity 1y` shell; renewal is `pulumi up --replace`. A `renewBefore` knob is a possible future addition.
- The `KeypairConfig` (`"Generate"`) / `RetentionPeriodConfig` (`"Global"` vs `{ "Period": n }`) enum **wire formats** are confirmed from upstream source but warrant **one live create→get round-trip** against the deployed cache before relying on retention.
- **Consumer wiring is a separate garden PR**: swapping `deploy/services/attic/index.ts`'s two `local.Command`s for `AtticCache` + `AtticToken`, preserving the existing `cache` cache via adoption.

## Links
- ADR-032 (this PR) · ADR-026 / #258 (LiteLLM dynamic-resource + transport precedent) · ADR-031 (OnePassword write resource precedent)
- garden ADR 046 (attic deployment) · garden ADR 071 (CI cache contract)

🤖 Generated with [Claude Code](https://claude.com/claude-code)