### PR TITLE
ci(pulumi): plumb attic binary cache through reusable workflow

### DIFF
--- a/.github/actions/pulumi-setup/action.yml
+++ b/.github/actions/pulumi-setup/action.yml
@@ -10,10 +10,41 @@ inputs:
   nodejs_package_manager:
     description: 'Node.js package manager: "pnpm", "npm", or "none"'
     required: true
+  runs-on:
+    description: Runner label, forwarded to nix-setup for cache selection
+    required: false
+    default: ''
+  extra-substituters:
+    description: Optional newline-delimited extra substituter URLs, forwarded to nix-setup
+    required: false
+    default: ''
+  extra-trusted-public-keys:
+    description: Optional newline-delimited extra trusted public keys, forwarded to nix-setup
+    required: false
+    default: ''
+  attic-endpoint:
+    description: Optional Attic server endpoint, forwarded to nix-setup for watch-store push
+    required: false
+    default: ''
+  attic-cache-name:
+    description: Optional Attic cache name, forwarded to nix-setup
+    required: false
+    default: ''
+  attic-token:
+    description: Optional Attic push token, forwarded to nix-setup
+    required: false
+    default: ''
 runs:
   using: composite
   steps:
     - uses: jmmaloney4/sector7/.github/actions/nix-setup@main
+      with:
+        runs-on: ${{ inputs.runs-on }}
+        extra-substituters: ${{ inputs.extra-substituters }}
+        extra-trusted-public-keys: ${{ inputs.extra-trusted-public-keys }}
+        attic-endpoint: ${{ inputs.attic-endpoint }}
+        attic-cache-name: ${{ inputs.attic-cache-name }}
+        attic-token: ${{ inputs.attic-token }}
     - uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
       with:
         workload_identity_provider: ${{ inputs.google_workload_identity_provider }}

--- a/.github/actions/pulumi-setup/action.yml
+++ b/.github/actions/pulumi-setup/action.yml
@@ -40,9 +40,10 @@ runs:
     - uses: jmmaloney4/sector7/.github/actions/nix-setup@main
       with:
         runs-on: ${{ inputs.runs-on }}
-        # Mirror the detect-pulumi-stacks job: disable the FlakeHub fallback
-        # when a binary cache is configured, so the two jobs behave consistently.
-        cache: ${{ !contains(inputs.runs-on, 'self-hosted') && inputs.extra-substituters == '' }}
+        # Keep the FlakeHub fallback enabled unless a fully-configured custom
+        # cache is available (substituters + trusted keys both set), so a
+        # missing public key doesn't leave nix-setup without a usable cache.
+        cache: ${{ !contains(inputs.runs-on, 'self-hosted') && !(inputs.extra-substituters != '' && inputs.extra-trusted-public-keys != '') }}
         extra-substituters: ${{ inputs.extra-substituters }}
         extra-trusted-public-keys: ${{ inputs.extra-trusted-public-keys }}
         attic-endpoint: ${{ inputs.attic-endpoint }}

--- a/.github/actions/pulumi-setup/action.yml
+++ b/.github/actions/pulumi-setup/action.yml
@@ -40,6 +40,9 @@ runs:
     - uses: jmmaloney4/sector7/.github/actions/nix-setup@main
       with:
         runs-on: ${{ inputs.runs-on }}
+        # Mirror the detect-pulumi-stacks job: disable the FlakeHub fallback
+        # when a binary cache is configured, so the two jobs behave consistently.
+        cache: ${{ !contains(inputs.runs-on, 'self-hosted') && inputs.extra-substituters == '' }}
         extra-substituters: ${{ inputs.extra-substituters }}
         extra-trusted-public-keys: ${{ inputs.extra-trusted-public-keys }}
         attic-endpoint: ${{ inputs.attic-endpoint }}

--- a/.github/workflows/pulumi.yml
+++ b/.github/workflows/pulumi.yml
@@ -86,12 +86,16 @@ jobs:
       - uses: jmmaloney4/sector7/.github/actions/nix-setup@main
         with:
           runs-on: ${{ inputs.runs-on }}
-          cache: ${{ !contains(inputs.runs-on, 'self-hosted') && inputs.binary-cache-url == '' }}
+          # Keep the FlakeHub fallback enabled unless a fully-configured custom
+          # cache is available (URL + public key both set). A URL without a
+          # public key leaves nix-setup with an unverifiable substituter.
+          cache: ${{ !contains(inputs.runs-on, 'self-hosted') && !(inputs.binary-cache-url != '' && inputs.binary-cache-public-key != '') }}
           extra-substituters: ${{ inputs.binary-cache-url }}
           extra-trusted-public-keys: ${{ inputs.binary-cache-public-key }}
           attic-endpoint: ${{ inputs.binary-cache-endpoint }}
           attic-cache-name: ${{ inputs.binary-cache-name }}
-          attic-token: ${{ secrets.BINARY_CACHE_TOKEN }}
+          # Forks don't get push credentials even if the caller supplies a token.
+          attic-token: ${{ inputs.is_fork && '' || secrets.BINARY_CACHE_TOKEN }}
       - name: Detect all (project, stack) pairs
         id: set-matrix
         uses: jmmaloney4/sector7/.github/actions/detect-pulumi-stacks@main
@@ -135,7 +139,8 @@ jobs:
           extra-trusted-public-keys: ${{ inputs.binary-cache-public-key }}
           attic-endpoint: ${{ inputs.binary-cache-endpoint }}
           attic-cache-name: ${{ inputs.binary-cache-name }}
-          attic-token: ${{ secrets.BINARY_CACHE_TOKEN }}
+          # Forks don't get push credentials even if the caller supplies a token.
+          attic-token: ${{ inputs.is_fork && '' || secrets.BINARY_CACHE_TOKEN }}
       - name: Validate .#ci-pulumi shell
         shell: bash
         env:

--- a/.github/workflows/pulumi.yml
+++ b/.github/workflows/pulumi.yml
@@ -43,6 +43,30 @@ on:
         description: 'Node.js package manager: "pnpm", "npm", or "none"'
         required: true
         type: string
+      binary-cache-url:
+        description: 'Optional full binary cache URL to add as a substituter (e.g. https://cache.example.com/cache)'
+        required: false
+        default: ''
+        type: string
+      binary-cache-public-key:
+        description: 'Optional trusted public key for the binary cache'
+        required: false
+        default: ''
+        type: string
+      binary-cache-endpoint:
+        description: 'Optional Attic server endpoint (root URL) used for cache pushes'
+        required: false
+        default: ''
+        type: string
+      binary-cache-name:
+        description: 'Optional Attic cache name used for cache pushes'
+        required: false
+        default: ''
+        type: string
+    secrets:
+      BINARY_CACHE_TOKEN:
+        description: 'Optional Attic token used to push built store paths into the binary cache'
+        required: false
 jobs:
   detect-pulumi-stacks:
     name: "🧩 detect pulumi stacks"
@@ -62,7 +86,12 @@ jobs:
       - uses: jmmaloney4/sector7/.github/actions/nix-setup@main
         with:
           runs-on: ${{ inputs.runs-on }}
-          cache: ${{ !contains(inputs.runs-on, 'self-hosted') }}
+          cache: ${{ !contains(inputs.runs-on, 'self-hosted') && inputs.binary-cache-url == '' }}
+          extra-substituters: ${{ inputs.binary-cache-url }}
+          extra-trusted-public-keys: ${{ inputs.binary-cache-public-key }}
+          attic-endpoint: ${{ inputs.binary-cache-endpoint }}
+          attic-cache-name: ${{ inputs.binary-cache-name }}
+          attic-token: ${{ secrets.BINARY_CACHE_TOKEN }}
       - name: Detect all (project, stack) pairs
         id: set-matrix
         uses: jmmaloney4/sector7/.github/actions/detect-pulumi-stacks@main
@@ -101,6 +130,12 @@ jobs:
           google_workload_identity_provider: ${{ inputs.google_workload_identity_provider }}
           google_service_account_email: ${{ inputs.google_service_account_email }}
           nodejs_package_manager: ${{ inputs.nodejs_package_manager }}
+          runs-on: ${{ inputs.runs-on }}
+          extra-substituters: ${{ inputs.binary-cache-url }}
+          extra-trusted-public-keys: ${{ inputs.binary-cache-public-key }}
+          attic-endpoint: ${{ inputs.binary-cache-endpoint }}
+          attic-cache-name: ${{ inputs.binary-cache-name }}
+          attic-token: ${{ secrets.BINARY_CACHE_TOKEN }}
       - name: Validate .#ci-pulumi shell
         shell: bash
         env:


### PR DESCRIPTION
## Summary

Wire the same \`binary-cache-*\` inputs and \`BINARY_CACHE_TOKEN\` secret that the reusable \`nix.yml\` already accepts into the reusable \`pulumi.yml\` (and the \`pulumi-setup\` action it depends on).

- \`pulumi.yml\`: accept four new \`binary-cache-*\` inputs + \`BINARY_CACHE_TOKEN\` secret. Forward them to \`nix-setup\` in the detect job and to \`pulumi-setup\` in the preview+deploy job.
- \`pulumi-setup\`: accept the same set and forward to its nested \`nix-setup\` so the deploy job picks up the cache too.

When inputs are empty (any caller that hasn't been updated yet), \`nix-setup\`'s existing gates (\`extra-substituters != ''\`, \`attic-* != ''\`) keep everything no-op, so this is backwards-compatible. Self-hosted runners with the inputs unset continue to use the same fallback path as today.

## Why

The reusable pulumi workflow does heavy nix-store work inside \`nix develop .#ci-pulumi\` — pulling pulumi, node, gcloud, gke-gcloud-auth-plugin, package managers, etc. Without the Attic substituter, every preview and deploy rebuilds those store paths from source. Caller PRs (zeus, garden, yard) will follow to pass the inputs through.

## Test plan

- [ ] After merge, bump the SHA pin on the caller side (zeus / garden / yard pulumi.yml) and pass the \`ATTIC_*\` vars / secret. Confirm the first deploy after the bump pulls store paths from cache instead of rebuilding.
- [ ] Confirm \`attic watch-store\` starts in the detect job and the preview+deploy job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)