### PR TITLE
fix(renovate): drop broken autoReplaceStringTemplate from pulumi preset

### DIFF
--- a/packages/sector7/tests/renovate-pulumi.test.ts
+++ b/packages/sector7/tests/renovate-pulumi.test.ts
@@ -16,7 +16,22 @@ const pulumiConfig = JSON.parse(
 	}>;
 };
 
-const [manager] = pulumiConfig.customManagers;
+// Select by a stable property (targets Pulumi config files) rather than by
+// array position, so reordering or adding managers can't silently make these
+// tests exercise the wrong configuration.
+function selectPulumiManager() {
+	const matches = pulumiConfig.customManagers.filter((m) =>
+		m.managerFilePatterns.some((pattern) => pattern.includes("Pulumi")),
+	);
+	if (matches.length !== 1) {
+		throw new Error(
+			`expected exactly one Pulumi customManager, found ${matches.length}`,
+		);
+	}
+	return matches[0];
+}
+
+const manager = selectPulumiManager();
 const regexes = manager.matchStrings.map((pattern) => new RegExp(pattern));
 
 function firstMatch(input: string) {

--- a/packages/sector7/tests/renovate-pulumi.test.ts
+++ b/packages/sector7/tests/renovate-pulumi.test.ts
@@ -99,27 +99,28 @@ describe("renovate/pulumi.json Pulumi YAML version manager", () => {
 			// replacement is used. Nothing further to check.
 			return;
 		}
-		const captureGroupNames = new Set(
-			manager.matchStrings.flatMap((pattern) =>
-				[...pattern.matchAll(/\(\?<(\w+)>/g)].map((m) => m[1]),
-			),
-		);
+		// Computed update fields are always available on the upgrade object.
+		const ALWAYS_AVAILABLE = new Set([
+			"newValue",
+			"newDigest",
+			"newName",
+			"newVersion",
+		]);
 		const referenced = [...template.matchAll(/\{\{\{?\s*(\w+)\s*\}?\}\}/g)].map(
 			(m) => m[1],
 		);
 		for (const name of referenced) {
-			// Computed fields are always available on the upgrade object.
-			if (["newValue", "newDigest", "newName", "newVersion"].includes(name)) {
+			if (ALWAYS_AVAILABLE.has(name)) {
 				continue;
 			}
-			// If the template reuses one of our capture groups, that group must
-			// be a field Renovate actually preserves post-extraction.
-			if (captureGroupNames.has(name)) {
-				expect(
-					VALID_MATCH_FIELDS.has(name),
-					`autoReplaceStringTemplate references capture group "${name}", which Renovate drops after extraction (not a valid match field) — it will render empty and corrupt the file`,
-				).toBe(true);
-			}
+			// Anything else must be a field Renovate actually carries onto the
+			// upgrade object. A custom capture group (e.g. `versionKey`) or a
+			// typo is NOT carried and renders empty, corrupting the file — fail
+			// for any such reference, not just known capture groups.
+			expect(
+				VALID_MATCH_FIELDS.has(name),
+				`autoReplaceStringTemplate references "${name}", which Renovate does not carry onto the upgrade object (not a computed field or valid match field) — it will render empty and corrupt the file`,
+			).toBe(true);
 		}
 	});
 });

--- a/packages/sector7/tests/renovate-pulumi.test.ts
+++ b/packages/sector7/tests/renovate-pulumi.test.ts
@@ -1,0 +1,125 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const pulumiConfig = JSON.parse(
+	readFileSync(
+		resolve(import.meta.dirname, "../../../renovate/pulumi.json"),
+		"utf8",
+	),
+) as {
+	customManagers: Array<{
+		customType: string;
+		managerFilePatterns: string[];
+		matchStrings: string[];
+		autoReplaceStringTemplate?: string;
+	}>;
+};
+
+const [manager] = pulumiConfig.customManagers;
+const regexes = manager.matchStrings.map((pattern) => new RegExp(pattern));
+
+function firstMatch(input: string) {
+	return regexes.map((regex) => input.match(regex)).find(Boolean);
+}
+
+// The only dependency fields Renovate carries from a custom-manager match onto
+// the upgrade object that renders the *Template fields (including
+// autoReplaceStringTemplate). Capture groups outside this set are dropped after
+// extraction, so referencing them in a replace template yields an empty string.
+// Source: renovate lib/modules/manager/custom/utils.ts (validMatchFields) and
+// lib/modules/manager/custom/regex/utils.ts (createDependency).
+const VALID_MATCH_FIELDS = new Set([
+	"depName",
+	"packageName",
+	"currentValue",
+	"currentDigest",
+	"datasource",
+	"versioning",
+	"extractVersion",
+	"registryUrl",
+	"depType",
+	"indentation",
+]);
+
+const SAMPLE =
+	"  observability:tempoChartVersion: 2.2.0 # renovate: datasource=helm depName=tempo registryUrl=https://grafana-community.github.io/helm-charts";
+
+describe("renovate/pulumi.json Pulumi YAML version manager", () => {
+	it("extracts the annotated dependency", () => {
+		const match = firstMatch(SAMPLE);
+		expect(match?.groups?.versionKey).toBe("observability:tempoChartVersion");
+		expect(match?.groups?.currentValue).toBe("2.2.0");
+		expect(match?.groups?.datasource).toBe("helm");
+		expect(match?.groups?.depName).toBe("tempo");
+		expect(match?.groups?.registryUrl).toBe(
+			"https://grafana-community.github.io/helm-charts",
+		);
+	});
+
+	it("matches a single-segment stack-config key", () => {
+		const match = firstMatch(
+			"  langfuse:chartVersion: 1.5.31 # renovate: datasource=helm depName=langfuse registryUrl=https://langfuse.github.io/langfuse-k8s",
+		);
+		expect(match?.groups?.depName).toBe("langfuse");
+		expect(match?.groups?.currentValue).toBe("1.5.31");
+	});
+
+	it("does not match an unannotated version line", () => {
+		expect(
+			firstMatch("  observability:tempoChartVersion: 2.2.0"),
+		).toBeUndefined();
+	});
+
+	// Regression guard for WORKER_FILE_UPDATE_FAILED ("Error updating branch:
+	// update failure"). Renovate's default in-place replacement rewrites only
+	// currentValue; the resulting line must still re-extract to the new version
+	// (this mirrors Renovate's post-replace confirmIfDepUpdated check). A line
+	// that fails to re-extract aborts the whole update.
+	it("round-trips: the in-place-rewritten line re-extracts to the new version", () => {
+		const match = firstMatch(SAMPLE);
+		expect(match).toBeTruthy();
+		const rewritten = SAMPLE.replace(match!.groups!.currentValue, "2.2.3");
+		// the key, annotation and registryUrl must survive untouched
+		expect(rewritten).toContain("observability:tempoChartVersion: 2.2.3");
+
+		const reMatch = firstMatch(rewritten);
+		expect(reMatch?.groups?.currentValue).toBe("2.2.3");
+		expect(reMatch?.groups?.depName).toBe("tempo");
+	});
+
+	// The original bug: an autoReplaceStringTemplate referencing `versionKey`
+	// (a capture group Renovate does not carry onto the upgrade object) rendered
+	// it empty and corrupted the line. Forbid any replace template that
+	// references a captured group which is not a valid Renovate match field.
+	it("any autoReplaceStringTemplate only references valid Renovate match fields", () => {
+		const template = manager.autoReplaceStringTemplate;
+		if (!template) {
+			// Fixed state: no template, so Renovate's default in-place
+			// replacement is used. Nothing further to check.
+			return;
+		}
+		const captureGroupNames = new Set(
+			manager.matchStrings.flatMap((pattern) =>
+				[...pattern.matchAll(/\(\?<(\w+)>/g)].map((m) => m[1]),
+			),
+		);
+		const referenced = [...template.matchAll(/\{\{\{?\s*(\w+)\s*\}?\}\}/g)].map(
+			(m) => m[1],
+		);
+		for (const name of referenced) {
+			// Computed fields are always available on the upgrade object.
+			if (["newValue", "newDigest", "newName", "newVersion"].includes(name)) {
+				continue;
+			}
+			// If the template reuses one of our capture groups, that group must
+			// be a field Renovate actually preserves post-extraction.
+			if (captureGroupNames.has(name)) {
+				expect(
+					VALID_MATCH_FIELDS.has(name),
+					`autoReplaceStringTemplate references capture group "${name}", which Renovate drops after extraction (not a valid match field) — it will render empty and corrupt the file`,
+				).toBe(true);
+			}
+		}
+	});
+});

--- a/packages/sector7/tests/renovate-yaml-manifests.test.ts
+++ b/packages/sector7/tests/renovate-yaml-manifests.test.ts
@@ -17,12 +17,18 @@ const yamlConfig = JSON.parse(
 
 function managerRegexes(description: string): RegExp[] {
 	// Match by prefix so that extending a manager's description (e.g. appending
-	// an RE2-compatibility note) does not silently break these lookups.
-	const manager = yamlConfig.customManagers.find((candidate) =>
+	// an RE2-compatibility note) does not silently break these lookups. Require
+	// exactly one match so an ambiguous prefix fails loudly instead of silently
+	// binding the first entry.
+	const matches = yamlConfig.customManagers.filter((candidate) =>
 		candidate.description.startsWith(description),
 	);
 
-	expect(manager).toBeDefined();
+	expect(
+		matches,
+		`expected exactly one manager whose description starts with "${description}"`,
+	).toHaveLength(1);
+	const manager = matches[0];
 	if (!manager) {
 		throw new Error(`Missing manager: ${description}`);
 	}

--- a/packages/sector7/tests/renovate-yaml-manifests.test.ts
+++ b/packages/sector7/tests/renovate-yaml-manifests.test.ts
@@ -16,8 +16,10 @@ const yamlConfig = JSON.parse(
 };
 
 function managerRegexes(description: string): RegExp[] {
-	const manager = yamlConfig.customManagers.find(
-		(candidate) => candidate.description === description,
+	// Match by prefix so that extending a manager's description (e.g. appending
+	// an RE2-compatibility note) does not silently break these lookups.
+	const manager = yamlConfig.customManagers.find((candidate) =>
+		candidate.description.startsWith(description),
 	);
 
 	expect(manager).toBeDefined();
@@ -65,11 +67,7 @@ describe("renovate/yaml-manifests.json file patterns", () => {
 	});
 
 	it("does not match non-yaml files", () => {
-		const testFiles = [
-			"kube-vip.json",
-			"README.md",
-			"yaml-manifests.json",
-		];
+		const testFiles = ["kube-vip.json", "README.md", "yaml-manifests.json"];
 
 		for (const file of testFiles) {
 			expect(
@@ -187,16 +185,18 @@ describe("renovate/yaml-manifests.json Helm chart version regex manager", () => 
 		expect(match?.groups?.currentValue).toBe("v1.14.5");
 	});
 
-	it("matches with parameters in a different order (registryUrl before depName)", () => {
+	it("is order-sensitive: depName must precede registryUrl (RE2 has no lookahead)", () => {
+		// The manager intentionally requires `depName` immediately after
+		// `datasource=helm` because RE2 cannot express the lookahead that would
+		// allow arbitrary field order. Annotations that put registryUrl first do
+		// not extract — this documents that contract so the annotation style
+		// stays consistent.
 		const yaml = [
 			"  # renovate: datasource=helm registryUrl=https://helm.cilium.io/ depName=cilium",
 			'  version: "1.17.15"',
 		].join("\n");
 
-		const match = firstMatch(managerRegexes(description), yaml);
-		expect(match?.groups?.depName).toBe("cilium");
-		expect(match?.groups?.registryUrl).toBe("https://helm.cilium.io/");
-		expect(match?.groups?.currentValue).toBe("1.17.15");
+		expect(firstMatch(managerRegexes(description), yaml)).toBeUndefined();
 	});
 
 	it("does not match unannotated version lines", () => {

--- a/renovate/pulumi.json
+++ b/renovate/pulumi.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://docs.renovatebot.com/renovate-schema.json",
-	"description": "Pulumi-specific Renovate configuration with custom regex managers for dependency extraction",
+	"description": "Pulumi-specific Renovate configuration. Tracks dependency versions annotated inline in Pulumi YAML config files (`Pulumi.yaml`, `Pulumi.<stack>.yaml`) as `someVersion: X.Y.Z # renovate: datasource=<ds> depName=<name> registryUrl=<url>` — e.g. Helm chart versions consumed by Pulumi programs. Replacement deliberately relies on Renovate's default in-place behaviour, which rewrites only the matched `currentValue` and preserves the rest of the line. Do NOT add an `autoReplaceStringTemplate` that references the `versionKey` capture group: Renovate only carries its recognised match fields (depName, packageName, currentValue, currentDigest, datasource, versioning, extractVersion, registryUrl, depType, indentation) plus the computed new* fields onto the upgrade object that renders the replace template, so `{{{versionKey}}}` resolves to an empty string. That produced a malformed line (`  : X.Y.Z # ...`) which failed Renovate's post-replace re-extraction (confirmIfDepUpdated) and aborted every update with WORKER_FILE_UPDATE_FAILED, surfacing on the dependency dashboard as 'Error updating branch: update failure'.",
 	"customManagers": [
 		{
 			"customType": "regex",
@@ -11,8 +11,7 @@
 			"datasourceTemplate": "{{{datasource}}}",
 			"depNameTemplate": "{{{depName}}}",
 			"registryUrlTemplate": "{{{registryUrl}}}",
-			"versioningTemplate": "semver",
-			"autoReplaceStringTemplate": "{{{versionKey}}}: {{{newValue}}} # renovate: datasource={{{datasource}}} depName={{{depName}}} registryUrl={{{registryUrl}}}"
+			"versioningTemplate": "semver"
 		}
 	]
 }


### PR DESCRIPTION
## Summary

The `renovate/pulumi.json` custom manager could **never apply an update**. It detected new versions fine (so consumers' dependency dashboards showed the targets), but every branch creation failed with `WORKER_FILE_UPDATE_FAILED`, which Renovate surfaces as **“Error updating branch: update failure.”**

### Root cause

The manager defined:

```json
"autoReplaceStringTemplate": "{{{versionKey}}}: {{{newValue}}} # renovate: datasource={{{datasource}}} depName={{{depName}}} registryUrl={{{registryUrl}}}"
```

`versionKey` is a **custom capture group**, not one of Renovate's recognised match fields. Renovate only carries `validMatchFields` (`depName`, `currentValue`, `datasource`, `registryUrl`, `versioning`, …) onto the upgrade object that renders replace templates — see `lib/modules/manager/custom/regex/utils.ts` (`createDependency`) and `lib/modules/manager/custom/utils.ts` (`validMatchFields`). So `{{{versionKey}}}` rendered **empty**, producing a malformed line:

```
  : 2.2.3 # renovate: datasource=helm depName=tempo registryUrl=...
```

Renovate's post-replace re-extraction (`confirmIfDepUpdated` in `workers/repository/update/branch/auto-replace.js`) then failed to parse that line (the `…Version:` regex no longer matches) and threw `WORKER_FILE_UPDATE_FAILED`.

This had been latent since the preset's first commit; it became visible once garden moved its Helm chart versions to Pulumi-config tracking — tempo, alloy, grafana, kube-state-metrics, langfuse, tailscale-operator all sat permanently in the dashboard's **Errored** bucket with no branch ever created. (The HelmChart-CRD manager in `yaml-manifests.json`, which has no `autoReplaceStringTemplate`, works — e.g. cilium bumps merge fine.)

### Fix

Remove the template and rely on Renovate's **default in-place replacement**, which rewrites only `currentValue` and preserves the rest of the line — the same approach the working `yaml-manifests` manager uses. Expanded the `description` to document why a `versionKey` template must not be reintroduced.

## How it was verified

Ran the change against real Renovate code (`renovate@latest`):

- **Detection** (full `renovate --platform=local` dry run): `tempo 2.2.0 → 2.2.3`, branch `renovate/tempo-2.x`. ✓
- **Re-extraction** (`custom/regex` extractor): original `2.2.0` → 1 dep; default-rewritten `2.2.3` line → 1 dep (`currentValue=2.2.3`) ✓; the empty-`versionKey` line (`  : 2.2.3 #…`) → **0 deps** (this is the failure path). 

## Test plan

- `pnpm --filter @jmmaloney4/sector7 run test` → **287 passed** (was 6 failing on `main`).
- New `packages/sector7/tests/renovate-pulumi.test.ts`: extraction, round-trip (in-place rewrite re-extracts to the new version), and a **regression guard** that fails if any `autoReplaceStringTemplate` references a capture group outside Renovate's valid match fields.

## Risks

- Low. Config-only change to one custom manager + tests. Detection behaviour is unchanged; only the (previously broken) write path changes, to Renovate's well-trodden default. The in-place rewrite is safe here because `currentValue` (a `\d+.\d+.\d+`) appears exactly once per matched line.

## Out of scope (also fixed here, pre-existing)

`renovate-yaml-manifests.test.ts` had **6 tests already red on `main`** (these checks aren't gated in CI). Commit `fabb4e1` extended the helm manager's `description`, which broke the test's exact-string manager lookup, and one test still asserted pre-RE2 order-independence. Fixed by matching descriptions by prefix and correcting the stale test to assert the intended depName-first contract — so this PR leaves the renovate test suite fully green.

## Downstream

After this merges, garden's Renovate (extends `sector7//renovate/all.json` at HEAD) will pick it up on its next run and the six errored Helm bumps should create normally. Context: jmmaloney4/garden#87 (dependency dashboard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)