### PR TITLE
ci(nix-setup): disable build fsync on ephemeral CI runners

### DIFF
--- a/.github/actions/nix-setup/action.yml
+++ b/.github/actions/nix-setup/action.yml
@@ -38,6 +38,17 @@ runs:
         show_costs: true
         sccache: s3
     - uses: DeterminateSystems/nix-installer-action@1d87d45818068401a10cf16bdc5f00b24994a83f # main
+      with:
+        # Disable build fsync on CI runners. The nix-store workload is
+        # fsync-bound (sqlite path-registration + small-file writes); on a
+        # contended disk this serializes everything (~80% iowait observed on
+        # voldemort). Runners are ephemeral, so trading crash-durability for
+        # throughput is safe — a crashed job just re-runs. `fsync-store-paths`
+        # already defaults to false; pinned here so a future default change
+        # can't silently reintroduce the stall.
+        extra-conf: |
+          fsync-metadata = false
+          fsync-store-paths = false
     - if: ${{ inputs.cache == 'true' }}
       uses: DeterminateSystems/flakehub-cache-action@f9c8d8aaf92e6dbde896d6f84350f33d62392bd5 # main
       # TODO: Fix this


### PR DESCRIPTION
## Summary

Sets `fsync-metadata = false` (and pins `fsync-store-paths = false`, already the default) in the runner nix.conf, via the `DeterminateSystems/nix-installer-action` `extra-conf` input in `.github/actions/nix-setup/action.yml`.

**Why:** the nix-store workload is `fsync`-bound — sqlite path-registration + thousands of small random file writes. On a contended disk this serializes everything. While diagnosing ~2h CI jobs on `voldemort` we measured **~80% iowait** (PSI `io full avg10=78`) at only ~3 MB/s throughput, with the CPU sitting idle and clocking down to 800 MHz waiting on the disk. Disabling build `fsync` removes that serialization point.

**Why it's safe:** CI runners are **ephemeral**. `fsync` trades throughput for crash-durability; on a disposable runner a crash mid-build just re-runs the job, and the binary cache (Attic/FlakeHub) is the durable artifact — not the local store. This is a standard CI optimization.

## Blast radius

`nix-setup` is shared by every repo that calls it (garden, jackpkgs, cavinsresearch/zeus, …) and is referenced `@main`, so this takes effect for all of them on their next runner spin-up — no per-repo bump needed. The change is a universal CI win; no repo relies on runner-store crash-durability.

## Test plan

- [x] YAML validated with `yq` — `with.extra-conf` nests correctly under the installer step with the two nix.conf lines.
- [x] `extra-conf` confirmed as a real input on the pinned `nix-installer-action` (`@1d87d458`): *"Extra configuration lines for `/etc/nix/nix.conf`"*.
- [x] `fsync-metadata` / `fsync-store-paths` confirmed as valid nix settings (`nix config show`); `fsync-store-paths` already defaults to `false`.
- [ ] Real effect is observable only on a live runner — verify a post-merge CI job's nix.conf contains the settings and that iowait drops on a multi-job node.

Note: full local `nix flake check` was blocked by a **pre-existing** `pnpm-deps` FOD hash mismatch on `main` (unrelated to this YAML-only change, which touches no JS deps). Relying on PR CI for the formatter/lint gate.

## Risk

Low. Single composite-action change; no code/type/dependency impact. Worst case if a runner crashes mid-build is a re-run (already the norm for CI).

## Context

Diagnosed in garden investigation `docs/internal/investigations/2026-06-12-ci-runner-slowness-disk-io-and-oversubscription.md` (option #4). Companion fix already shipped: garden runner CPU request raised to 2 (`jmmaloney4/garden` `dc08d3dc`).