### PR TITLE
release: v0.16.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@jmmaloney4/sector7",
 	"private": true,
-	"version": "0.16.8",
+	"version": "0.16.9",
 	"description": "Sector7 monorepo",
 	"license": "MPL-2.0",
 	"workspaces": [

--- a/packages/sector7/package.json
+++ b/packages/sector7/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@jmmaloney4/sector7",
-	"version": "0.16.8",
+	"version": "0.16.9",
 	"description": "Reusable Pulumi components for infrastructure management",
 	"license": "MPL-2.0",
 	"publishConfig": {


### PR DESCRIPTION
## Summary

Cut sector7 **v0.16.9**. Bumps the root and `packages/sector7` `package.json` from 0.16.8 → 0.16.9.

Once merged to `main`, pushing the `v0.16.9` tag triggers `_dogfood-pnpm.yml` (dry_run=false on `refs/tags/v*`), which builds and publishes the GitHub Release tarball `jmmaloney4-sector7-0.16.9.tgz`.

## Changes since v0.16.8

- **feat(cloudsql): enable structured JSON logs by default on auth-proxy sidecar (#297)** — `CloudSqlAuthProxySidecar` now passes `--structured-logs` by default (opt-out via `structuredLogs: false`).
- deps: update Pulumi Dependencies to v9.27.0 (#285).

## Test plan

Version-bump only; no code changes. Publish is verified post-merge by the tag-triggered workflow producing the release asset `jmmaloney4-sector7-0.16.9.tgz`.