### PR TITLE
fix(compute-flake-build-matrix): cap nix-eval-jobs at --max-memory-size 3072

### DIFF
--- a/.github/actions/compute-flake-build-matrix/main.sh
+++ b/.github/actions/compute-flake-build-matrix/main.sh
@@ -54,15 +54,15 @@ nix_eval_args=(
 
 # --max-memory-size bounds each eval worker's RSS; nix-eval-jobs recycles a
 # worker once it exceeds this (checked between attributes), reclaiming the
-# evaluator heap Nix never frees mid-run. 4096 MiB is nix-eval-jobs' OWN
-# default -- the behavioral fix for the warm-store OOM is the runner's 5Gi
-# cgroup limit (garden#1047), which lets the default 4 GiB worker recycle
-# (4 < 5) before the cgroup kills it; at the old 3Gi limit that same default
-# OOMed. We pin it explicitly so the eval budget stays coupled below the 5Gi
-# limit in code -- a future nix-eval-jobs default change can't then silently
-# break the pairing. Lower it (e.g. 3072) for headroom independent of the pod
-# limit. (garden#1046; large flakes like garden's 143 nodes are what hit this.)
-nix run github:nix-community/nix-eval-jobs/v2.34.1 "${nix_eval_args[@]}" -- --flake . --check-cache-status --meta --workers 1 --max-memory-size 4096 --select "(${select_expr}) \"${system}\"" >"$tmp_all"
+# evaluator heap Nix never frees mid-run. Set to 3072 MiB -- below BOTH
+# nix-eval-jobs' 4 GiB default AND the warm-store runner's 5Gi cgroup limit
+# (garden#1047) -- so the worker recycles ~2 GiB under the limit, independent
+# of it. That headroom matters because the RSS check is only between
+# attributes, so a worker can spike during one heavy attribute; recycling early
+# keeps it under the cgroup OOM killer. (The 4 GiB default OOMed at the old 3Gi
+# limit, and even at 5Gi leaves only 1 GiB slack.) garden#1046; large flakes
+# like garden's 143 nodes are what hit this.
+nix run github:nix-community/nix-eval-jobs/v2.34.1 "${nix_eval_args[@]}" -- --flake . --check-cache-status --meta --workers 1 --max-memory-size 3072 --select "(${select_expr}) \"${system}\"" >"$tmp_all"
 
 # Transform nix-eval-jobs output to matrix format
 echo "Processing nix-eval-jobs output..." >&2

--- a/.github/actions/compute-flake-build-matrix/main.sh
+++ b/.github/actions/compute-flake-build-matrix/main.sh
@@ -53,12 +53,15 @@ nix_eval_args=(
 )
 
 # --max-memory-size bounds each eval worker's RSS; nix-eval-jobs recycles a
-# worker once it exceeds this (between attributes), reclaiming the evaluator
-# heap that Nix never frees mid-run. The DEFAULT is 4 GiB/worker, which on the
-# warm-store runners exceeds the pod's memory limit and gets the worker
-# OOMKilled by the cgroup before it can recycle (garden#1046). Pin it to 4096
-# MiB explicitly, kept under the runner's 5Gi cgroup limit so recycling wins
-# the race with the OOM killer. Large flakes (garden: 143 nodes) need this.
+# worker once it exceeds this (checked between attributes), reclaiming the
+# evaluator heap Nix never frees mid-run. 4096 MiB is nix-eval-jobs' OWN
+# default -- the behavioral fix for the warm-store OOM is the runner's 5Gi
+# cgroup limit (garden#1047), which lets the default 4 GiB worker recycle
+# (4 < 5) before the cgroup kills it; at the old 3Gi limit that same default
+# OOMed. We pin it explicitly so the eval budget stays coupled below the 5Gi
+# limit in code -- a future nix-eval-jobs default change can't then silently
+# break the pairing. Lower it (e.g. 3072) for headroom independent of the pod
+# limit. (garden#1046; large flakes like garden's 143 nodes are what hit this.)
 nix run github:nix-community/nix-eval-jobs/v2.34.1 "${nix_eval_args[@]}" -- --flake . --check-cache-status --meta --workers 1 --max-memory-size 4096 --select "(${select_expr}) \"${system}\"" >"$tmp_all"
 
 # Transform nix-eval-jobs output to matrix format

--- a/.github/actions/compute-flake-build-matrix/main.sh
+++ b/.github/actions/compute-flake-build-matrix/main.sh
@@ -52,7 +52,14 @@ nix_eval_args=(
   --option extra-trusted-public-keys "$extra_trusted_public_keys_value"
 )
 
-nix run github:nix-community/nix-eval-jobs/v2.34.1 "${nix_eval_args[@]}" -- --flake . --check-cache-status --meta --workers 1 --select "(${select_expr}) \"${system}\"" >"$tmp_all"
+# --max-memory-size bounds each eval worker's RSS; nix-eval-jobs recycles a
+# worker once it exceeds this (between attributes), reclaiming the evaluator
+# heap that Nix never frees mid-run. The DEFAULT is 4 GiB/worker, which on the
+# warm-store runners exceeds the pod's memory limit and gets the worker
+# OOMKilled by the cgroup before it can recycle (garden#1046). Pin it to 4096
+# MiB explicitly, kept under the runner's 5Gi cgroup limit so recycling wins
+# the race with the OOM killer. Large flakes (garden: 143 nodes) need this.
+nix run github:nix-community/nix-eval-jobs/v2.34.1 "${nix_eval_args[@]}" -- --flake . --check-cache-status --meta --workers 1 --max-memory-size 4096 --select "(${select_expr}) \"${system}\"" >"$tmp_all"
 
 # Transform nix-eval-jobs output to matrix format
 echo "Processing nix-eval-jobs output..." >&2


### PR DESCRIPTION
## Summary
`nix-eval-jobs` evaluates in forked workers and recycles a worker once its RSS exceeds `--max-memory-size` (checked **between attributes**), reclaiming the evaluator heap Nix never frees mid-run. On the warm-store runners the in-pod evaluation of large flakes (garden: 143 nodes) grew past the **3Gi** pod limit and got **OOMKilled** (garden#1046), surfaced once #1036's `cpuRequest 1→2` let the eval actually run.

## Change
Set `--max-memory-size 3072`. This sits **below both** nix-eval-jobs' 4 GiB default **and** the warm-store runner's new 5Gi cgroup limit (garden#1047), so the worker recycles ~2 GiB under the limit, **independent of it**.

Why not the default (4096): 4096 == the default, so passing it is a no-op — it would rely entirely on the 5Gi limit. 3072 does real work: the RSS check is only *between* attributes, so a worker can spike during one heavy attribute; the extra slack keeps it under the OOM killer. Trade: more frequent worker recycles → slightly slower eval.

## ⚠️ Deploy ordering
This action is `@main` (live on merge). **Merge after garden#1047 (3Gi→5Gi limit) is deployed.** At the old 3Gi limit a 3072 recycle point sits *at* the cgroup wall (3 GiB = 3072 MiB) and won't reliably help; with the 5Gi limit it leaves a 2 GiB margin.

## Test plan
- [x] `bash -n` clean; code passes `--max-memory-size 3072`.
- [ ] After garden#1047 deploy + this merge: a garden `detect` runner completes without `OOMKilled`.

## Links
- garden#1047 (paired 5Gi limit) · garden#1046 (tracking) · ergodicsystems/hq#173

🤖 Generated with [Claude Code](https://claude.com/claude-code)