### PR TITLE
fix(nix-setup): enable flakes for in-pod client on host-daemon path

### DIFF
--- a/.github/actions/nix-setup/action.yml
+++ b/.github/actions/nix-setup/action.yml
@@ -63,7 +63,15 @@ runs:
           # `nix profile add nixpkgs#attic-client` (watch-store seed) fails too.
           # experimental-features is a client-side, non-daemon-restricted
           # setting, so an untrusted daemon client may set it via NIX_CONFIG.
-          echo "NIX_CONFIG=extra-experimental-features = nix-command flakes" >> "$GITHUB_ENV"
+          # Append rather than assign so we don't clobber any NIX_CONFIG a
+          # caller/earlier step already set (substituters, access-tokens, …);
+          # the `extra-` prefix also merges with any base experimental-features.
+          {
+            echo "NIX_CONFIG<<__NIX_CONFIG_EOF__"
+            if [ -n "${NIX_CONFIG:-}" ]; then printf '%s\n' "$NIX_CONFIG"; fi
+            echo "extra-experimental-features = nix-command flakes"
+            echo "__NIX_CONFIG_EOF__"
+          } >> "$GITHUB_ENV"
           # The node mounts /nix but not /run/current-system, so expose the host
           # store's Nix CLI via the NixOS *system* profile, which lives under
           # /nix (so it comes with the mount) and carries nix. NB: the *default*

--- a/.github/actions/nix-setup/action.yml
+++ b/.github/actions/nix-setup/action.yml
@@ -53,6 +53,17 @@ runs:
           echo "Host Nix daemon detected; using the host store, skipping in-pod install."
           echo "present=true" >> "$GITHUB_OUTPUT"
           echo "NIX_REMOTE=daemon" >> "$GITHUB_ENV"
+          # Enable flakes/nix-command for the in-pod Nix *client*. Normally the
+          # DeterminateSystems installer (skipped on this branch) writes a pod
+          # /etc/nix/nix.conf that turns these on. We only bind-mount the host's
+          # /nix — NOT its /etc/nix — so the host's flakes-enabled config is
+          # invisible inside the pod, and the host `nix` binary reads the pod's
+          # (flakes-less) config dir. Without this, `nix-eval-jobs` flake eval
+          # dies with "experimental Nix feature 'flakes' is disabled" and
+          # `nix profile add nixpkgs#attic-client` (watch-store seed) fails too.
+          # experimental-features is a client-side, non-daemon-restricted
+          # setting, so an untrusted daemon client may set it via NIX_CONFIG.
+          echo "NIX_CONFIG=extra-experimental-features = nix-command flakes" >> "$GITHUB_ENV"
           # The node mounts /nix but not /run/current-system, so expose the host
           # store's Nix CLI via the NixOS *system* profile, which lives under
           # /nix (so it comes with the mount) and carries nix. NB: the *default*


### PR DESCRIPTION
## Summary

On the host-daemon path, `nix-setup` correctly skips the DeterminateSystems installer — but that installer was the only thing writing a pod-side `/etc/nix/nix.conf` that enables `nix-command`/`flakes`. Garden's ARC runners bind-mount only the host's `/nix`, **not** its `/etc/nix`, so voldemort's flakes-enabled config is invisible inside the pod, and the host `nix` binary (on the system profile) reads the pod's flakes-less config dir.

This silently broke the warm-store rollout in two ways, both observed on a live garden `detect` run ([run 27973888979](https://github.com/jmmaloney4/garden/actions/runs/27973888979)):

1. **Red CI:** `nix-eval-jobs` flake evaluation fails with `experimental Nix feature 'flakes' is disabled` — every garden `main` run since the warm store was promoted to all runner scopes.
2. **Watch-store dead:** the seed step's `nix profile add nixpkgs#attic-client` needs flakes too → `attic: command not found` → `attic watch-store` never starts → no incremental cache push.

## Fix

One line in the host-daemon branch of the `Detect host Nix daemon` step: export `NIX_CONFIG=extra-experimental-features = nix-command flakes` via `$GITHUB_ENV`, mirroring the existing `NIX_REMOTE=daemon` export. `experimental-features` is a **client-side, non-daemon-restricted** setting, so an untrusted daemon client may set it for its own evaluation.

This closes the gap in #1007's acceptance criteria — its host-daemon branch dropped the Nix client config the installer used to provide.

### What this does NOT change
- **Non-host-daemon consumers** (cloud runners): unaffected — this branch only runs when the daemon socket is present.
- **The "ignoring untrusted substituter" warnings** in the same job are cosmetic and intentionally left alone: voldemort's daemon already carries Attic at `priority=10` from its own NixOS config (garden PR1 / ADR 105), so substitution is unaffected by the client's ignored passthrough.

## Test plan
- [x] `action.yml` is valid YAML; new line matches surrounding indentation/style.
- [ ] **Post-merge (live on `@main`):** a garden `detect` run on a warm-store runner shows no `flakes is disabled` error, `nix-eval-jobs` produces the matrix, and `/tmp/attic-watch-store.log` shows `attic watch-store` running.

## Risks
- Low. Single additive env export, gated on host-daemon presence. Worst case the setting is redundant (a future pod image that already enables flakes) — `extra-experimental-features` appends, so no clobber.

## Links
- Spec / tracking: jmmaloney4/garden#1007 (reopened)
- ADR 105 `ci-runner-host-nix-daemon-warm-store`; umbrella ergodicsystems/hq#173

🤖 Generated with [Claude Code](https://claude.com/claude-code)