### PR TITLE
release: bump root package.json to 0.16.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@jmmaloney4/sector7",
 	"private": true,
-	"version": "0.16.5",
+	"version": "0.16.6",
 	"description": "Sector7 monorepo",
 	"license": "MPL-2.0",
 	"workspaces": [


### PR DESCRIPTION
## Summary

Completes the 0.16.6 release started in #272. The pnpm release analyzer failed on the `v0.16.6` tag (run 27444839057) with `Version mismatch: @jmmaloney4/sector7 is 0.16.6, expected 0.16.5` — prior release commits bump both the root `package.json` and `packages/sector7/package.json`, and #272 only bumped the latter. After merge, the `v0.16.6` tag will be re-pointed at the merge commit to re-run the publish workflow.

## Test plan

- One-line version sync; analyzer enforces the invariant in CI on the tag run.

## Risks

- None; metadata only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)