### PR TITLE
fix(compute-flake-build-matrix): nice/ionice the eval so it can't starve the runner agent

### DIFF
--- a/.github/actions/compute-flake-build-matrix/main.sh
+++ b/.github/actions/compute-flake-build-matrix/main.sh
@@ -62,7 +62,18 @@ nix_eval_args=(
 # keeps it under the cgroup OOM killer. (The 4 GiB default OOMed at the old 3Gi
 # limit, and even at 5Gi leaves only 1 GiB slack.) garden#1046; large flakes
 # like garden's 143 nodes are what hit this.
-nix run github:nix-community/nix-eval-jobs/v2.34.1 "${nix_eval_args[@]}" -- --flake . --check-cache-status --meta --workers 1 --max-memory-size 3072 --select "(${select_expr}) \"${system}\"" >"$tmp_all"
+# Run the eval at the lowest CPU/IO priority so it can't starve the GitHub
+# runner agent. The agent (Runner.Listener) shares this pod's cgroup with the
+# eval; a heavy nix-eval-jobs run (garden: 143 nodes) can peg CPU + disk and
+# stall the agent's heartbeats, which GitHub reports as "the self-hosted runner
+# lost communication with the server" -- often WITHOUT a clean OOM, because the
+# agent loses the scheduler race before the kernel acts (garden#1046). nice +
+# ionice keep the normal-priority agent winning CPU/IO so it stays connected.
+# Built as a prefix array so it degrades gracefully if either tool is absent.
+lowprio=()
+command -v nice >/dev/null 2>&1 && lowprio+=(nice -n 19)
+command -v ionice >/dev/null 2>&1 && lowprio+=(ionice -c2 -n7)
+"${lowprio[@]}" nix run github:nix-community/nix-eval-jobs/v2.34.1 "${nix_eval_args[@]}" -- --flake . --check-cache-status --meta --workers 1 --max-memory-size 3072 --select "(${select_expr}) \"${system}\"" >"$tmp_all"
 
 # Transform nix-eval-jobs output to matrix format
 echo "Processing nix-eval-jobs output..." >&2


### PR DESCRIPTION
## Summary
Garden `detect` keeps failing **flakily** with *"the self-hosted runner lost communication with the server"* — and crucially, **often without a clean `OOMKilled` event**. The disconnect and the occasional OOM are the same root cause: the GitHub **runner agent** (`Runner.Listener`, which must heartbeat to GitHub) shares the runner pod's cgroup with the heavy `nix-eval-jobs` eval. When the eval pegs CPU + disk (garden: 143-node flake), the agent loses the scheduler/IO race and **misses heartbeats before the kernel OOM-killer even acts** → GitHub marks it "lost communication" instead of a real build failure.

## Change
Wrap the eval in `nice -n 19` + `ionice -c2 -n7` so the **normal-priority agent always preempts** the eval for CPU and disk IO — its heartbeats keep flowing even while the eval saturates the pod.

```sh
lowprio=()
command -v nice   >/dev/null 2>&1 && lowprio+=(nice -n 19)
command -v ionice >/dev/null 2>&1 && lowprio+=(ionice -c2 -n7)
"${lowprio[@]}" nix run …nix-eval-jobs…
```
Graceful-degrade prefix array (skips either tool if absent), so non-Linux / minimal consumers are unaffected. The eval is **deprioritised, not capped** — it still runs to completion, just yielding to the agent. (Left `--meta` and the eval-splitting for a follow-up.)

## Test plan
- [x] `bash -n` clean; verified the empty-array and missing-tool `&&` paths are safe under `set -euo pipefail`.
- [ ] Post-merge (live `@main`): a garden `detect` run completes without "lost communication"; if the eval is still too big it should now fail with a *real* error rather than a flaky disconnect.

## Risk
Low. Worst case the eval is slower under contention (intended). `@main`, so live to all consumers on merge — but the change is a no-op on uncontended runners.

## Links
- garden#1046 (runner OOM/disconnect) · ergodicsystems/hq#173

🤖 Generated with [Claude Code](https://claude.com/claude-code)