### PR TITLE
fix(attic): preserve Host header via node:http through port-forward

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@jmmaloney4/sector7",
 	"private": true,
-	"version": "0.16.3",
+	"version": "0.16.4",
 	"description": "Sector7 monorepo",
 	"license": "MPL-2.0",
 	"workspaces": [

--- a/packages/sector7/attic/admin.ts
+++ b/packages/sector7/attic/admin.ts
@@ -80,9 +80,9 @@ interface TokenProviderState extends TokenProviderInputs {
 // Like the LiteLLM admin providers, the in-process port-forward lives in the
 // shared `../k8s/port-forward` module (`withPortForward`), whose lazy
 // `await import()` of @kubernetes/client-node / node:net keeps the provider
-// closures serializable. The helpers below otherwise use only the global `fetch`
-// and `mintAtticToken` (whose own node:crypto import is lazy), so they hold no
-// top-level native imports either.
+// closures serializable. The helpers below similarly reach `node:http` through a
+// lazy `await import()` inside `atticFetch` (and `mintAtticToken` lazily imports
+// node:crypto), so they hold no top-level native imports either.
 // https://www.pulumi.com/docs/concepts/resources/dynamic-providers/#how-dynamic-providers-are-serialized
 // ---------------------------------------------------------------------------
 
@@ -149,31 +149,63 @@ interface AtticResponse {
 	json: any;
 }
 
-/** Low-level cache-config request that surfaces the status so callers can branch. */
+/**
+ * Low-level cache-config request that surfaces the status so callers can branch.
+ *
+ * Uses `node:http` (lazily imported) rather than the global `fetch`. Attic
+ * validates the HTTP `Host` header against its `allowed-hosts` list, but the
+ * transport reaches the pod through a `127.0.0.1:<ephemeral-port>` port-forward,
+ * so the wire `Host` must be overridden to the in-cluster Service FQDN that
+ * `allowed-hosts` actually permits. undici (the global `fetch`) treats `Host` as
+ * a forbidden header and silently drops a caller override — so a `fetch()` here
+ * sends `Host: 127.0.0.1:<port>` and Attic rejects it with 400 "Bad Host".
+ * `node:http` honors a caller-supplied `Host`, so it is the correct transport.
+ */
 async function atticFetch(
 	baseUrl: string,
 	token: string,
+	target: AdminTarget,
 	path: string,
 	method: "GET" | "POST" | "PATCH" | "DELETE",
 	body?: unknown,
 ): Promise<AtticResponse> {
-	const response = await fetch(`${baseUrl}${path}`, {
-		method,
-		headers: {
-			Authorization: `Bearer ${token}`,
-			...(body !== undefined ? { "Content-Type": "application/json" } : {}),
-		},
-		body: body !== undefined ? JSON.stringify(body) : undefined,
-	});
-	const text = await response.text();
-	// biome-ignore lint/suspicious/noExplicitAny: cache-config responses are dynamic JSON
-	let json: any;
-	try {
-		json = text ? JSON.parse(text) : {};
-	} catch {
-		json = undefined;
+	const http = await import("node:http");
+	const payload = body !== undefined ? JSON.stringify(body) : undefined;
+	const host = `${target.deploymentName}.${target.namespace}.svc.cluster.local`;
+	const headers: Record<string, string> = {
+		Authorization: `Bearer ${token}`,
+		Host: host,
+	};
+	if (payload !== undefined) {
+		headers["Content-Type"] = "application/json";
+		headers["Content-Length"] = String(Buffer.byteLength(payload));
 	}
-	return { status: response.status, ok: response.ok, text, json };
+	return await new Promise<AtticResponse>((resolve, reject) => {
+		const req = http.request(
+			`${baseUrl}${path}`,
+			{ method, headers },
+			(res) => {
+				const chunks: Buffer[] = [];
+				res.on("data", (chunk: Buffer) => chunks.push(chunk));
+				res.on("end", () => {
+					const text = Buffer.concat(chunks).toString("utf8");
+					const status = res.statusCode ?? 0;
+					const ok = status >= 200 && status < 300;
+					// biome-ignore lint/suspicious/noExplicitAny: cache-config responses are dynamic JSON
+					let json: any;
+					try {
+						json = text ? JSON.parse(text) : {};
+					} catch {
+						json = undefined;
+					}
+					resolve({ status, ok, text, json });
+				});
+			},
+		);
+		req.on("error", reject);
+		if (payload !== undefined) req.write(payload);
+		req.end();
+	});
 }
 
 /** Throw on a non-2xx cache-config response; otherwise return the parsed body. */
@@ -229,11 +261,12 @@ function buildPatchBody(inputs: CacheProviderInputs): Record<string, unknown> {
 async function readPublicKey(
 	baseUrl: string,
 	token: string,
+	target: AdminTarget,
 	cacheName: string,
 ): Promise<string> {
 	const path = `/_api/v1/cache-config/${cacheName}`;
 	const config = ensureOk(
-		await atticFetch(baseUrl, token, path, "GET"),
+		await atticFetch(baseUrl, token, target, path, "GET"),
 		"GET",
 		path,
 	);
@@ -353,6 +386,7 @@ const cacheProvider: dynamic.ResourceProvider = {
 			const res = await atticFetch(
 				baseUrl,
 				token,
+				inputs,
 				path,
 				"POST",
 				buildCreateBody(inputs),
@@ -362,7 +396,7 @@ const cacheProvider: dynamic.ResourceProvider = {
 				// requested retention with a follow-up PATCH.
 				if (inputs.retentionPeriodSeconds !== "") {
 					ensureOk(
-						await atticFetch(baseUrl, token, path, "PATCH", {
+						await atticFetch(baseUrl, token, inputs, path, "PATCH", {
 							retention_period: retentionPeriod(inputs.retentionPeriodSeconds),
 						}),
 						"PATCH",
@@ -387,7 +421,7 @@ const cacheProvider: dynamic.ResourceProvider = {
 				// confirm the immutable field, so refuse rather than adopt an unverified
 				// cache and record an assumed storeDir in state.
 				const existing = ensureOk(
-					await atticFetch(baseUrl, token, path, "GET"),
+					await atticFetch(baseUrl, token, inputs, path, "GET"),
 					"GET",
 					path,
 				);
@@ -403,6 +437,7 @@ const cacheProvider: dynamic.ResourceProvider = {
 					await atticFetch(
 						baseUrl,
 						token,
+						inputs,
 						path,
 						"PATCH",
 						buildPatchBody(inputs),
@@ -413,7 +448,12 @@ const cacheProvider: dynamic.ResourceProvider = {
 			} else {
 				ensureOk(res, "POST", path);
 			}
-			const publicKey = await readPublicKey(baseUrl, token, inputs.cacheName);
+			const publicKey = await readPublicKey(
+				baseUrl,
+				token,
+				inputs,
+				inputs.cacheName,
+			);
 			return { id: inputs.cacheName, outs: { ...inputs, publicKey } };
 		});
 	},
@@ -431,11 +471,23 @@ const cacheProvider: dynamic.ResourceProvider = {
 		return withCacheBaseUrl(news, async (baseUrl) => {
 			const path = `/_api/v1/cache-config/${news.cacheName}`;
 			ensureOk(
-				await atticFetch(baseUrl, token, path, "PATCH", buildPatchBody(news)),
+				await atticFetch(
+					baseUrl,
+					token,
+					news,
+					path,
+					"PATCH",
+					buildPatchBody(news),
+				),
 				"PATCH",
 				path,
 			);
-			const publicKey = await readPublicKey(baseUrl, token, news.cacheName);
+			const publicKey = await readPublicKey(
+				baseUrl,
+				token,
+				news,
+				news.cacheName,
+			);
 			return { outs: { ...news, publicKey } };
 		});
 	},
@@ -446,7 +498,7 @@ const cacheProvider: dynamic.ResourceProvider = {
 		const token = await mintAdminToken(props, cacheName, ADMIN_DELETE_FLAGS);
 		await withCacheBaseUrl(props, async (baseUrl) => {
 			const path = `/_api/v1/cache-config/${cacheName}`;
-			const res = await atticFetch(baseUrl, token, path, "DELETE");
+			const res = await atticFetch(baseUrl, token, props, path, "DELETE");
 			// Idempotent delete: a cache already removed out of band (404) means the
 			// desired end state is reached, so don't fail `pulumi destroy`/replacement.
 			if (res.status === 404) return;

--- a/packages/sector7/package.json
+++ b/packages/sector7/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@jmmaloney4/sector7",
-	"version": "0.16.3",
+	"version": "0.16.4",
 	"description": "Reusable Pulumi components for infrastructure management",
 	"license": "MPL-2.0",
 	"publishConfig": {

--- a/packages/sector7/tests/attic.test.ts
+++ b/packages/sector7/tests/attic.test.ts
@@ -1,4 +1,5 @@
 import * as crypto from "node:crypto";
+import { EventEmitter } from "node:events";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 // ---------------------------------------------------------------------------
@@ -9,9 +10,11 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 // constructors inert and (b) capture the ResourceProvider passed to
 // dynamic.Resource's super(), then exercise the provider directly.
 //
-// The cache provider opens a port-forward and `fetch`es the cache-config API; we
-// stub @kubernetes/client-node and node:net so it yields a local base URL without
-// a real cluster, and stub global fetch to capture the calls. The token provider
+// The cache provider opens a port-forward and calls the cache-config API over
+// `node:http`; we stub @kubernetes/client-node and node:net so it yields a local
+// base URL without a real cluster, and mock `node:http` to capture the requests
+// (the provider uses node:http rather than fetch because Attic validates the Host
+// header and undici drops a caller-supplied Host override). The token provider
 // needs neither — it mints a JWT in-process via the real node:crypto.
 // ---------------------------------------------------------------------------
 
@@ -117,6 +120,60 @@ vi.mock("node:net", () => ({
 	},
 }));
 
+// `node:http` mock. `atticFetch` reaches the cache-config API through
+// `await import("node:http")`; this intercepts it and routes every request to the
+// responder installed by `installFetch`, recording each call (including the Host
+// header the provider sets, so a test can assert it matches Attic's allowed-hosts).
+type HttpCall = {
+	path: string;
+	method: string;
+	body: unknown;
+	host: string | undefined;
+};
+const httpState: {
+	responder: (
+		path: string,
+		method: string,
+		body: unknown,
+	) => { status?: number; body?: unknown } | undefined;
+	calls: HttpCall[];
+} = { responder: () => ({}), calls: [] };
+
+// biome-ignore lint/suspicious/noExplicitAny: minimal http.request stand-in
+function mockHttpRequest(url: any, options: any, cb: any): any {
+	const req: any = new EventEmitter();
+	let bodyStr = "";
+	req.write = (chunk: string) => {
+		bodyStr += chunk;
+		return true;
+	};
+	req.end = () => {
+		const path = String(url).replace(/^http:\/\/127\.0\.0\.1:\d+/, "");
+		const method = options?.method ?? "GET";
+		const body = bodyStr ? JSON.parse(bodyStr) : undefined;
+		const host = options?.headers?.Host;
+		httpState.calls.push({ path, method, body, host });
+		const r = httpState.responder(path, method, body) ?? {};
+		const status = r.status ?? 200;
+		const payload = r.body ?? {};
+		const text =
+			typeof payload === "string" ? payload : JSON.stringify(payload);
+		const res: any = new EventEmitter();
+		res.statusCode = status;
+		queueMicrotask(() => {
+			cb(res);
+			res.emit("data", Buffer.from(text, "utf8"));
+			res.emit("end");
+		});
+	};
+	return req;
+}
+
+vi.mock("node:http", () => ({
+	default: { request: mockHttpRequest },
+	request: mockHttpRequest,
+}));
+
 import { AtticCache, AtticToken } from "../attic/admin.ts";
 import {
 	ATTIC_CLAIM_NAMESPACE,
@@ -146,8 +203,9 @@ function cacheInputs(overrides: Record<string, unknown> = {}) {
 	};
 }
 
-// A mock fetch returning canned cache-config responses; responder may set a
-// status (defaults 200) and a body (object → JSON, string → raw text).
+// Install a responder for the mocked `node:http` transport, returning canned
+// cache-config responses; responder may set a status (defaults 200) and a body
+// (object → JSON, string → raw text). Returns the recorded call log.
 function installFetch(
 	responder: (
 		path: string,
@@ -155,25 +213,9 @@ function installFetch(
 		body: unknown,
 	) => { status?: number; body?: unknown } | undefined,
 ) {
-	const calls: Array<{ path: string; method: string; body: unknown }> = [];
-	const mock = vi.fn(async (url: string, init?: RequestInit) => {
-		const path = url.replace(/^http:\/\/127\.0\.0\.1:\d+/, "");
-		const method = init?.method ?? "GET";
-		const body = init?.body ? JSON.parse(init.body as string) : undefined;
-		calls.push({ path, method, body });
-		const r = responder(path, method, body) ?? {};
-		const status = r.status ?? 200;
-		const payload = r.body ?? {};
-		return {
-			ok: status >= 200 && status < 300,
-			status,
-			statusText: "",
-			text: async () =>
-				typeof payload === "string" ? payload : JSON.stringify(payload),
-		} as Response;
-	});
-	vi.stubGlobal("fetch", mock);
-	return calls;
+	httpState.responder = responder;
+	httpState.calls = [];
+	return httpState.calls;
 }
 
 let cacheProvider: Provider;
@@ -265,6 +307,24 @@ describe("AtticCache provider — lifecycle", () => {
 			keypair: "Generate",
 			is_public: true,
 		});
+	});
+
+	it("sends the in-cluster Service FQDN as the Host header (allowed-hosts match)", async () => {
+		// Regression guard: the provider port-forwards to 127.0.0.1, but Attic
+		// validates Host against allowed-hosts. Every request must carry the
+		// <deployment>.<namespace>.svc.cluster.local Host so it is accepted — never
+		// the 127.0.0.1 the transport actually connects to.
+		const calls = installFetch((_path, method) => {
+			if (method === "POST")
+				return { status: 200, body: { public_key: "pk:new" } };
+			if (method === "GET") return { body: { public_key: "pk:new" } };
+			return {};
+		});
+		await cacheProvider.create(cacheInputs());
+		expect(calls.length).toBeGreaterThan(0);
+		for (const c of calls) {
+			expect(c.host).toBe("attic.attic-prod.svc.cluster.local");
+		}
 	});
 
 	it("adopts an existing cache via PATCH on CacheAlreadyExists", async () => {


### PR DESCRIPTION
## Summary

The Attic cache-config dynamic provider (`AtticCache` / `AtticToken`) provisions caches by calling the Attic admin API through an in-process `127.0.0.1:<ephemeral-port>` port-forward. Attic validates the HTTP `Host` header against `allowed-hosts` and returns `400 "General request error: Bad Host"` when it doesn't match.

Because the transport connects to `127.0.0.1`, the wire `Host` undici sends is `127.0.0.1:<ephemeral-port>` — **including the random port**. Attic compares the full Host value (port included), so it never matches a bare `127.0.0.1` (or the in-cluster FQDN) in `allowed-hosts`.

- **v0.16.2** tried to set `Host: <svc>.cluster.local` via `fetch()` — a no-op: `Host` is a forbidden header in undici, silently dropped.
- **v0.16.3** removed that dead code and deferred the fix to consumers' `allowed-hosts`. But adding bare `127.0.0.1` there can't work either, since the wire Host carries the ephemeral port.

## Fix

Switch `atticFetch` from `fetch()` to **`node:http`** (lazily imported via `await import()` to preserve dynamic-provider closure serializability, matching the `port-forward` / `mintAtticToken` pattern). `node:http` honors a caller-supplied `Host`, so every request now carries `Host: <deployment>.<namespace>.svc.cluster.local` — the in-cluster hostname Attic already allows. No reliance on `127.0.0.1` being in `allowed-hosts`.

`target: AdminTarget` is re-threaded through `atticFetch` / `readPublicKey` and all create/update/delete call sites to compute that host.

## Test plan

- Test mock swapped from global `fetch` to `node:http`; all existing cache lifecycle/diff/check tests pass against the new transport.
- **New regression test** asserts every request on `create` carries `Host: attic.attic-prod.svc.cluster.local` (never `127.0.0.1`).
- `pnpm run build` (tsc) ✓ · `pnpm run test` 258 passed ✓ · biome clean ✓

## Risks

- Low. Behavior-preserving transport swap; the only observable change is the wire `Host` header, which is the bug being fixed.
- Consumers (garden `deploy/services/attic`) can drop the `127.0.0.1` `allowed-hosts` workaround after bumping to v0.16.4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)