### PR TITLE
chore(renovate): enforce minimumReleaseAge via internalChecksFilter strict

### DIFF
--- a/renovate/default.json
+++ b/renovate/default.json
@@ -22,6 +22,7 @@
 	"dependencyDashboardLabels": ["chore/deps"],
 	"rangeStrategy": "pin",
 	"minimumReleaseAge": "4 days",
+	"internalChecksFilter": "strict",
 	"pinDigests": true,
 	"labels": ["chore/deps", "renovate"],
 	"commitMessagePrefix": "deps: ",


### PR DESCRIPTION
## Summary

Add `"internalChecksFilter": "strict"` to `renovate/default.json` so the existing `minimumReleaseAge: "4 days"` actually filters out fresh versions from PRs, instead of only gating Renovate's own automerge.

## Why

Without `internalChecksFilter: "strict"`, `minimumReleaseAge` is a *soft* gate:
1. Renovate opens the PR immediately with the fresh version.
2. It posts a pending `renovate/stability-days`-style check.
3. Renovate's own automerge waits for the check to pass.
4. A human clicking **Merge** in the GitHub UI bypasses the check entirely (unless branch protection requires it).

Concrete incident in zeus today: PRs cavinsresearch/zeus#971, #973, #975 were opened by Renovate at 14:43–14:45 UTC on 2026-06-13 carrying `@aws-sdk/client-s3@3.1068.0` (published 2026-06-12 18:59 UTC, ~20h old) and `tailwindcss@4.3.1` (published 2026-06-12 17:58 UTC, ~21h old). Jack manually merged each within ~90 seconds. The fresh lockfile entries then failed zeus's pnpm `minimumReleaseAge` policy on the next `pnpm install`, breaking `direnv reload`.

With `internalChecksFilter: "strict"`, Renovate filters at update selection: it will not propose `tailwindcss@4.3.1` until that version is ≥ 4 days old; it'll either target an older version that satisfies the window or hold the update. The PR you see is always merge-safe by the policy, regardless of whether a human or the bot merges.

Reference: https://docs.renovatebot.com/configuration-options/#internalchecksfilter

## Test plan

- [x] `nix build .#checks.x86_64-linux.renovate-config -L` passes (renovate-config-validator --strict on all preset files)
- [ ] On next Renovate run in a consumer repo (e.g. zeus), confirm freshly-published versions (<4 days old) no longer appear in PRs

## Risks

- Renovate dashboard may show fewer pending PRs (filtered at selection rather than queued with a pending status). This is the intended behavior; the package-rule override for `^jmmaloney4/sector7` already sets `minimumReleaseAge: null`, so internal sector7 updates are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)