### PR TITLE
feat(renovate): ignore docs/ paths for dependency updates

### DIFF
--- a/renovate/default.json
+++ b/renovate/default.json
@@ -14,6 +14,7 @@
 	"prHourlyLimit": 10,
 	"prConcurrentLimit": 5,
 	"rebaseWhen": "conflicted",
+	"ignorePaths": ["**/docs/**"],
 	"automergeType": "pr",
 	"automergeStrategy": "merge",
 	"platformAutomerge": false,

--- a/renovate/default.json
+++ b/renovate/default.json
@@ -14,7 +14,6 @@
 	"prHourlyLimit": 10,
 	"prConcurrentLimit": 5,
 	"rebaseWhen": "conflicted",
-	"ignorePaths": ["**/docs/**"],
 	"automergeType": "pr",
 	"automergeStrategy": "merge",
 	"platformAutomerge": false,
@@ -45,8 +44,13 @@
 			"pinDigests": false
 		},
 		{
-			"description": "Disable requires-python updates \u2014 managed manually per project as a capped minor range (e.g. >=3.13,<3.14)",
+			"description": "Disable requires-python updates — managed manually per project as a capped minor range (e.g. >=3.13,<3.14)",
 			"matchDepTypes": ["requires-python"],
+			"enabled": false
+		},
+		{
+			"description": "Skip dependency updates under docs/ directories — archived reference material not actively maintained",
+			"matchFileNames": ["**/docs/**"],
 			"enabled": false
 		}
 	]


### PR DESCRIPTION
## Summary

Add `ignorePaths: ["**/docs/**"]` to the shared default Renovate preset so that all consumers automatically skip dependency updates under any `docs/` directory.

## Why

Code under `docs/` directories is typically archived reference material or generated documentation that is not actively maintained. Renovate should not attempt to keep its dependencies current.

Triggered by cavinsresearch/zeus#833 where Renovate bumped `mypy` inside `tools/frec/docs/reverse-engineering/setup.py` — a frozen reverse-engineering reference file.

## Scope

- Applies to all repos extending `renovate/default.json` (directly or via `all.json`), including zeus, garden, yard, jackpkgs.
- Root-level `docs/` directories (e.g., zeus `docs/internal/decisions/`) are also ignored, but verified to contain no dependency manifests, so no functional impact.
- Pattern `**/docs/**` matches any `docs/` subtree at any depth.

## Testing

- Renovate JSON lint validated by the existing sector7 CI tsc check (passed locally).
- After merge, zeus #833 can be closed and Renovate will recreate it without the docs file.