### PR TITLE
chore(renovate): drop minimumReleaseAge overrides except first-party sector7

### DIFF
--- a/renovate/minor-patch-automerge.json
+++ b/renovate/minor-patch-automerge.json
@@ -31,16 +31,14 @@
 			"matchPackageNames": ["@types/node", "node", "ts-node"],
 			"matchUpdateTypes": ["minor", "patch"],
 			"automerge": true,
-			"schedule": ["at any time"],
-			"minimumReleaseAge": null
+			"schedule": ["at any time"]
 		},
 		{
 			"groupName": "TypeScript Dependencies",
 			"matchPackageNames": ["typescript", "@types/*"],
 			"matchUpdateTypes": ["minor", "patch"],
 			"automerge": true,
-			"schedule": ["at any time"],
-			"minimumReleaseAge": null
+			"schedule": ["at any time"]
 		},
 		{
 			"groupName": "Testing Dependencies",
@@ -75,8 +73,7 @@
 			"matchUpdateTypes": ["minor", "patch"],
 			"automerge": true,
 			"addLabels": ["deps/pulumi"],
-			"schedule": ["at any time"],
-			"minimumReleaseAge": null
+			"schedule": ["at any time"]
 		},
 		{
 			"description": "Deduplicate pnpm installs when updating Pulumi npm packages",
@@ -86,8 +83,7 @@
 			"matchUpdateTypes": ["minor", "patch"],
 			"addLabels": ["deps/pulumi"],
 			"postUpdateOptions": ["pnpmDedupe"],
-			"schedule": ["at any time"],
-			"minimumReleaseAge": null
+			"schedule": ["at any time"]
 		},
 		{
 			"groupName": "Nix Dependencies",


### PR DESCRIPTION
## Summary

The 4-day stability gate (`minimumReleaseAge: "4 days"` in `default.json`) was being silently overridden to `null` on four package groups in `minor-patch-automerge.json`, letting **third-party** minor/patch updates merge with **zero soak time**:

- `Node.js Core`
- `TypeScript Dependencies`
- `Pulumi Dependencies`
- the Pulumi `pnpmDedupe` dedup rule

This is why [garden#885](https://github.com/jmmaloney4/garden/pull/885) opened+automerged `@pulumi/gcp` `9.26.0 → 9.27.0` when the release was only ~5 hours old — the Pulumi group exempted it from the 4-day gate.

This PR removes those four overrides so external dependencies respect the 4-day default again.

## What is intentionally kept

`null` overrides remain **only** for first-party sector7 self-references, which have no reason to soak before merging:

| File | Rule | Why kept |
|---|---|---|
| `default.json` | internal sector7 actions (own repo) | first-party |
| `sector7-release-tarballs.json` | `jmmaloney4/sector7` package via GitHub release tarballs | first-party (our own published package) |

The `"4 days"` default in `default.json` is unchanged.

## Test plan

- [x] `nix build .#checks.aarch64-darwin.renovate-config` — `renovate-config-validator --strict` passes for all presets (exit 0)
- [x] `python3 -m json.tool` valid for every renovate JSON
- [x] `grep minimumReleaseAge renovate/` confirms only the three intended references remain (4-day default + two first-party `null`s)

## Risk

Low — config-only. Effect: Node/TypeScript/Pulumi minor+patch PRs now wait 4 days before automerge, matching every other third-party dependency. No change to first-party sector7 release flow.