### PR TITLE
feat(nix-setup): use host Nix daemon when present, skip in-pod install

### DIFF
--- a/.github/actions/nix-setup/action.yml
+++ b/.github/actions/nix-setup/action.yml
@@ -53,9 +53,13 @@ runs:
           echo "Host Nix daemon detected; using the host store, skipping in-pod install."
           echo "present=true" >> "$GITHUB_OUTPUT"
           echo "NIX_REMOTE=daemon" >> "$GITHUB_ENV"
-          # The node mounts /nix but not /run/current-system, so expose the
-          # host store's Nix CLI via the daemon's own default profile.
-          echo "/nix/var/nix/profiles/default/bin" >> "$GITHUB_PATH"
+          # The node mounts /nix but not /run/current-system, so expose the host
+          # store's Nix CLI via the NixOS *system* profile, which lives under
+          # /nix (so it comes with the mount) and carries nix. NB: the *default*
+          # profile (/nix/var/nix/profiles/default) does NOT contain nix on
+          # NixOS — verified on voldemort (Determinate Nix 3.21.1), where nix is
+          # at /nix/var/nix/profiles/system/sw/bin/nix.
+          echo "/nix/var/nix/profiles/system/sw/bin" >> "$GITHUB_PATH"
         else
           echo "No host Nix daemon; will install Nix in-pod."
           echo "present=false" >> "$GITHUB_OUTPUT"

--- a/.github/actions/nix-setup/action.yml
+++ b/.github/actions/nix-setup/action.yml
@@ -37,7 +37,31 @@ runs:
       with:
         show_costs: true
         sccache: s3
-    - uses: DeterminateSystems/nix-installer-action@a7ad9c4f0c65208097f4d34f3cfa1913b80cce5c # main
+    # If the runner has a host Nix daemon available (its /nix store and daemon
+    # socket bind-mounted from the node — see garden's ARC runner template), use
+    # that warm, shared store instead of installing a second, per-pod Nix. Two
+    # independent daemons writing one /nix corrupt the store, so every step that
+    # installs or configures in-pod Nix below is gated on the host daemon being
+    # ABSENT. This auto-detects via the socket, so consumers without a host
+    # daemon (cloud runners) are unaffected, and it safely no-ops until the
+    # mount is actually present.
+    - name: Detect host Nix daemon
+      id: host-daemon
+      shell: bash
+      run: |
+        if [ -S /nix/var/nix/daemon-socket/socket ]; then
+          echo "Host Nix daemon detected; using the host store, skipping in-pod install."
+          echo "present=true" >> "$GITHUB_OUTPUT"
+          echo "NIX_REMOTE=daemon" >> "$GITHUB_ENV"
+          # The node mounts /nix but not /run/current-system, so expose the
+          # host store's Nix CLI via the daemon's own default profile.
+          echo "/nix/var/nix/profiles/default/bin" >> "$GITHUB_PATH"
+        else
+          echo "No host Nix daemon; will install Nix in-pod."
+          echo "present=false" >> "$GITHUB_OUTPUT"
+        fi
+    - if: ${{ steps.host-daemon.outputs.present != 'true' }}
+      uses: DeterminateSystems/nix-installer-action@a7ad9c4f0c65208097f4d34f3cfa1913b80cce5c # main
       with:
         # Disable build fsync on CI runners. The nix-store workload is
         # fsync-bound (sqlite path-registration + small-file writes); on a
@@ -49,12 +73,15 @@ runs:
         extra-conf: |
           fsync-metadata = false
           fsync-store-paths = false
-    - if: ${{ inputs.cache == 'true' }}
+    - if: ${{ inputs.cache == 'true' && steps.host-daemon.outputs.present != 'true' }}
       uses: DeterminateSystems/flakehub-cache-action@9926dde74484ccb2224835b80531de64ed4336ef # main
       # TODO: Fix this
       # with:
       # use-gha-cache: enabled
-    - if: ${{ inputs.extra-substituters != '' || inputs.extra-trusted-public-keys != '' }}
+    # Skipped when using a host daemon: client-side nix.conf edits don't take
+    # effect for an untrusted daemon client, and the host daemon already carries
+    # the homelab substituters/keys (Attic-first) from its NixOS config.
+    - if: ${{ (inputs.extra-substituters != '' || inputs.extra-trusted-public-keys != '') && steps.host-daemon.outputs.present != 'true' }}
       shell: bash
       env:
         INPUT_EXTRA_SUBSTITUTERS: ${{ inputs.extra-substituters }}


### PR DESCRIPTION
**DRAFT** — PR2 of the warm CI store work (ADR `105-ci-runner-host-nix-daemon-warm-store`, ergodicsystems/hq#173). Spec: jmmaloney4/garden#1007. Pairs with the garden ARC mount PR (PR3). **Do not merge** until validated on a canary runner.

## Why

The slow `detect`/nix-eval-jobs job is a cold-store evaluation — every ephemeral runner installs Nix from scratch. ADR 105's fix is to give runners a **warm shared `/nix`** by bind-mounting the node's store + daemon socket into the pod (garden PR3) and having them use the **host** Nix daemon instead of installing their own. Two independent daemons writing one `/nix` corrupt the store, so the in-pod installer must be skipped when a host daemon is present.

## What

`.github/actions/nix-setup/action.yml`: a new **auto-detecting** gate.

- New `Detect host Nix daemon` step probes `/nix/var/nix/daemon-socket/socket`.
- **When present:** set `NIX_REMOTE=daemon`, put the host store's Nix CLI on `PATH`, and **skip** the in-pod `nix-installer-action`, `flakehub-cache-action`, and client-side `configure-binary-cache.sh`.
- **When absent (cloud runners):** behavior is **unchanged** — installer runs as before.

Auto-detection means no caller change is needed and it safely no-ops until garden PR3 actually mounts the socket.

## Open questions for canary validation

1. **Nix CLI on PATH.** The node mounts `/nix` but not `/run/current-system`. This uses `/nix/var/nix/profiles/default/bin` — needs confirming that path exposes a usable `nix` on voldemort (may need PR3 to also surface the system profile / a wrapper).
2. **Daemon-client trust.** The runner connects to the host daemon as the pod uid; confirm it can build/realise. `trusted-users`/uid mapping is deferred to PR3 — verify whether it's actually needed for the CI workload (plain builds don't require trust; client-side substituter overrides do, which we now skip).
3. **watch-store** step left as-is (best-effort, creds-gated) — confirm it behaves sanely against the host store.

## Validation

`action.yml` parses as valid YAML. Real validation is a canary runner with the PR3 mount — tracked before un-drafting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)