### PR TITLE
feat(cloudsql): enable structured JSON logs by default on auth-proxy sidecar

### DIFF
--- a/packages/sector7/cloudsql/auth-proxy-sidecar.ts
+++ b/packages/sector7/cloudsql/auth-proxy-sidecar.ts
@@ -50,6 +50,13 @@ export interface CloudSqlAuthProxySidecarArgs {
 	databaseUrl?: pulumi.Input<string>;
 	proxyPort?: pulumi.Input<number>;
 	image?: pulumi.Input<string>;
+	/**
+	 * Emit logs in the proxy's structured JSON `LogEntry` format
+	 * (`--structured-logs`). Defaults to `true` so sidecar logs are
+	 * machine-parseable by cluster log pipelines (e.g. Loki/Alloy) instead of
+	 * unstructured text. Set to `false` to restore the proxy's plaintext logs.
+	 */
+	structuredLogs?: pulumi.Input<boolean>;
 	extraArgs?: pulumi.Input<pulumi.Input<string>[]>;
 	resources?: pulumi.Input<k8s.types.input.core.v1.ResourceRequirements>;
 	kubernetes?: CloudSqlAuthProxyKubernetesArgs;
@@ -100,6 +107,7 @@ function buildContainer(args: {
 	connectionName: string;
 	proxyPort: number;
 	image: string;
+	structuredLogs: boolean;
 	extraArgs?: string[];
 	resources: k8s.types.input.core.v1.ResourceRequirements;
 	credentialSecretName?: string;
@@ -109,6 +117,9 @@ function buildContainer(args: {
 		"--address=127.0.0.1",
 		`--port=${args.proxyPort}`,
 	];
+	if (args.structuredLogs) {
+		sidecarArgs.push("--structured-logs");
+	}
 	if (args.credentialSecretName) {
 		sidecarArgs.push(`--credentials-file=${CREDENTIALS_FILE_PATH}`);
 	}
@@ -161,6 +172,9 @@ export class CloudSqlAuthProxySidecar extends pulumi.ComponentResource {
 		const image = pulumi
 			.output(args.image)
 			.apply((value) => value ?? DEFAULT_PROXY_IMAGE);
+		const structuredLogs = pulumi
+			.output(args.structuredLogs)
+			.apply((value) => value ?? true);
 		const extraArgs = pulumi.output(args.extraArgs);
 		const resources = pulumi
 			.output(args.resources)
@@ -313,6 +327,7 @@ export class CloudSqlAuthProxySidecar extends pulumi.ComponentResource {
 				pulumi.output(args.connectionName),
 				proxyPort,
 				image,
+				structuredLogs,
 				extraArgs,
 				resources,
 				credentialSecretNameOutput,
@@ -322,6 +337,7 @@ export class CloudSqlAuthProxySidecar extends pulumi.ComponentResource {
 					connectionName,
 					resolvedProxyPort,
 					resolvedImage,
+					resolvedStructuredLogs,
 					resolvedExtraArgs,
 					resolvedResources,
 					resolvedCredentialSecretName,
@@ -330,6 +346,7 @@ export class CloudSqlAuthProxySidecar extends pulumi.ComponentResource {
 						connectionName,
 						proxyPort: resolvedProxyPort,
 						image: resolvedImage,
+						structuredLogs: resolvedStructuredLogs,
 						extraArgs: resolvedExtraArgs,
 						resources: resolvedResources,
 						credentialSecretName: resolvedCredentialSecretName,

--- a/packages/sector7/tests/cloudsql-auth-proxy-sidecar.test.ts
+++ b/packages/sector7/tests/cloudsql-auth-proxy-sidecar.test.ts
@@ -45,6 +45,7 @@ describe("CloudSqlAuthProxySidecar", () => {
 			"my-project:us-east5:my-instance",
 			"--address=127.0.0.1",
 			"--port=6432",
+			"--structured-logs",
 		]);
 		expect(container.livenessProbe).toBeUndefined();
 		expect(container.readinessProbe).toBeUndefined();
@@ -95,6 +96,7 @@ describe("CloudSqlAuthProxySidecar", () => {
 			"my-project:us-east5:my-instance",
 			"--address=127.0.0.1",
 			"--port=5432",
+			"--structured-logs",
 			"--credentials-file=/cloudsql/credentials.json",
 		]);
 		expect(container.volumeMounts).toEqual([
@@ -188,9 +190,26 @@ describe("CloudSqlAuthProxySidecar", () => {
 			"my-project:us-east5:my-instance",
 			"--address=127.0.0.1",
 			"--port=5432",
+			"--structured-logs",
 			"--auto-iam-authn",
 		]);
 		expect(container.volumeMounts).toBeUndefined();
 		expect(volumes).toEqual([]);
+	});
+
+	it("omits --structured-logs when structuredLogs is disabled", async () => {
+		const proxy = new CloudSqlAuthProxySidecar("plaintext-proxy", {
+			connectionName: "my-project:us-east5:my-instance",
+			credentials: { mode: "ambient-iam" },
+			structuredLogs: false,
+		});
+
+		const container = await resolveOutput(proxy.container);
+
+		expect(container.args).toEqual([
+			"my-project:us-east5:my-instance",
+			"--address=127.0.0.1",
+			"--port=5432",
+		]);
 	});
 });


### PR DESCRIPTION
## Summary

`CloudSqlAuthProxySidecar` ran cloud-sql-proxy with no logging flags, so the sidecar emitted **unstructured plaintext**. In our clusters those logs reach Loki via Alloy's raw `pod_logs` path as opaque lines — no parsed `level`/fields, so you can't filter or alert by log level. cloud-sql-proxy v2 has a built-in `--structured-logs` flag ("Enable structured logging with LogEntry format"); this passes it **by default for every consumer** of the sidecar.

- New `structuredLogs?: pulumi.Input<boolean>` arg, **defaults to `true`** — makes structured logging the default across all sidecars (garden, zeus, yard, …).
- Escape hatch: set `structuredLogs: false` to restore plaintext.
- Arg order: `<instance> --address --port --structured-logs [--credentials-file] [...extraArgs]`. `extraArgs` still appends last, so a consumer could also pass `--quiet` etc.

## Why default-on

The flag is the only build-time change needed to make proxy logs machine-parseable; there's no reason a sidecar should emit plaintext by default. Consumers that have adopted a JSON log pipeline get parseable proxy logs for free after a redeploy; nothing else changes (same image, same behavior otherwise).

## Test plan

- `vitest run tests/cloudsql-auth-proxy-sidecar.test.ts` → **5/5 pass**. Updated the three existing arg-assertions (default/inline-key/ambient+extraArgs) to include `--structured-logs`, and added a new case asserting `structuredLogs: false` omits it.
- `tsc -p tsconfig.build.json --noEmit` → exit 0.
- `nix flake check -L`: the `treefmt` and `renovate-yaml-manifests` checks fail **on pristine `origin/main`** too (pre-existing drift, unrelated to this diff — verified by re-running with my changes stashed). This diff's files are treefmt-clean and the cloudsql tests pass.

## Risks

Low. Pure additive arg; default behavior change is limited to the proxy's log *format* (text → JSON). No interface break (new field is optional). Consumers pick it up on their next `pulumi up`/redeploy — the sidecar container spec gains one arg, triggering a pod roll.

## Context

Discovered while diagnosing ergon's Cloud SQL Auth Proxy connection-reset logs landing in Loki as unparseable plaintext. Companion to the ergon-side structured-logging work tracked in jmmaloney4/garden#1019.