### PR TITLE
release: bump sector7 to 0.16.6

### DIFF
--- a/packages/sector7/package.json
+++ b/packages/sector7/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@jmmaloney4/sector7",
-	"version": "0.16.5",
+	"version": "0.16.6",
 	"description": "Reusable Pulumi components for infrastructure management",
 	"license": "MPL-2.0",
 	"publishConfig": {


### PR DESCRIPTION
## Summary

Version bump to publish the `createServiceHttpRoute` HTTPRoute `timeouts` support (#271) as a GitHub release tarball, so garden can pin it and set a request timeout on the litellm route (fixes the Envoy 15s default route timeout killing `coding`-model requests — jmmaloney4/garden#803, jmmaloney4/garden#796).

Pushing the `v0.16.6` tag after merge triggers the pnpm publish workflow.

## Test plan

- One-line version bump; #271 passed tests, build, and `nix flake check -L` on the same tree.

## Risks

- None beyond the release itself; consumers pin tarballs explicitly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)