### PR TITLE
feat(nix): incrementally push built paths to Attic via watch-store

### DIFF
--- a/.github/actions/nix-setup/action.yml
+++ b/.github/actions/nix-setup/action.yml
@@ -17,6 +17,18 @@ inputs:
     description: Optional newline-delimited extra trusted public keys to append to the runner Nix config
     required: false
     default: ''
+  attic-endpoint:
+    description: Optional Attic server endpoint (root URL). When set together with attic-cache-name and attic-token, starts `attic watch-store` to push built store paths to the cache incrementally for the rest of the job.
+    required: false
+    default: ''
+  attic-cache-name:
+    description: Optional Attic cache name to push into via watch-store.
+    required: false
+    default: ''
+  attic-token:
+    description: Optional Attic token with push permission, used by watch-store.
+    required: false
+    default: ''
 runs:
   using: composite
   steps:
@@ -37,3 +49,14 @@ runs:
         INPUT_EXTRA_SUBSTITUTERS: ${{ inputs.extra-substituters }}
         INPUT_EXTRA_TRUSTED_PUBLIC_KEYS: ${{ inputs.extra-trusted-public-keys }}
       run: bash "${{ github.action_path }}/configure-binary-cache.sh"
+    # Best-effort incremental cache push: when Attic push creds are provided,
+    # start `attic watch-store` in the background so every store path built in
+    # this job is uploaded as it appears (survives concurrency cancellation and
+    # seeds the detect job's nix-eval-jobs closure). Never fails the job.
+    - if: ${{ inputs.attic-endpoint != '' && inputs.attic-cache-name != '' && inputs.attic-token != '' }}
+      shell: bash
+      env:
+        INPUT_ATTIC_ENDPOINT: ${{ inputs.attic-endpoint }}
+        INPUT_ATTIC_CACHE: ${{ inputs.attic-cache-name }}
+        INPUT_ATTIC_TOKEN: ${{ inputs.attic-token }}
+      run: bash "${{ github.action_path }}/start-attic-watch-store.sh"

--- a/.github/actions/nix-setup/start-attic-watch-store.sh
+++ b/.github/actions/nix-setup/start-attic-watch-store.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Start `attic watch-store` in the background so every store path realised
+# during this job is pushed to the Attic binary cache incrementally, as it
+# appears — not only by an end-of-job push step.
+#
+# Why this instead of a Nix `post-build-hook`: the runner uses a multi-user
+# Nix daemon (DeterminateSystems installer), so a post-build-hook would run as
+# root in the daemon's restricted context AND would *fail the build* if it
+# errored. `attic watch-store` runs as the runner user, needs no daemon/root
+# config, and is strictly best-effort — it never fails the job.
+#
+# Two payoffs:
+#   1. Resilient seeding — a job cancelled mid-build (concurrency
+#      cancel-in-progress) still uploads everything it finished, instead of
+#      losing it all because the single end-of-job push never ran.
+#   2. The detect job builds nix-eval-jobs from source (its pinned closure is
+#      in no public cache); watch-store pushes that closure to Attic, so
+#      subsequent detect runs substitute it instead of rebuilding.
+set -euo pipefail
+
+endpoint="${INPUT_ATTIC_ENDPOINT:-}"
+cache="${INPUT_ATTIC_CACHE:-}"
+token="${INPUT_ATTIC_TOKEN:-}"
+server="${INPUT_SERVER_NAME:-ci}"
+
+if [ -z "$endpoint" ] || [ -z "$cache" ] || [ -z "$token" ]; then
+  echo "Attic watch-store: endpoint/cache/token not all set; skipping."
+  exit 0
+fi
+
+# Ensure the attic client is on PATH for the rest of the job. attic-client is
+# in nixpkgs (substituted from cache.nixos.org), so this does not build.
+if ! command -v attic >/dev/null 2>&1; then
+  echo "Installing attic-client into the Nix profile..."
+  if ! nix profile install nixpkgs#attic-client; then
+    echo "::warning::failed to install attic-client; skipping watch-store"
+    exit 0
+  fi
+fi
+
+if ! attic login "$server" "$endpoint" "$token"; then
+  echo "::warning::attic login failed; skipping watch-store (incremental cache push disabled for this job)"
+  exit 0
+fi
+
+log=/tmp/attic-watch-store.log
+echo "Starting 'attic watch-store $server:$cache' in the background (log: $log)"
+# Detach fully so the watcher survives this step and keeps pushing for the
+# rest of the job. Redirect stdio to a file so the step does not hang on an
+# open pipe. Failures land in the log and never affect the job.
+nohup attic watch-store "$server:$cache" >"$log" 2>&1 &
+disown || true
+echo "attic watch-store started (pid $!)"

--- a/.github/actions/nix-setup/start-attic-watch-store.sh
+++ b/.github/actions/nix-setup/start-attic-watch-store.sh
@@ -38,6 +38,12 @@ if ! command -v attic >/dev/null 2>&1; then
   fi
 fi
 
+# Isolate the attic client state to a per-job config dir so the token is not
+# written into the runner's shared $HOME config (defence-in-depth; our runners
+# are ephemeral one-job pods, but this keeps state job-scoped regardless).
+XDG_CONFIG_HOME="$(mktemp -d -t attic-watch-XXXXXX)"
+export XDG_CONFIG_HOME
+
 if ! attic login "$server" "$endpoint" "$token"; then
   echo "::warning::attic login failed; skipping watch-store (incremental cache push disabled for this job)"
   exit 0
@@ -45,9 +51,12 @@ fi
 
 log=/tmp/attic-watch-store.log
 echo "Starting 'attic watch-store $server:$cache' in the background (log: $log)"
-# Detach fully so the watcher survives this step and keeps pushing for the
-# rest of the job. Redirect stdio to a file so the step does not hang on an
-# open pipe. Failures land in the log and never affect the job.
-nohup attic watch-store "$server:$cache" >"$log" 2>&1 &
+# Fully detach so the watcher survives this step (and step-boundary process
+# cleanup) and keeps pushing for the rest of the job: `setsid` puts it in its
+# own session/process group, stdin is closed (</dev/null) and stdout/stderr go
+# to a file so the step never hangs on an open pipe. It is still reaped at job
+# end. Failures land in the log and never affect the job. XDG_CONFIG_HOME is
+# inherited so the watcher reads the isolated login config.
+setsid attic watch-store "$server:$cache" </dev/null >"$log" 2>&1 &
 disown || true
 echo "attic watch-store started (pid $!)"

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -62,6 +62,10 @@ jobs:
       build_matrix_include: ${{ steps.split.outputs.build_matrix_include }}
       build_has_work: ${{ steps.split.outputs.build_has_work }}
       images_to_push: ${{ steps.split.outputs.image_matrix }}
+    env:
+      # Provided so nix-setup can start `attic watch-store`, which seeds the
+      # nix-eval-jobs closure built below into the cache for future runs.
+      BINARY_CACHE_TOKEN: ${{ secrets.BINARY_CACHE_TOKEN }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
@@ -73,6 +77,9 @@ jobs:
           cache: ${{ !contains(inputs.runs-on, 'self-hosted') && inputs.binary-cache-url == '' }}
           extra-substituters: ${{ inputs.binary-cache-url }}
           extra-trusted-public-keys: ${{ inputs.binary-cache-public-key }}
+          attic-endpoint: ${{ inputs.binary-cache-endpoint }}
+          attic-cache-name: ${{ inputs.binary-cache-name }}
+          attic-token: ${{ secrets.BINARY_CACHE_TOKEN }}
       - name: compute build-needed matrix via nix-eval-jobs
         id: compute
         uses: jmmaloney4/sector7/.github/actions/compute-flake-build-matrix@main
@@ -117,6 +124,9 @@ jobs:
           cache: ${{ !contains(inputs.runs-on, 'self-hosted') && inputs.binary-cache-url == '' }}
           extra-substituters: ${{ inputs.binary-cache-url }}
           extra-trusted-public-keys: ${{ inputs.binary-cache-public-key }}
+          attic-endpoint: ${{ inputs.binary-cache-endpoint }}
+          attic-cache-name: ${{ inputs.binary-cache-name }}
+          attic-token: ${{ secrets.BINARY_CACHE_TOKEN }}
       - name: "🚀 build with nix-fast-build"
         shell: 'nix -L shell nixpkgs#nix-fast-build -c bash {0}'
         run: |-


### PR DESCRIPTION
## Summary

Makes the Nix CI cache **seed reliably** and stops the `detect` job from rebuilding nix-eval-jobs every run. Adds an optional `attic watch-store` to `nix-setup` that, when Attic push creds are present, runs in the background for the whole job and uploads every store path **as it's built**.

## Why

Today the only push is a single `push-attic-cache` step at the *end* of the build job. With `concurrency: cancel-in-progress`, a run cancelled mid-build (very common under rapid merges, and made worse by an empty/cold cache) pushes **nothing** — so the cache never seeds. Separately, the `detect` job runs `nix run github:nix-community/nix-eval-jobs/v2.34.1`, whose closure is in no public cache, so it **builds ~11 derivations (nix 2.34.1, curl, nix-eval-jobs) from source every run**.

`attic watch-store` fixes both: it watches `/nix/store` and pushes paths as they appear, so
1. a cancelled build still uploads everything it finished (resilient seeding), and
2. the first `detect` run pushes the nix-eval-jobs closure to Attic → subsequent `detect` runs **substitute** it instead of rebuilding.

## Why watch-store, not a Nix `post-build-hook`

The runner installs Nix via DeterminateSystems (multi-user daemon). A `post-build-hook` runs as **root in the daemon's restricted context** and **fails the build if it errors** — risky for shared CI across all repos. `watch-store` runs as the runner user, needs no root/daemon config, and is strictly **best-effort**: it never fails the job and is a no-op when creds are absent (so non-Attic repos are unaffected).

## Changes

- `nix-setup`: new optional inputs `attic-endpoint` / `attic-cache-name` / `attic-token`; new `start-attic-watch-store.sh` step that logs in and starts `attic watch-store` in the background (only when all three are set).
- `nix.yml`: passes the creds into both the `detect` and `build` `nix-setup` calls; `detect` gains a job-level `BINARY_CACHE_TOKEN`. The end-of-job `push-attic-cache` step stays as a backstop for final outputs.

## Test plan / validation

- `bash -n` + `shellcheck`: clean.
- `actionlint` on `nix.yml`: clean.
- **Needs a real CI run to validate end-to-end** (watch-store start, login, background push, and that `detect`'s nix-eval-jobs closure lands in Attic). Safe by construction: gated on creds, best-effort, never fails the job.

## Rollout note

Consuming repos pin `nix.yml` at a SHA, so they pick up the `nix.yml` change on their next sector7 bump. The `nix-setup` action change is referenced `@main`, but only takes effect once a pinned `nix.yml` passes the new inputs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)