### PR TITLE
fix(renovate): make helm-chart YAML manager RE2-compatible

### DIFF
--- a/renovate/yaml-manifests.json
+++ b/renovate/yaml-manifests.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://docs.renovatebot.com/renovate-schema.json",
-	"description": "Track annotated dependency pins in YAML files that Renovate's built-in managers don't cover: (1) container images in Kubernetes or HelmChart CRD manifests, and (2) Helm chart versions in HelmChart CRD specs. Both patterns require an inline `# renovate:` comment annotation on the line above, matching the opt-in style of renovate/docker-images.json. For container images, the image string itself carries the registry/repo:tag, so only datasource=docker is required in the annotation. For Helm chart versions, the annotation should include datasource=helm, depName, and optional registryUrl because the chart name and repo URL may be on separate lines.",
+	"description": "Track annotated dependency pins in YAML files that Renovate's built-in managers don't cover: (1) container images in Kubernetes or HelmChart CRD manifests, and (2) Helm chart versions in HelmChart CRD specs. Both patterns require an inline `# renovate:` comment annotation on the line above, matching the opt-in style of renovate/docker-images.json. For container images, the image string itself carries the registry/repo:tag, so only datasource=docker is required in the annotation. For Helm chart versions, the annotation fields must appear in order — datasource=helm depName=<chart> [registryUrl=<url>] [versioning=<scheme>] — because Renovate compiles matchStrings with RE2, which does not support the lookahead assertions that would otherwise allow arbitrary field order.",
 	"customManagers": [
 		{
 			"customType": "regex",
@@ -15,10 +15,10 @@
 		},
 		{
 			"customType": "regex",
-			"description": "Annotated Helm chart versions in YAML",
+			"description": "Annotated Helm chart versions in YAML; annotation fields are order-sensitive (depName, then optional registryUrl, then optional versioning) for RE2 compatibility",
 			"managerFilePatterns": ["/\\.ya?ml$/"],
 			"matchStrings": [
-				"#\\s*renovate:\\s*datasource=helm(?=[^\\n]*?\\bdepName=(?<depName>\\S+))(?=[^\\n]*?\\bregistryUrl=(?<registryUrl>\\S+))?(?=[^\\n]*?\\bversioning=(?<versioning>\\S+))?[^\\n]*\\r?\\n[^\\n]*?version:\\s*[\"']?(?<currentValue>[^\"'\\s]+)[\"']?"
+				"#\\s*renovate:\\s*datasource=helm\\s+depName=(?<depName>\\S+)(?:\\s+registryUrl=(?<registryUrl>\\S+))?(?:\\s+versioning=(?<versioning>\\S+))?[^\\n]*\\r?\\n[^\\n]*?version:\\s*[\"']?(?<currentValue>[^\"'\\s]+)[\"']?"
 			],
 			"datasourceTemplate": "helm",
 			"depNameTemplate": "{{{depName}}}",


### PR DESCRIPTION
## Summary

The `renovate-config` flake check (`renovate-config-validator --strict`) has been **failing on every fresh build of `main`** since #289. The cause: the helm-chart custom manager in `renovate/yaml-manifests.json` uses **lookahead assertions** (`(?=...)`) to allow arbitrary annotation field order. Renovate compiles `customManagers` matchStrings with **RE2, which does not support lookahead**, so the validator rejects it:

```
Invalid regExp for customManagers: `#\s*renovate:\s*datasource=helm(?=...)...`
```

(`main` only *looked* green because of a stale cached/substituted Nix build output — a fresh build, or a branch with content byte-identical to `main`, fails identically.)

## Fix

Rewrite the matchString without lookahead by requiring a **fixed field order**:

```
# renovate: datasource=helm depName=<chart> [registryUrl=<url>] [versioning=<scheme>]
```

`depName` is required; `registryUrl` and `versioning` remain optional but must follow in that order. Descriptions updated to document the constraint and the RE2 rationale.

## Test plan

- `jq` parse of `renovate/yaml-manifests.json` ✅
- `nix build .#checks.aarch64-darwin.renovate-config` → **exit 0** (was exit 1 on `main`) ✅
- Regex match tests:
  - `depName` only → matches, captures `currentValue` ✅
  - `depName` + `registryUrl` (quoted version) → matches ✅
  - `depName` + `registryUrl` + `versioning` → matches ✅
  - wrong field order → correctly no match ✅

## Risks

- The annotation field order is now enforced. The YAML preset is new (#289) with no known consumers yet, so impact is minimal. Any future annotations must follow the documented order.

## Notes

Unblocks a follow-up renovate-preset cleanup PR (schedules / rate limits / sector7 digest pinning), which will rebase on top of this once merged.