### PR TITLE
fix(renovate): restore npm minimum release age

### DIFF
--- a/renovate/minor-patch-automerge.json
+++ b/renovate/minor-patch-automerge.json
@@ -10,8 +10,7 @@
 			"matchUpdateTypes": ["minor", "patch", "pin"],
 			"automerge": true,
 			"addLabels": ["deps/npm"],
-			"schedule": ["at any time"],
-			"minimumReleaseAge": null
+			"schedule": ["at any time"]
 		},
 		{
 			"groupName": "Rust Dependencies",


### PR DESCRIPTION
## Summary
- remove the npm catch-all override that disabled `minimumReleaseAge` for grouped JS/TS minor and patch updates
- restore the shared 4-day stability gate from `renovate/default.json` for ordinary npm dependency bumps
- keep the more-specific exceptions intact (`Node.js Core`, `TypeScript Dependencies`, `Pulumi Dependencies`, internal sector7 tarballs)

## Why
We traced garden PR `jmmaloney4/garden#858` and found it was opened with npm updates younger than the intended 4-day floor because the shared Sector7 preset explicitly nullified the gate for the `JS/TS Dependencies` catch-all rule:

```json
{
  "groupName": "JS/TS Dependencies",
  "matchManagers": ["npm"],
  "matchUpdateTypes": ["minor", "patch", "pin"],
  "minimumReleaseAge": null
}
```

That override defeats the policy in `renovate/default.json`:

```json
"minimumReleaseAge": "4 days"
```

Given pnpm's own minimum-age supply-chain posture and the recent debugging around too-fresh npm releases, the catch-all npm rule should inherit the default gate instead of bypassing it.

## Validation
- `python3 -m json.tool renovate/minor-patch-automerge.json`
- inspected the effective preset chain from `renovate/all.json` through `renovate/default.json` and `renovate/minor-patch-automerge.json`
- attempted local Renovate validator execution; the repo's `checks.x86_64-darwin.renovate-config` wrapper is miswired under `nix run` on this machine, and direct `renovate-config-validator` currently requires a GitHub token even for static validation in this environment

## Risk
- npm minor/patch update PRs in downstream consumers will wait 4 days before opening/automerge unless a more-specific package rule still nullifies the gate
- this is the intended behavior change
