### PR TITLE
fix(litellm): key router fallbacks by public model name (litellm#10317)

### DIFF
--- a/packages/sector7/litellm/config.ts
+++ b/packages/sector7/litellm/config.ts
@@ -140,7 +140,22 @@ function buildFallbackMap(
 		const raw =
 			key === "fallbacks" ? group.fallbacks : group.contextWindowFallbacks;
 		const chain =
-			raw && raw.length > 0 ? raw.map((t) => publicNameOf.get(t) ?? t) : null;
+			raw && raw.length > 0
+				? raw.map((t) => {
+						// Resolve internal->public; fail fast rather than keep a raw,
+						// unmapped name. validateLiteLLMConfig already rejects unknown
+						// targets, so this is defense-in-depth: a silently-kept name
+						// would reintroduce the exact "fallback never matches" bug.
+						const publicTarget = publicNameOf.get(t);
+						if (publicTarget === undefined) {
+							throw new Error(
+								`${key} target '${t}' for public model '${publicKey}' ` +
+									"does not resolve to a known model group.",
+							);
+						}
+						return publicTarget;
+					})
+				: null;
 
 		if (!chainByPublicName.has(publicKey)) {
 			chainByPublicName.set(publicKey, chain);

--- a/packages/sector7/litellm/config.ts
+++ b/packages/sector7/litellm/config.ts
@@ -128,38 +128,40 @@ function buildFallbackMap(
 		publicNameOf.set(group.name, group.teamPublicModelName ?? group.name);
 	}
 
-	const byPublicName = new Map<string, string[]>();
+	// Track the chain for every public model name, INCLUDING groups that declare
+	// none (recorded as null). The fallback map is global and keyed by the public
+	// name, so a name that one team gives a chain and another leaves empty is
+	// still a conflict: the global entry would silently apply that chain to the
+	// team that opted out. Every team exposing a shared public name must agree —
+	// matching chains dedupe, any divergence (including present-vs-absent) throws.
+	const chainByPublicName = new Map<string, string[] | null>();
 	for (const group of groups) {
-		const targets =
-			key === "fallbacks" ? group.fallbacks : group.contextWindowFallbacks;
-		if (!targets || targets.length === 0) {
-			continue;
-		}
 		const publicKey = group.teamPublicModelName ?? group.name;
-		const publicTargets = targets.map((t) => publicNameOf.get(t) ?? t);
+		const raw =
+			key === "fallbacks" ? group.fallbacks : group.contextWindowFallbacks;
+		const chain =
+			raw && raw.length > 0 ? raw.map((t) => publicNameOf.get(t) ?? t) : null;
 
-		const existing = byPublicName.get(publicKey);
-		if (existing) {
-			// Two teams share this public model name. LiteLLM's fallback map is
-			// global and keyed by the public name, so it can only hold one chain
-			// per name — the same client-facing `cheap` can't fall back to
-			// `local` for one team and something else for another. Identical
-			// chains dedupe cleanly; differing chains are unrepresentable.
-			if (JSON.stringify(existing) !== JSON.stringify(publicTargets)) {
-				throw new Error(
-					`Conflicting ${key} for public model '${publicKey}': ` +
-						`[${existing.join(", ")}] vs [${publicTargets.join(", ")}]. ` +
-						"LiteLLM's global fallback map cannot express per-team fallback " +
-						"chains for a shared team_public_model_name (litellm#10317); " +
-						"give the capabilities distinct public names or identical chains.",
-				);
-			}
+		if (!chainByPublicName.has(publicKey)) {
+			chainByPublicName.set(publicKey, chain);
 			continue;
 		}
-		byPublicName.set(publicKey, publicTargets);
+		const existing = chainByPublicName.get(publicKey) ?? null;
+		if (JSON.stringify(existing) !== JSON.stringify(chain)) {
+			const fmt = (c: string[] | null) => (c ? `[${c.join(", ")}]` : "(none)");
+			throw new Error(
+				`Conflicting ${key} for public model '${publicKey}': ` +
+					`${fmt(existing)} vs ${fmt(chain)}. LiteLLM's global fallback map ` +
+					"cannot express per-team fallback chains for a shared " +
+					"team_public_model_name (litellm#10317); give the capabilities " +
+					"distinct public names or matching chains.",
+			);
+		}
 	}
 
-	return [...byPublicName].map(([name, targets]) => ({ [name]: targets }));
+	return [...chainByPublicName]
+		.filter((entry): entry is [string, string[]] => entry[1] !== null)
+		.map(([name, targets]) => ({ [name]: targets }));
 }
 
 export function validateLiteLLMConfig(args: {

--- a/packages/sector7/litellm/config.ts
+++ b/packages/sector7/litellm/config.ts
@@ -117,14 +117,49 @@ function buildFallbackMap(
 	groups: LiteLLMModelGroup[],
 	key: "fallbacks" | "contextWindowFallbacks",
 ): Array<Record<string, string[]>> {
-	return groups.flatMap((group) => {
+	// LiteLLM resolves fallbacks by the *public* model name the client requested
+	// (the `team_public_model_name` alias), not the resolved internal model_group
+	// name — a known, won't-fix upstream limitation (BerriAI/litellm#10317). So
+	// the fallback map must be keyed (and valued) by public names, or it never
+	// matches and the chain silently never fires. Map every internal model_group
+	// name to its public alias, then emit public→public entries.
+	const publicNameOf = new Map<string, string>();
+	for (const group of groups) {
+		publicNameOf.set(group.name, group.teamPublicModelName ?? group.name);
+	}
+
+	const byPublicName = new Map<string, string[]>();
+	for (const group of groups) {
 		const targets =
 			key === "fallbacks" ? group.fallbacks : group.contextWindowFallbacks;
 		if (!targets || targets.length === 0) {
-			return [];
+			continue;
 		}
-		return [{ [group.name]: targets }];
-	});
+		const publicKey = group.teamPublicModelName ?? group.name;
+		const publicTargets = targets.map((t) => publicNameOf.get(t) ?? t);
+
+		const existing = byPublicName.get(publicKey);
+		if (existing) {
+			// Two teams share this public model name. LiteLLM's fallback map is
+			// global and keyed by the public name, so it can only hold one chain
+			// per name — the same client-facing `cheap` can't fall back to
+			// `local` for one team and something else for another. Identical
+			// chains dedupe cleanly; differing chains are unrepresentable.
+			if (JSON.stringify(existing) !== JSON.stringify(publicTargets)) {
+				throw new Error(
+					`Conflicting ${key} for public model '${publicKey}': ` +
+						`[${existing.join(", ")}] vs [${publicTargets.join(", ")}]. ` +
+						"LiteLLM's global fallback map cannot express per-team fallback " +
+						"chains for a shared team_public_model_name (litellm#10317); " +
+						"give the capabilities distinct public names or identical chains.",
+				);
+			}
+			continue;
+		}
+		byPublicName.set(publicKey, publicTargets);
+	}
+
+	return [...byPublicName].map(([name, targets]) => ({ [name]: targets }));
 }
 
 export function validateLiteLLMConfig(args: {

--- a/packages/sector7/tests/litellm-config.test.ts
+++ b/packages/sector7/tests/litellm-config.test.ts
@@ -285,6 +285,47 @@ describe("generateLiteLLMConfig", () => {
 		).toThrow(/Conflicting fallbacks for public model 'cheap'/);
 	});
 
+	it("throws when one team gives a shared public model a fallback and another leaves it empty", () => {
+		const modelGroups = buildLiteLLMTeamScopedModelGroups({
+			teams: [
+				{
+					id: "personal",
+					alias: "personal",
+					capabilities: [
+						{
+							name: "cheap",
+							deploymentIds: ["cheap-personal"],
+							fallbacks: ["local"],
+						},
+						{ name: "local", deploymentIds: ["local-personal"] },
+					],
+				},
+				{
+					id: "research",
+					alias: "research",
+					// research::cheap intentionally has NO fallback — the global
+					// `cheap -> local` entry would otherwise leak onto it.
+					capabilities: [
+						{ name: "cheap", deploymentIds: ["cheap-research"] },
+						{ name: "local", deploymentIds: ["local-research"] },
+					],
+				},
+			],
+		});
+		expect(() =>
+			generateLiteLLMConfig({
+				providers: { openai: { hasApiKey: true } },
+				deployments: [
+					"cheap-personal",
+					"local-personal",
+					"cheap-research",
+					"local-research",
+				].map((id) => ({ id, provider: "openai", providerModel: "openai/m" })),
+				modelGroups,
+			}),
+		).toThrow(/Conflicting fallbacks for public model 'cheap'.*\(none\)/s);
+	});
+
 	it("rejects missing deployment references and multi-replica without redis", () => {
 		expect(() =>
 			generateLiteLLMConfig({

--- a/packages/sector7/tests/litellm-config.test.ts
+++ b/packages/sector7/tests/litellm-config.test.ts
@@ -182,9 +182,10 @@ describe("generateLiteLLMConfig", () => {
 
 		const routerSettings = parsed.router_settings as Record<string, unknown>;
 		expect(routerSettings.routing_strategy).toBe("least-busy");
-		expect(routerSettings.fallbacks).toEqual([
-			{ "personal::coding": ["personal::cheap"] },
-		]);
+		// Keyed/valued by the PUBLIC model name, not the internal model_group name:
+		// LiteLLM looks fallbacks up by the team_public_model_name alias the client
+		// requested (litellm#10317), so internal-name keys never fire.
+		expect(routerSettings.fallbacks).toEqual([{ coding: ["cheap"] }]);
 
 		const generalSettings = parsed.general_settings as Record<string, unknown>;
 		expect(generalSettings.enforce_user_param).toBe(false);
@@ -193,6 +194,95 @@ describe("generateLiteLLMConfig", () => {
 		expect(litellmSettings.json_logs).toBe(true);
 		expect(litellmSettings.max_budget).toBe(999);
 		expect(litellmSettings.success_callback).toEqual(["prometheus"]);
+	});
+
+	it("dedupes a shared public fallback chain across teams into one entry", () => {
+		const modelGroups = buildLiteLLMTeamScopedModelGroups({
+			teams: ["personal", "research"].map((team) => ({
+				id: team,
+				alias: team,
+				capabilities: [
+					{
+						name: "cheap",
+						deploymentIds: [`cheap-${team}`],
+						fallbacks: ["local"],
+					},
+					{ name: "local", deploymentIds: [`local-${team}`] },
+				],
+			})),
+		});
+		const generated = generateLiteLLMConfig({
+			providers: { openai: { hasApiKey: true } },
+			deployments: ["personal", "research"].flatMap((team) => [
+				{
+					id: `cheap-${team}`,
+					provider: "openai",
+					providerModel: "openai/glm-4.7",
+				},
+				{
+					id: `local-${team}`,
+					provider: "openai",
+					providerModel: "openai/qwen3",
+				},
+			]),
+			modelGroups,
+		});
+		const routerSettings = (
+			parse(generated.configYaml) as Record<string, unknown>
+		).router_settings as Record<string, unknown>;
+		// Both teams map `cheap`->`local`; the global fallback map holds it once.
+		expect(routerSettings.fallbacks).toEqual([{ cheap: ["local"] }]);
+	});
+
+	it("throws when two teams give a shared public model conflicting fallbacks", () => {
+		const modelGroups = buildLiteLLMTeamScopedModelGroups({
+			teams: [
+				{
+					id: "personal",
+					alias: "personal",
+					capabilities: [
+						{
+							name: "cheap",
+							deploymentIds: ["cheap-personal"],
+							fallbacks: ["local"],
+						},
+						{ name: "local", deploymentIds: ["local-personal"] },
+						{ name: "smart", deploymentIds: ["smart-personal"] },
+					],
+				},
+				{
+					id: "research",
+					alias: "research",
+					capabilities: [
+						{
+							name: "cheap",
+							deploymentIds: ["cheap-research"],
+							fallbacks: ["smart"],
+						},
+						{ name: "local", deploymentIds: ["local-research"] },
+						{ name: "smart", deploymentIds: ["smart-research"] },
+					],
+				},
+			],
+		});
+		expect(() =>
+			generateLiteLLMConfig({
+				providers: { openai: { hasApiKey: true } },
+				deployments: [
+					"cheap-personal",
+					"local-personal",
+					"smart-personal",
+					"cheap-research",
+					"local-research",
+					"smart-research",
+				].map((id) => ({
+					id,
+					provider: "openai",
+					providerModel: "openai/m",
+				})),
+				modelGroups,
+			}),
+		).toThrow(/Conflicting fallbacks for public model 'cheap'/);
 	});
 
 	it("rejects missing deployment references and multi-replica without redis", () => {


### PR DESCRIPTION
## Summary

Team-scoped LiteLLM fallbacks never fired. `buildFallbackMap` keyed `router_settings.fallbacks` by the **internal** model_group name (`personal::cheap`), but LiteLLM resolves fallbacks by the **public** name the client requested (the `team_public_model_name` alias, e.g. `cheap`) — a known, won't-fix upstream limitation ([BerriAI/litellm#10317](https://github.com/BerriAI/litellm/issues/10317)). The fallback chain was registered under a key LiteLLM never looks up, so every team-scoped tier silently failed with *"No fallback model group found for original model_group=…"* instead of falling back.

## Fix
Key **and** value the fallback map by the public name (mapping each internal model_group → its `teamPublicModelName`):
- `{ "personal::coding": ["personal::cheap"] }` → `{ coding: ["cheap"] }`
- The fallback targets are public names too, so LiteLLM re-resolves them per-team-key (a personal key's `cheap` → `personal::cheap`).

Because the map is global and keyed by public name, two teams sharing a public model name must share its fallback chain: **identical chains dedupe** to one entry, **conflicting chains throw** with a clear message (rather than one silently winning).

Non-team-scoped groups (where `name` == public name) are unchanged.

## Test plan
- Full suite green (`vitest run`): **260 passed**, `tsc --noEmit` clean, biome formatted.
- Updated the team-scoped assertion to expect public-name keys.
- Added tests: cross-team **dedupe** (`{cheap:[local]}` once) and cross-team **conflict** (throws).

## Real-world impact / context
This is the root cause behind garden's inert tiers — `opus`/`smart-lite` 404'd with no fallback even though `opus→smart` (codex, healthy) was configured. Consumed by garden's LiteLLM stack; after release + dep bump, the cheap-tier rework gets a working qwen fallback.

> Note: end-to-end fallback firing is verified against the live LiteLLM on the garden deploy (config-generation is unit-tested here; the local containerized repro was blocked by no docker daemon).

🤖 Generated with [Claude Code](https://claude.com/claude-code)