### PR TITLE
ci(nix): wire attic cache into dogfood workflow

### DIFF
--- a/.github/workflows/_dogfood-nix.yml
+++ b/.github/workflows/_dogfood-nix.yml
@@ -15,3 +15,9 @@ jobs:
     with:
       repository: ${{ github.repository }}
       ref: ${{ github.ref }}
+      binary-cache-url: ${{ vars.ATTIC_CACHE_URL }}
+      binary-cache-public-key: ${{ vars.ATTIC_CACHE_PUBLIC_KEY }}
+      binary-cache-endpoint: ${{ vars.ATTIC_SERVER_URL }}
+      binary-cache-name: ${{ vars.ATTIC_CACHE_NAME }}
+    secrets:
+      BINARY_CACHE_TOKEN: ${{ secrets.ATTIC_CACHE_TOKEN }}

--- a/.github/workflows/_dogfood-nix.yml
+++ b/.github/workflows/_dogfood-nix.yml
@@ -20,4 +20,6 @@ jobs:
       binary-cache-endpoint: ${{ vars.ATTIC_SERVER_URL }}
       binary-cache-name: ${{ vars.ATTIC_CACHE_NAME }}
     secrets:
-      BINARY_CACHE_TOKEN: ${{ secrets.ATTIC_CACHE_TOKEN }}
+      # Only forward the push-capable cache token on trusted events so PR runs
+      # can read from the cache but not push to it.
+      BINARY_CACHE_TOKEN: ${{ github.event_name == 'push' && secrets.ATTIC_CACHE_TOKEN || '' }}

--- a/.github/workflows/_dogfood-nix.yml
+++ b/.github/workflows/_dogfood-nix.yml
@@ -20,6 +20,7 @@ jobs:
       binary-cache-endpoint: ${{ vars.ATTIC_SERVER_URL }}
       binary-cache-name: ${{ vars.ATTIC_CACHE_NAME }}
     secrets:
-      # Only forward the push-capable cache token on trusted events so PR runs
-      # can read from the cache but not push to it.
-      BINARY_CACHE_TOKEN: ${{ github.event_name == 'push' && secrets.ATTIC_CACHE_TOKEN || '' }}
+      # Forward the push-capable cache token only on trusted events (push,
+      # workflow_dispatch). PR runs read from the cache via the substituter
+      # but cannot push.
+      BINARY_CACHE_TOKEN: ${{ (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && secrets.ATTIC_CACHE_TOKEN || '' }}


### PR DESCRIPTION
## Summary

- Pass the \`ATTIC_*\` repo vars and \`ATTIC_CACHE_TOKEN\` secret to the reusable nix workflow from the dogfood caller (\`.github/workflows/_dogfood-nix.yml\`).
- Mirrors the wiring on \`jmmaloney4/garden\` and \`cavinsresearch/zeus\`.

## Dependency

Depends on **jmmaloney4/garden#842**, which provisions the \`ATTIC_*\` Actions vars and \`ATTIC_CACHE_TOKEN\` secret on this repo via the \`deploy/services/attic\` Pulumi stack. Until that lands and \`pulumi up\` runs, these references resolve to empty strings and the reusable workflow's cache-related steps are gated off (no-op) — so this PR is safe to land first; it just won't take effect until the vars exist.

## Test plan

- [ ] Merge jmmaloney4/garden#842 and run \`pulumi up\` on the \`attic\` stack.
- [ ] Trigger the dogfood workflow and confirm \`nix-eval-jobs\` skips cached store paths.
- [ ] Confirm \`attic watch-store\` starts in the detect job and the post-build push step runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)