### PR TITLE
feat(gateway): support HTTPRoute rule timeouts in createServiceHttpRoute

### DIFF
--- a/packages/sector7/gateway/index.ts
+++ b/packages/sector7/gateway/index.ts
@@ -29,6 +29,21 @@ export interface HttpRouteTimeouts {
 // unit (h, m, s, ms), e.g. "600s", "1h30m", "0s".
 const GATEWAY_API_DURATION = /^([0-9]{1,5}(h|m|s|ms)){1,4}$/;
 
+const DURATION_UNIT_MS: Record<string, number> = {
+	h: 3_600_000,
+	m: 60_000,
+	s: 1_000,
+	ms: 1,
+};
+
+function gatewayApiDurationToMs(duration: string): number {
+	let total = 0;
+	for (const match of duration.matchAll(/([0-9]{1,5})(ms|h|m|s)/g)) {
+		total += Number(match[1]) * (DURATION_UNIT_MS[match[2] ?? ""] ?? 0);
+	}
+	return total;
+}
+
 export interface ServiceHttpRouteArgs {
 	/**
 	 * Logical/resource name for the HTTPRoute (e.g. "periscope").
@@ -93,10 +108,28 @@ export function createServiceHttpRoute(
 			`createServiceHttpRoute: pathPrefix must be an absolute path starting with "/" (got ${JSON.stringify(args.pathPrefix)})`,
 		);
 	}
-	for (const [field, value] of Object.entries(args.timeouts ?? {})) {
-		if (value !== undefined && !GATEWAY_API_DURATION.test(value)) {
+	// Only emit timeout fields that are actually set — an empty `timeouts: {}`
+	// is rejected by the Gateway API CRD at apply time.
+	const timeouts = Object.fromEntries(
+		Object.entries(args.timeouts ?? {}).filter(([, v]) => v !== undefined),
+	) as HttpRouteTimeouts;
+	for (const [field, value] of Object.entries(timeouts)) {
+		if (!GATEWAY_API_DURATION.test(value)) {
 			throw new Error(
 				`createServiceHttpRoute: timeouts.${field} must be a Gateway API duration like "600s", "30m", or "0s" (got ${JSON.stringify(value)})`,
+			);
+		}
+	}
+	// Gateway API requires backendRequest <= request, except request "0s"
+	// (disabled) which lifts the bound. Enforce at preview, not apply.
+	if (timeouts.request !== undefined && timeouts.backendRequest !== undefined) {
+		const requestMs = gatewayApiDurationToMs(timeouts.request);
+		if (
+			requestMs > 0 &&
+			gatewayApiDurationToMs(timeouts.backendRequest) > requestMs
+		) {
+			throw new Error(
+				`createServiceHttpRoute: timeouts.backendRequest (${timeouts.backendRequest}) must not exceed timeouts.request (${timeouts.request})`,
 			);
 		}
 	}
@@ -126,7 +159,7 @@ export function createServiceHttpRoute(
 									],
 								}
 							: {}),
-						...(args.timeouts !== undefined ? { timeouts: args.timeouts } : {}),
+						...(Object.keys(timeouts).length > 0 ? { timeouts } : {}),
 						backendRefs: [
 							{
 								name: args.serviceName,

--- a/packages/sector7/gateway/index.ts
+++ b/packages/sector7/gateway/index.ts
@@ -5,6 +5,30 @@ import * as pulumi from "@pulumi/pulumi";
 // HTTPRoute — Gateway API route for a service (ADR 040, updated by ADR 075)
 // ---------------------------------------------------------------------------
 
+/**
+ * Gateway API HTTPRoute rule timeouts (GEP-1742).
+ *
+ * Values are Gateway API Duration strings (GEP-2257), e.g. "600s", "30m",
+ * "1h". "0s" disables the timeout entirely.
+ */
+export interface HttpRouteTimeouts {
+	/**
+	 * Maximum time for the gateway to complete the entire request/response
+	 * exchange, including streaming the full response body. Envoy's built-in
+	 * default is 15s, which silently kills long-running requests (e.g. LLM
+	 * completions and SSE streams) — set this explicitly for slow backends.
+	 */
+	request?: string;
+	/**
+	 * Timeout for a single gateway-to-backend attempt. Must be <= request.
+	 */
+	backendRequest?: string;
+}
+
+// Gateway API Duration format (GEP-2257): 1-4 groups of <up to 5 digits> +
+// unit (h, m, s, ms), e.g. "600s", "1h30m", "0s".
+const GATEWAY_API_DURATION = /^([0-9]{1,5}(h|m|s|ms)){1,4}$/;
+
 export interface ServiceHttpRouteArgs {
 	/**
 	 * Logical/resource name for the HTTPRoute (e.g. "periscope").
@@ -35,6 +59,13 @@ export interface ServiceHttpRouteArgs {
 	 * paths for the hostname (the default).
 	 */
 	pathPrefix?: string;
+	/**
+	 * Optional rule timeouts (GEP-1742). Without this, Envoy applies its
+	 * built-in 15s route timeout — any request slower than that is killed with
+	 * a 504 ("upstream request timeout") even while actively streaming. Set
+	 * `request` generously (e.g. "600s") for LLM/streaming backends.
+	 */
+	timeouts?: HttpRouteTimeouts;
 	/** Kubernetes provider. */
 	provider: k8s.Provider;
 	/** Resources this HTTPRoute depends on. */
@@ -62,6 +93,13 @@ export function createServiceHttpRoute(
 			`createServiceHttpRoute: pathPrefix must be an absolute path starting with "/" (got ${JSON.stringify(args.pathPrefix)})`,
 		);
 	}
+	for (const [field, value] of Object.entries(args.timeouts ?? {})) {
+		if (value !== undefined && !GATEWAY_API_DURATION.test(value)) {
+			throw new Error(
+				`createServiceHttpRoute: timeouts.${field} must be a Gateway API duration like "600s", "30m", or "0s" (got ${JSON.stringify(value)})`,
+			);
+		}
+	}
 	return new k8s.apiextensions.CustomResource(
 		`${args.name}-route`,
 		{
@@ -88,6 +126,7 @@ export function createServiceHttpRoute(
 									],
 								}
 							: {}),
+						...(args.timeouts !== undefined ? { timeouts: args.timeouts } : {}),
 						backendRefs: [
 							{
 								name: args.serviceName,

--- a/packages/sector7/tests/gateway.test.ts
+++ b/packages/sector7/tests/gateway.test.ts
@@ -134,6 +134,38 @@ describe("gateway module surface", () => {
 		).toThrow(/Gateway API duration/);
 	});
 
+	it("rejects backendRequest longer than request", () => {
+		expect(() =>
+			createServiceHttpRoute({
+				name: "t",
+				namespace: "ns",
+				hostnames: ["h.example.com"],
+				serviceName: "svc",
+				port: 80,
+				timeouts: { request: "30s", backendRequest: "1m" },
+				provider: {} as any,
+			}),
+		).toThrow(/must not exceed/);
+	});
+
+	it("allows any backendRequest when request is '0s' (disabled)", () => {
+		// request "0s" disables the route timeout, lifting the ordering bound.
+		// The validation must not throw; resource construction itself is not
+		// exercisable outside a Pulumi runtime, so expect that specific failure
+		// instead of a validation error.
+		expect(() =>
+			createServiceHttpRoute({
+				name: "t",
+				namespace: "ns",
+				hostnames: ["h.example.com"],
+				serviceName: "svc",
+				port: 80,
+				timeouts: { request: "0s", backendRequest: "1h" },
+				provider: {} as any,
+			}),
+		).not.toThrow(/must not exceed/);
+	});
+
 	it("has correct defaults in SharedGatewayReferenceGrantArgs type", () => {
 		const args: SharedGatewayReferenceGrantArgs = {
 			name: "allow-test",

--- a/packages/sector7/tests/gateway.test.ts
+++ b/packages/sector7/tests/gateway.test.ts
@@ -80,6 +80,60 @@ describe("gateway module surface", () => {
 		).toThrow();
 	});
 
+	it("ServiceHttpRouteArgs accepts optional timeouts", () => {
+		const args: ServiceHttpRouteArgs = {
+			name: "test",
+			namespace: "test-ns",
+			hostnames: ["test.example.com"],
+			serviceName: "test-svc",
+			port: 80,
+			timeouts: { request: "600s", backendRequest: "600s" },
+			provider: {} as any,
+		};
+		expect(args.timeouts?.request).toBe("600s");
+	});
+
+	it("accepts '0s' to disable a timeout", () => {
+		const args: ServiceHttpRouteArgs = {
+			name: "test",
+			namespace: "test-ns",
+			hostnames: ["test.example.com"],
+			serviceName: "test-svc",
+			port: 80,
+			timeouts: { request: "0s" },
+			provider: {} as any,
+		};
+		expect(args.timeouts?.request).toBe("0s");
+	});
+
+	it("rejects a timeouts.request that is not a Gateway API duration", () => {
+		expect(() =>
+			createServiceHttpRoute({
+				name: "t",
+				namespace: "ns",
+				hostnames: ["h.example.com"],
+				serviceName: "svc",
+				port: 80,
+				timeouts: { request: "600" },
+				provider: {} as any,
+			}),
+		).toThrow(/Gateway API duration/);
+	});
+
+	it("rejects a timeouts.backendRequest that is not a Gateway API duration", () => {
+		expect(() =>
+			createServiceHttpRoute({
+				name: "t",
+				namespace: "ns",
+				hostnames: ["h.example.com"],
+				serviceName: "svc",
+				port: 80,
+				timeouts: { backendRequest: "ten seconds" },
+				provider: {} as any,
+			}),
+		).toThrow(/Gateway API duration/);
+	});
+
 	it("has correct defaults in SharedGatewayReferenceGrantArgs type", () => {
 		const args: SharedGatewayReferenceGrantArgs = {
 			name: "allow-test",


### PR DESCRIPTION
## Summary

`createServiceHttpRoute()` emits HTTPRoutes with no `timeouts` field, so Envoy Gateway applies Envoy's built-in **15s route timeout**. Any request slower than 15s is killed with a 504 (`upstream request timeout`) — and since the route timeout bounds the *entire* response, it fires even while an SSE stream is actively flowing. This is the root cause of jmmaloney4/garden#803 and the dominant trigger behind jmmaloney4/garden#796: live Envoy access logs on garden's `private-gateway` show a hard wall of `UT`-flagged litellm requests at 15.0–15.8s, and no request through the gateway has ever completed past ~15.8s.

This PR adds an optional `timeouts` arg (Gateway API GEP-1742: `request` / `backendRequest`) to `ServiceHttpRouteArgs`, threaded into `spec.rules[0].timeouts`. Values are validated against the Gateway API duration format (GEP-2257) up front, following the existing `pathPrefix` fail-fast pattern, so a bad duration fails at preview rather than producing an invalid manifest at apply.

No behavior change for existing callers — the field is omitted from the manifest when not passed.

## Test plan

- 4 new vitest cases: type surface accepts `timeouts`, accepts `"0s"` (disable), rejects non-duration strings for both fields (`pnpm test`: 262 passed).
- `pnpm run build` (tsc) passes.
- `nix flake check -L` passes.
- End-to-end validation happens in the follow-up garden PR (litellm callsite + live Envoy log verification).

## Risks

- Low: additive, optional field. The duration regex matches GEP-2257; exotic-but-valid multi-group durations like `"1h30m"` are accepted.
- `backendRequest <= request` is documented but not cross-validated; the gateway controller rejects violations at admission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)