### PR TITLE
release: bump to 0.16.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@jmmaloney4/sector7",
 	"private": true,
-	"version": "0.16.6",
+	"version": "0.16.7",
 	"description": "Sector7 monorepo",
 	"license": "MPL-2.0",
 	"workspaces": [

--- a/packages/sector7/package.json
+++ b/packages/sector7/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@jmmaloney4/sector7",
-	"version": "0.16.6",
+	"version": "0.16.7",
 	"description": "Reusable Pulumi components for infrastructure management",
 	"license": "MPL-2.0",
 	"publishConfig": {


### PR DESCRIPTION
Cuts **v0.16.7**, publishing the team-scoped fallback fix (#274) — router fallbacks keyed by public model name so team-aliased tiers fall back ([litellm#10317](https://github.com/BerriAI/litellm/issues/10317)).

After merge, tag `v0.16.7` triggers the pnpm release workflow to pack + upload `jmmaloney4-sector7-0.16.7.tgz`, which garden then pins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)