### PR TITLE
fix(renovate): group pep621 Python deps and ignore dbt_packages

### DIFF
--- a/renovate/default.json
+++ b/renovate/default.json
@@ -53,6 +53,11 @@
 			"description": "Skip dependency updates under docs/ directories — archived reference material not actively maintained",
 			"matchFileNames": ["**/docs/**"],
 			"enabled": false
+		},
+		{
+			"description": "Skip dependency updates under dbt_packages/ directories — vendored dbt package code, not maintained in this repo",
+			"matchFileNames": ["**/dbt_packages/**"],
+			"enabled": false
 		}
 	]
 }

--- a/renovate/minor-patch-automerge.json
+++ b/renovate/minor-patch-automerge.json
@@ -21,7 +21,7 @@
 		},
 		{
 			"groupName": "Python Dependencies",
-			"matchManagers": ["pip_requirements", "pip_setup", "pipenv", "poetry"],
+			"matchManagers": ["pip_requirements", "pip_setup", "pipenv", "poetry", "pep621"],
 			"matchDatasources": ["pypi"],
 			"matchUpdateTypes": ["minor", "patch"],
 			"automerge": true


### PR DESCRIPTION
## Summary

Two fixes to the shared Renovate presets, both surfaced by the `addendalabs/yard` dependency dashboard:

1. **Group PEP 621 Python deps.** The `Python Dependencies` group rule in `minor-patch-automerge.json` only matched the `pip_requirements`, `pip_setup`, `pipenv`, and `poetry` managers. Projects that declare dependencies in `pyproject.toml` `[project]` tables (PEP 621 / uv workspaces) are detected by Renovate's **`pep621`** manager, which was absent from `matchManagers`. Because `packageRules` conditions are AND-ed, the rule never matched and every Python minor/patch update opened its own PR instead of being grouped + automerged. Adds `pep621` to `matchManagers`.

2. **Ignore `dbt_packages/`.** Adds a `**/dbt_packages/**` disable rule in `default.json`, mirroring the existing `**/docs/**` rule. These are vendored dbt package checkouts (e.g. `dbt_utils`) not maintained in-repo; they were generating individual update PRs and lookup-failure warnings from their bundled CircleCI / docker-compose / GitHub Actions manifests.

## Test plan

- `renovate-config-validator --strict` passes on both edited files (the same check enforced by `checks.renovate-config` in `flake.nix`).
- After merge, the `pep621` Python updates in consumers (e.g. `addendalabs/yard`, issue addendalabs/yard#21) should collapse into a single "Python Dependencies" PR, and `dbt_packages/` detections should drop off the dashboard.

## Risks

- Low. Both changes are additive matcher/disable rules. The Python grouping inherits the existing rule's `automerge: true` for minor/patch only; major updates remain individual per `major-updates.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)