### PR TITLE
refactor(renovate): unify schedules, drop PR rate limits, restore sector7 digest pinning

### DIFF
--- a/renovate/default.json
+++ b/renovate/default.json
@@ -11,8 +11,8 @@
 		":pinAllExceptPeerDependencies"
 	],
 	"schedule": ["before 4:00 am"],
-	"prHourlyLimit": 10,
-	"prConcurrentLimit": 5,
+	"prHourlyLimit": 0,
+	"prConcurrentLimit": 0,
 	"rebaseWhen": "conflicted",
 	"automergeType": "pr",
 	"automergeStrategy": "merge",
@@ -39,10 +39,9 @@
 	},
 	"packageRules": [
 		{
-			"description": "Skip pinning and stability days for internal sector7 actions (own repo)",
+			"description": "Skip the stability delay for internal sector7 actions (own repo); digest pinning still applies via the global pinDigests policy",
 			"matchPackageNames": ["/^jmmaloney4\\/sector7($|\\/)/"],
-			"minimumReleaseAge": null,
-			"pinDigests": false
+			"minimumReleaseAge": null
 		},
 		{
 			"description": "Disable requires-python updates — managed manually per project as a capped minor range (e.g. >=3.13,<3.14)",

--- a/renovate/lock-maintenance.json
+++ b/renovate/lock-maintenance.json
@@ -4,7 +4,7 @@
 	"addLabels": ["renovate"],
 	"lockFileMaintenance": {
 		"enabled": true,
-		"schedule": ["before 4:00 am on the first day of the month"],
+		"schedule": ["before 4:00 am on Sunday"],
 		"automerge": true,
 		"packageRules": [{ "matchManagers": ["nix"], "allowedVersions": ">=0" }]
 	}

--- a/renovate/minor-patch-automerge.json
+++ b/renovate/minor-patch-automerge.json
@@ -9,8 +9,7 @@
 			"matchManagers": ["npm"],
 			"matchUpdateTypes": ["minor", "patch", "pin"],
 			"automerge": true,
-			"addLabels": ["deps/npm"],
-			"schedule": ["at any time"]
+			"addLabels": ["deps/npm"]
 		},
 		{
 			"groupName": "Rust Dependencies",
@@ -30,19 +29,11 @@
 			"groupName": "Node.js Core",
 			"matchPackageNames": ["@types/node", "node", "ts-node"],
 			"matchUpdateTypes": ["minor", "patch"],
-			"automerge": true,
-			"schedule": ["at any time"]
+			"automerge": true
 		},
 		{
 			"groupName": "TypeScript Dependencies",
 			"matchPackageNames": ["typescript", "@types/*"],
-			"matchUpdateTypes": ["minor", "patch"],
-			"automerge": true,
-			"schedule": ["at any time"]
-		},
-		{
-			"groupName": "Testing Dependencies",
-			"matchPackageNames": ["jest", "@types/jest"],
 			"matchUpdateTypes": ["minor", "patch"],
 			"automerge": true
 		},
@@ -72,8 +63,7 @@
 			"matchPackageNames": ["/@pulumi/*/", "/pulumi*/"],
 			"matchUpdateTypes": ["minor", "patch"],
 			"automerge": true,
-			"addLabels": ["deps/pulumi"],
-			"schedule": ["at any time"]
+			"addLabels": ["deps/pulumi"]
 		},
 		{
 			"description": "Deduplicate pnpm installs when updating Pulumi npm packages",
@@ -82,15 +72,13 @@
 			"matchPackageNames": ["/@pulumi/*/", "/pulumi*/"],
 			"matchUpdateTypes": ["minor", "patch"],
 			"addLabels": ["deps/pulumi"],
-			"postUpdateOptions": ["pnpmDedupe"],
-			"schedule": ["at any time"]
+			"postUpdateOptions": ["pnpmDedupe"]
 		},
 		{
 			"groupName": "Nix Dependencies",
 			"matchManagers": ["nix"],
 			"matchUpdateTypes": ["minor", "patch"],
-			"automerge": true,
-			"schedule": ["before 4:00 am on Saturday and Sunday"]
+			"automerge": true
 		},
 		{
 			"groupName": "Nix PyPI Dependencies",
@@ -98,7 +86,6 @@
 			"matchDatasources": ["pypi"],
 			"matchUpdateTypes": ["minor", "patch"],
 			"automerge": true,
-			"schedule": ["before 4:00 am on Saturday and Sunday"],
 			"addLabels": ["deps/nix/pypi"]
 		},
 		{
@@ -107,7 +94,6 @@
 			"matchDatasources": ["github-releases"],
 			"matchUpdateTypes": ["minor", "patch"],
 			"automerge": true,
-			"schedule": ["before 4:00 am on Saturday and Sunday"],
 			"addLabels": ["deps/nix/github"]
 		}
 	]


### PR DESCRIPTION
## Summary

Cleanup of the shared Renovate presets, per request:

### `default.json`
- **Disable PR rate limits**: `prHourlyLimit` and `prConcurrentLimit` set to `0` (unlimited). Renovate treats `0` as "no limit" — deleting the keys would instead revert to Renovate's built-in defaults (2/hour, 10 concurrent), which is *not* the goal.
- **Restore digest pinning for internal sector7 action refs**: removed `pinDigests: false` from the `jmmaloney4/sector7` packageRule so it inherits the global `pinDigests: true`. The stability-delay exemption (`minimumReleaseAge: null`) is **kept** — first-party refs still skip the 4-day wait, but are now digest-pinned again like everything else.

### `minor-patch-automerge.json`
- **Removed the `Testing Dependencies` group** (matched `jest` / `@types/jest`). We use vitest, which already flows into the `JS/TS Dependencies` npm catch-all group (still automerged).
- **Unified all schedules**: stripped every per-group `schedule` override (`at any time` on JS/TS, Node.js Core, TypeScript, Pulumi ×2; `before 4:00 am on Saturday and Sunday` on the three Nix groups) so every group now inherits the global `before 4:00 am` (any day of the week).

### `lock-maintenance.json`
- Moved lock file maintenance from monthly (`before 4:00 am on the first day of the month`) to **weekly on Sundays** (`before 4:00 am on Sunday`).

## Test plan

- `jq` parse of all three changed files ✅
- `nix build .#checks.aarch64-darwin.renovate-config` (`renovate-config-validator --strict`) → **exit 0** ✅
- Confirmed no stray `schedule` overrides, `at any time`, weekend, monthly, or `Testing Dependencies` references remain ✅

## Risks

- **No rate limiting**: Renovate may open many PRs at once during a busy update window. This is the requested behavior; `prConcurrentLimit`/`prHourlyLimit` can be reintroduced if it becomes noisy.
- Schedule consolidation means previously-"at any time" groups (JS/TS, Pulumi, etc.) now only open in the pre-4am window.

## Notes

Rebased on top of #291 (the RE2 helm-regex fix), which unblocked the `renovate-config` flake check.