### PR TITLE
ci(pnpm): add attic cache support

### DIFF
--- a/.github/workflows/pnpm.yml
+++ b/.github/workflows/pnpm.yml
@@ -25,6 +25,30 @@ on:
         required: false
         type: string
         default: 'release'
+      binary-cache-url:
+        description: 'Optional full binary cache URL to add as a substituter (e.g. https://cache.example.com/cache)'
+        required: false
+        default: ''
+        type: string
+      binary-cache-public-key:
+        description: 'Optional trusted public key for the binary cache'
+        required: false
+        default: ''
+        type: string
+      binary-cache-endpoint:
+        description: 'Optional Attic server endpoint (root URL) used for cache pushes'
+        required: false
+        default: ''
+        type: string
+      binary-cache-name:
+        description: 'Optional Attic cache name used for cache pushes'
+        required: false
+        default: ''
+        type: string
+    secrets:
+      BINARY_CACHE_TOKEN:
+        description: 'Optional Attic token used to push built store paths into the binary cache'
+        required: false
 jobs:
   analyze:
     name: "🧱 analyze pnpm packages"
@@ -43,7 +67,15 @@ jobs:
       - uses: jmmaloney4/sector7/.github/actions/nix-setup@main
         with:
           runs-on: ${{ inputs.runs-on }}
-          cache: ${{ !contains(inputs.runs-on, 'self-hosted') }}
+          # Keep the FlakeHub fallback enabled unless a fully-configured custom
+          # cache is available (URL + public key both set). A URL without a
+          # public key leaves nix-setup with an unverifiable substituter.
+          cache: ${{ !contains(inputs.runs-on, 'self-hosted') && !(inputs.binary-cache-url != '' && inputs.binary-cache-public-key != '') }}
+          extra-substituters: ${{ inputs.binary-cache-url }}
+          extra-trusted-public-keys: ${{ inputs.binary-cache-public-key }}
+          attic-endpoint: ${{ inputs.binary-cache-endpoint }}
+          attic-cache-name: ${{ inputs.binary-cache-name }}
+          attic-token: ${{ secrets.BINARY_CACHE_TOKEN }}
       - name: Add ci-pnpm tools to PATH
         run: nix develop .#ci-pnpm --command bash -c 'echo "$PATH" >> "$GITHUB_PATH"'
       - name: Analyze packages (target=${{ inputs.target }})
@@ -78,7 +110,15 @@ jobs:
       - uses: jmmaloney4/sector7/.github/actions/nix-setup@main
         with:
           runs-on: ${{ inputs.runs-on }}
-          cache: ${{ !contains(inputs.runs-on, 'self-hosted') }}
+          # Keep the FlakeHub fallback enabled unless a fully-configured custom
+          # cache is available (URL + public key both set). A URL without a
+          # public key leaves nix-setup with an unverifiable substituter.
+          cache: ${{ !contains(inputs.runs-on, 'self-hosted') && !(inputs.binary-cache-url != '' && inputs.binary-cache-public-key != '') }}
+          extra-substituters: ${{ inputs.binary-cache-url }}
+          extra-trusted-public-keys: ${{ inputs.binary-cache-public-key }}
+          attic-endpoint: ${{ inputs.binary-cache-endpoint }}
+          attic-cache-name: ${{ inputs.binary-cache-name }}
+          attic-token: ${{ secrets.BINARY_CACHE_TOKEN }}
       - name: Verify lockfile is up to date
         run: nix develop .#ci-pnpm --command pnpm install --frozen-lockfile
   publish-packages:
@@ -100,7 +140,15 @@ jobs:
       - uses: jmmaloney4/sector7/.github/actions/nix-setup@main
         with:
           runs-on: ${{ inputs.runs-on }}
-          cache: ${{ !contains(inputs.runs-on, 'self-hosted') }}
+          # Keep the FlakeHub fallback enabled unless a fully-configured custom
+          # cache is available (URL + public key both set). A URL without a
+          # public key leaves nix-setup with an unverifiable substituter.
+          cache: ${{ !contains(inputs.runs-on, 'self-hosted') && !(inputs.binary-cache-url != '' && inputs.binary-cache-public-key != '') }}
+          extra-substituters: ${{ inputs.binary-cache-url }}
+          extra-trusted-public-keys: ${{ inputs.binary-cache-public-key }}
+          attic-endpoint: ${{ inputs.binary-cache-endpoint }}
+          attic-cache-name: ${{ inputs.binary-cache-name }}
+          attic-token: ${{ secrets.BINARY_CACHE_TOKEN }}
       - name: Add ci-pnpm tools to PATH
         run: nix develop .#ci-pnpm --command bash -c 'echo "$PATH" >> "$GITHUB_PATH"'
       - name: Install dependencies

--- a/.github/workflows/pnpm.yml
+++ b/.github/workflows/pnpm.yml
@@ -71,11 +71,11 @@ jobs:
           # cache is available (URL + public key both set). A URL without a
           # public key leaves nix-setup with an unverifiable substituter.
           cache: ${{ !contains(inputs.runs-on, 'self-hosted') && !(inputs.binary-cache-url != '' && inputs.binary-cache-public-key != '') }}
-          extra-substituters: ${{ inputs.binary-cache-url }}
-          extra-trusted-public-keys: ${{ inputs.binary-cache-public-key }}
-          attic-endpoint: ${{ inputs.binary-cache-endpoint }}
-          attic-cache-name: ${{ inputs.binary-cache-name }}
-          attic-token: ${{ secrets.BINARY_CACHE_TOKEN }}
+          extra-substituters: ${{ inputs.binary-cache-url != '' && inputs.binary-cache-public-key != '' && inputs.binary-cache-url || '' }}
+          extra-trusted-public-keys: ${{ inputs.binary-cache-url != '' && inputs.binary-cache-public-key != '' && inputs.binary-cache-public-key || '' }}
+          attic-endpoint: ${{ inputs.binary-cache-endpoint != '' && inputs.binary-cache-name != '' && secrets.BINARY_CACHE_TOKEN != '' && inputs.binary-cache-endpoint || '' }}
+          attic-cache-name: ${{ inputs.binary-cache-endpoint != '' && inputs.binary-cache-name != '' && secrets.BINARY_CACHE_TOKEN != '' && inputs.binary-cache-name || '' }}
+          attic-token: ${{ inputs.binary-cache-endpoint != '' && inputs.binary-cache-name != '' && secrets.BINARY_CACHE_TOKEN != '' && secrets.BINARY_CACHE_TOKEN || '' }}
       - name: Add ci-pnpm tools to PATH
         run: nix develop .#ci-pnpm --command bash -c 'echo "$PATH" >> "$GITHUB_PATH"'
       - name: Analyze packages (target=${{ inputs.target }})
@@ -114,11 +114,11 @@ jobs:
           # cache is available (URL + public key both set). A URL without a
           # public key leaves nix-setup with an unverifiable substituter.
           cache: ${{ !contains(inputs.runs-on, 'self-hosted') && !(inputs.binary-cache-url != '' && inputs.binary-cache-public-key != '') }}
-          extra-substituters: ${{ inputs.binary-cache-url }}
-          extra-trusted-public-keys: ${{ inputs.binary-cache-public-key }}
-          attic-endpoint: ${{ inputs.binary-cache-endpoint }}
-          attic-cache-name: ${{ inputs.binary-cache-name }}
-          attic-token: ${{ secrets.BINARY_CACHE_TOKEN }}
+          extra-substituters: ${{ inputs.binary-cache-url != '' && inputs.binary-cache-public-key != '' && inputs.binary-cache-url || '' }}
+          extra-trusted-public-keys: ${{ inputs.binary-cache-url != '' && inputs.binary-cache-public-key != '' && inputs.binary-cache-public-key || '' }}
+          attic-endpoint: ${{ inputs.binary-cache-endpoint != '' && inputs.binary-cache-name != '' && secrets.BINARY_CACHE_TOKEN != '' && inputs.binary-cache-endpoint || '' }}
+          attic-cache-name: ${{ inputs.binary-cache-endpoint != '' && inputs.binary-cache-name != '' && secrets.BINARY_CACHE_TOKEN != '' && inputs.binary-cache-name || '' }}
+          attic-token: ${{ inputs.binary-cache-endpoint != '' && inputs.binary-cache-name != '' && secrets.BINARY_CACHE_TOKEN != '' && secrets.BINARY_CACHE_TOKEN || '' }}
       - name: Verify lockfile is up to date
         run: nix develop .#ci-pnpm --command pnpm install --frozen-lockfile
   publish-packages:
@@ -144,11 +144,11 @@ jobs:
           # cache is available (URL + public key both set). A URL without a
           # public key leaves nix-setup with an unverifiable substituter.
           cache: ${{ !contains(inputs.runs-on, 'self-hosted') && !(inputs.binary-cache-url != '' && inputs.binary-cache-public-key != '') }}
-          extra-substituters: ${{ inputs.binary-cache-url }}
-          extra-trusted-public-keys: ${{ inputs.binary-cache-public-key }}
-          attic-endpoint: ${{ inputs.binary-cache-endpoint }}
-          attic-cache-name: ${{ inputs.binary-cache-name }}
-          attic-token: ${{ secrets.BINARY_CACHE_TOKEN }}
+          extra-substituters: ${{ inputs.binary-cache-url != '' && inputs.binary-cache-public-key != '' && inputs.binary-cache-url || '' }}
+          extra-trusted-public-keys: ${{ inputs.binary-cache-url != '' && inputs.binary-cache-public-key != '' && inputs.binary-cache-public-key || '' }}
+          attic-endpoint: ${{ inputs.binary-cache-endpoint != '' && inputs.binary-cache-name != '' && secrets.BINARY_CACHE_TOKEN != '' && inputs.binary-cache-endpoint || '' }}
+          attic-cache-name: ${{ inputs.binary-cache-endpoint != '' && inputs.binary-cache-name != '' && secrets.BINARY_CACHE_TOKEN != '' && inputs.binary-cache-name || '' }}
+          attic-token: ${{ inputs.binary-cache-endpoint != '' && inputs.binary-cache-name != '' && secrets.BINARY_CACHE_TOKEN != '' && secrets.BINARY_CACHE_TOKEN || '' }}
       - name: Add ci-pnpm tools to PATH
         run: nix develop .#ci-pnpm --command bash -c 'echo "$PATH" >> "$GITHUB_PATH"'
       - name: Install dependencies


### PR DESCRIPTION
## Summary
- add Attic binary cache inputs to the reusable `pnpm.yml` workflow
- thread those inputs through every `nix-setup` call in `analyze`, `verify-lockfile`, and `publish-packages`
- match the cache-selection behavior already used in `pulumi.yml`: keep FlakeHub fallback unless both custom cache URL and public key are provided

## Why
- `pnpm.yml` was the odd workflow out: `nix.yml` and `pulumi.yml` already support custom Attic substituters and push credentials
- this lets callers seed and reuse the same binary cache path for pnpm CI without forking the workflow

## Validation
- `git diff --check`
- `nix flake check -L` *(fails on pre-existing unrelated treefmt churn in `renovate/minor-patch-automerge.json`; the workflow change itself evaluates cleanly and the pnpm deps derivation starts successfully)*

## Risks
- low risk: change is limited to reusable workflow inputs and `nix-setup` wiring
- no behavior change for existing callers unless they pass the new cache inputs/secrets
