### PR TITLE
fix(attic): emit integer permission flags, not booleans

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@jmmaloney4/sector7",
 	"private": true,
-	"version": "0.16.4",
+	"version": "0.16.5",
 	"description": "Sector7 monorepo",
 	"license": "MPL-2.0",
 	"workspaces": [

--- a/packages/sector7/attic/token.ts
+++ b/packages/sector7/attic/token.ts
@@ -61,20 +61,26 @@ function base64url(buf: Buffer): string {
 }
 
 /**
- * Render permission flags into Attic's short-key form, emitting only the flags
- * that are `true` (matching `atticadm`'s minimal output; absent = deny).
+ * Render permission flags into Attic's short-key form, emitting only the granted
+ * flags (absent = deny) with the integer value `1`.
+ *
+ * Attic deserializes each permission value as an integer, NOT a JSON boolean —
+ * `atticadm make-token --dump-claims` emits `{"r":1,"cc":1,...}`. Emitting `true`
+ * instead makes Attic reject the whole token with 401 (the permission claim fails
+ * to deserialize), which silently breaks every minted token. Match `atticadm`'s
+ * `1`/absent encoding exactly.
  */
 function permissionClaim(
 	flags: AtticCachePermissionFlags,
-): Record<string, boolean> {
-	const out: Record<string, boolean> = {};
-	if (flags.pull) out.r = true;
-	if (flags.push) out.w = true;
-	if (flags.delete) out.d = true;
-	if (flags.createCache) out.cc = true;
-	if (flags.configureCache) out.cr = true;
-	if (flags.configureCacheRetention) out.cq = true;
-	if (flags.destroyCache) out.cd = true;
+): Record<string, number> {
+	const out: Record<string, number> = {};
+	if (flags.pull) out.r = 1;
+	if (flags.push) out.w = 1;
+	if (flags.delete) out.d = 1;
+	if (flags.createCache) out.cc = 1;
+	if (flags.configureCache) out.cr = 1;
+	if (flags.configureCacheRetention) out.cq = 1;
+	if (flags.destroyCache) out.cd = 1;
 	return out;
 }
 
@@ -93,7 +99,7 @@ export async function mintAtticToken(
 	const crypto = await import("node:crypto");
 
 	const header = { alg: "HS256", typ: "JWT" };
-	const caches: Record<string, Record<string, boolean>> = {};
+	const caches: Record<string, Record<string, number>> = {};
 	for (const [pattern, flags] of Object.entries(args.caches)) {
 		caches[pattern] = permissionClaim(flags);
 	}

--- a/packages/sector7/package.json
+++ b/packages/sector7/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@jmmaloney4/sector7",
-	"version": "0.16.4",
+	"version": "0.16.5",
 	"description": "Reusable Pulumi components for infrastructure management",
 	"license": "MPL-2.0",
 	"publishConfig": {

--- a/packages/sector7/tests/attic.test.ts
+++ b/packages/sector7/tests/attic.test.ts
@@ -501,21 +501,31 @@ describe("AtticToken provider", () => {
 		expect(result.outs.expiresAt).toBe(
 			(result.outs.notBefore as number) + 3600,
 		);
-		// Permission short-keys under the Attic namespace claim.
+		// Permission short-keys under the Attic namespace claim. Values MUST be the
+		// integer 1, not boolean true — Attic deserializes them as integers and 401s
+		// on a JSON boolean (matches `atticadm make-token --dump-claims`).
 		expect(payload[ATTIC_CLAIM_NAMESPACE]).toEqual({
-			caches: { mycache: { r: true, w: true } },
+			caches: { mycache: { r: 1, w: 1 } },
 		});
 	});
 
-	it("emits only the granted permission flags", async () => {
+	it("emits granted permission flags as the integer 1, never booleans", async () => {
 		const result = await tokenProvider.create({
 			...tokenInputs,
 			caches: { "team-*": { pull: true, createCache: true } },
 		});
 		const payload = decodeSegment((result.outs.token as string).split(".")[1]);
-		expect(payload[ATTIC_CLAIM_NAMESPACE]).toEqual({
-			caches: { "team-*": { r: true, cc: true } },
-		});
+		const grants = (
+			payload[ATTIC_CLAIM_NAMESPACE] as {
+				caches: Record<string, Record<string, unknown>>;
+			}
+		).caches["team-*"];
+		// Only granted flags present, each strictly the integer 1 (not `true`).
+		expect(grants).toEqual({ r: 1, cc: 1 });
+		for (const v of Object.values(grants)) {
+			expect(v).toBe(1);
+			expect(typeof v).toBe("number");
+		}
 	});
 
 	it("replaces on any claim-affecting input change", async () => {


### PR DESCRIPTION
## Summary

Attic deserializes each JWT permission flag as an **integer**, not a JSON boolean. `atticadm make-token --dump-claims` emits `{"r":1,"cc":1,"cr":1,"cq":1}`. sector7's `permissionClaim` emitted `{r: true, cc: true, ...}`, so Attic rejected **every minted token** with `401` — the permission claim fails to deserialize.

This silently broke both `AtticCache` admin tokens and `AtticToken` CI tokens. The old in-pod `atticadm` bootstrap was immune because it produced the integer form. The unit tests passed because they verified the signature/JSON shape but asserted the (wrong) boolean values — codifying the bug rather than catching it.

## How it was found

Surfaced after the Host-header fix (v0.16.4): once the cache-config requests passed Attic's `allowed-hosts` check, they hit auth and got `401`. Ruled out clock skew (pod clock = real UTC) and secret mismatch (deployed `attic-jwt-secret` sha256 == server env var sha256 == minting secret). The only difference between a working `atticadm` token and the rejected sector7 token, against the same live server:

```
atticadm   {"caches":{"jmmaloney4":{"r":1}}}     → HTTP 404 (auth OK, cache absent)
sector7    {"caches":{"jmmaloney4":{"r":true}}}  → HTTP 401
```

## Fix

`permissionClaim` now emits the integer `1` for each granted flag (absent = deny), returning `Record<string, number>`; `mintAtticToken`'s caches map typed to match. Tests updated to assert integer values, with an explicit `typeof === "number"` / `=== 1` guard so a regression to booleans fails loudly.

## Test plan

- `pnpm run build` (tsc) ✓ · `pnpm run test` 258 passed ✓ · biome clean ✓
- Verified end-to-end against the live attic-prod server: integer-perm token accepted (404 on missing cache), boolean-perm token 401, same secret + clock.

## Risks

- Low, and strictly corrective: every token Attic actually accepts uses the integer form. No consumer API change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)