### PR TITLE
fix(litellm): self-heal server-side key loss via provider read()

### DIFF
--- a/packages/sector7/litellm/admin.ts
+++ b/packages/sector7/litellm/admin.ts
@@ -112,6 +112,25 @@ async function withProxyBaseUrl<T>(
 	);
 }
 
+/**
+ * Error raised when a LiteLLM admin request returns a non-2xx status. Carries
+ * the HTTP `status` so callers can distinguish a definitive client-side outcome
+ * (e.g. a 404 "this key no longer exists") from an auth failure or a transient
+ * server/network error — see `keyProvider.read()`, which must only treat a
+ * genuine not-found as resource deletion.
+ */
+class LiteLLMRequestError extends Error {
+	// Declared + assigned explicitly rather than via a constructor parameter
+	// property: this package sets `erasableSyntaxOnly`, which forbids the latter.
+	readonly status: number;
+
+	constructor(status: number, message: string) {
+		super(message);
+		this.name = "LiteLLMRequestError";
+		this.status = status;
+	}
+}
+
 /** Issue an authenticated request against the LiteLLM admin API. */
 async function adminRequest(
 	baseUrl: string,
@@ -132,7 +151,8 @@ async function adminRequest(
 
 	const text = await response.text();
 	if (!response.ok) {
-		throw new Error(
+		throw new LiteLLMRequestError(
+			response.status,
 			`LiteLLM ${method} ${path} failed: ${response.status} ${response.statusText}\n${text}`,
 		);
 	}
@@ -494,6 +514,23 @@ function buildKeyUpdateBody(
 	return body;
 }
 
+/**
+ * True when an admin request failed because the queried key no longer exists on
+ * the proxy. A 404 (not found) or 400 (LiteLLM reports a missing/invalid token
+ * as a bad request in several versions) is treated as definitive absence.
+ *
+ * Auth failures (401/403 — a wrong master key, which would fail EVERY key at
+ * once) and server/network errors are deliberately NOT absence: `read()` must
+ * preserve state on those so a transient refresh hiccup never triggers a
+ * needless recreate.
+ */
+function isMissingKeyError(err: unknown): boolean {
+	return (
+		err instanceof LiteLLMRequestError &&
+		(err.status === 404 || err.status === 400)
+	);
+}
+
 const keyProvider: dynamic.ResourceProvider = {
 	async check(
 		_olds: KeyProviderState,
@@ -574,6 +611,41 @@ const keyProvider: dynamic.ResourceProvider = {
 				id: tokenId,
 				outs: { ...inputs, tokenId },
 			};
+		});
+	},
+
+	// Reconcile stored state against the live admin plane on `pulumi refresh`
+	// (and `pulumi up --refresh`). Without this, a key that vanished server-side
+	// — Cloud SQL restore, a redeploy onto a fresh DB, a manual /key/delete —
+	// stays invisible: diff() only compares declared inputs, so plain `up`
+	// reports no changes while every consumer 401s on a token the proxy no
+	// longer knows. Reporting the resource as gone lets the next `up` re-run
+	// create(), which re-registers the SAME RandomPassword-derived value
+	// (non-rotating, idempotent) — self-healing the drift.
+	async read(id: string, props: KeyProviderState): Promise<dynamic.ReadResult> {
+		const token = id || props?.tokenId;
+		// No persisted token hash to probe (e.g. a half-created resource): treat
+		// as absent so the next up creates it; never invent existence.
+		if (!token) return { id: undefined };
+		return withProxyBaseUrl(props, async (baseUrl) => {
+			try {
+				await adminRequest(
+					baseUrl,
+					props.masterKey,
+					`/key/info?key=${encodeURIComponent(token)}`,
+					"GET",
+				);
+			} catch (err) {
+				// Only a definitive not-found drops the resource. Auth/5xx/network
+				// errors are re-thrown so a transient refresh can't trigger a
+				// credential-churning recreate. (One LiteLLM variant returns 200 with
+				// an `{error}` body for a missing key; adminRequest surfaces that as a
+				// generic error, so it is preserved rather than self-healed — the safe
+				// direction.)
+				if (isMissingKeyError(err)) return { id: undefined };
+				throw err;
+			}
+			return { id: token, props };
 		});
 	},
 

--- a/packages/sector7/tests/litellm-admin.test.ts
+++ b/packages/sector7/tests/litellm-admin.test.ts
@@ -37,6 +37,10 @@ type Provider = {
 		news: Record<string, unknown>,
 	) => Promise<{ outs: Record<string, unknown> }>;
 	delete: (id: string, props: Record<string, unknown>) => Promise<void>;
+	read?: (
+		id: string,
+		props: Record<string, unknown>,
+	) => Promise<{ id?: string; props?: Record<string, unknown> }>;
 };
 
 const capturedProviders: Provider[] = [];
@@ -154,6 +158,22 @@ function installFetch(
 	});
 	vi.stubGlobal("fetch", mock);
 	return calls;
+}
+
+// A mock fetch returning a fixed HTTP status — used to exercise read()'s
+// not-found vs. transient-error branches, which the always-200 installFetch
+// can't express.
+function installFetchStatus(status: number, payload: unknown = {}) {
+	const mock = vi.fn(async () => {
+		return {
+			ok: status >= 200 && status < 300,
+			status,
+			statusText: String(status),
+			text: async () => JSON.stringify(payload ?? {}),
+		} as Response;
+	});
+	vi.stubGlobal("fetch", mock);
+	return mock;
 }
 
 let teamProvider: Provider;
@@ -612,6 +632,48 @@ describe("LiteLLMApiKey provider", () => {
 		await expect(
 			keyProvider.create({ ...baseKey, tokenId: undefined }),
 		).rejects.toThrow(/no token id/);
+		vi.unstubAllGlobals();
+	});
+
+	it("read keeps state when the key still exists on the proxy", async () => {
+		installFetchStatus(200, { info: { key_alias: "prod-openwebui" } });
+		const result = await keyProvider.read?.("hash-1", baseKey);
+		expect(result?.id).toBe("hash-1");
+		vi.unstubAllGlobals();
+	});
+
+	it("read drops the resource when the key is gone (404) so up recreates it", async () => {
+		installFetchStatus(404, { error: "key not found" });
+		const result = await keyProvider.read?.("hash-1", baseKey);
+		expect(result?.id).toBeUndefined();
+		vi.unstubAllGlobals();
+	});
+
+	it("read treats a 400 (missing/invalid token) as gone", async () => {
+		installFetchStatus(400, { error: "invalid key" });
+		const result = await keyProvider.read?.("hash-1", baseKey);
+		expect(result?.id).toBeUndefined();
+		vi.unstubAllGlobals();
+	});
+
+	it("read re-throws on an auth failure (401) rather than dropping state", async () => {
+		installFetchStatus(401, { error: "auth" });
+		await expect(keyProvider.read?.("hash-1", baseKey)).rejects.toThrow();
+		vi.unstubAllGlobals();
+	});
+
+	it("read re-throws on a server error (500) rather than dropping state", async () => {
+		installFetchStatus(500, { error: "boom" });
+		await expect(keyProvider.read?.("hash-1", baseKey)).rejects.toThrow();
+		vi.unstubAllGlobals();
+	});
+
+	it("read reports absent without probing when no token hash is stored", async () => {
+		const mock = installFetchStatus(200, {});
+		const result = await keyProvider.read?.("", { ...baseKey, tokenId: "" });
+		expect(result?.id).toBeUndefined();
+		// Must not hit the admin plane when there is nothing to reconcile.
+		expect(mock).not.toHaveBeenCalled();
 		vi.unstubAllGlobals();
 	});
 });


### PR DESCRIPTION
## Summary

Closes #306.

The `LiteLLMApiKey` dynamic provider implemented `check`/`diff`/`create`/`update`/`delete` but **no `read()`**, so `pulumi refresh`/`up` could not detect when a key disappeared from the LiteLLM server (`LiteLLM_VerificationTokenTable` in Cloud SQL). When that happened — Cloud SQL restore, redeploy onto a fresh DB, a wiped Postgres volume, a manual/alias-collision `/key/delete` — Pulumi state and every downstream consumer kept serving a token the proxy now rejects with **401 `token_not_found_in_db`**, while `pulumi up` reported **no changes**. The drift was silent and never self-healed.

Observed in the wild: a Hermes agent session 401'd against `litellm.mellori-delta.ts.net` for a key whose `sk-…` value still matched 1Password / Pulumi state — the DB had simply lost the row.

## What changed

- **`keyProvider.read(id, props)`** — on `pulumi refresh` (and `pulumi up --refresh`), probe `GET /key/info?key=<stored token hash>`:
  - **Definitive not-found** (4xx that isn't an auth failure) → return `{ id: undefined }`, so the engine treats the resource as externally deleted and the next `up` re-runs `create()`. Because the key value comes from a stable `RandomPassword`, `create()` re-registers the **same** `sk-…` — **non-rotating and idempotent** (it already deletes same-alias keys then regenerates). Consumers keep working; no rotation.
  - **Auth (401/403), 5xx, network/port-forward errors** → re-throw, preserving state. A transient refresh hiccup must never trigger a credential-churning recreate. 401/403 in particular would hit *every* key at once (wrong master key) — never "this key is gone".
- **`LiteLLMRequestError`** — `adminRequest` now throws a status-typed error on `!response.ok` (was a generic `Error`) so `read()` can distinguish not-found from transient failures. No other call site depends on the message text.

## Why `read()` (not `diff()`)

`diff()` is a pure, offline state comparison — it must stay fast and side-effect-free. Reconciling against the live admin plane is exactly what the dynamic-provider `read()` hook is for. The trade-off: **self-healing requires a refresh** (`pulumi refresh` or `pulumi up --refresh`); plain `up` does not call `read()`. Documented in the code comment.

## Test plan

- `vitest run tests/litellm-admin.test.ts` → **30/30 green** (24 existing + 6 new):
  - key still present → state preserved (`id` kept)
  - key gone (404) → dropped (`id: undefined`) so `up` recreates
  - 400 (missing/invalid token) → treated as gone
  - 401 (auth) → re-throws, state preserved
  - 500 (server error) → re-throws, state preserved
  - no stored token hash → reports absent **without** probing the admin plane
- Types verified against the installed `@pulumi/pulumi@3.246.0` SDK: `read?: (id, props?) => Promise<ReadResult>`, `ReadResult { id?: string; props?: Outputs }` — signature mirrors the existing `delete(id, props: KeyProviderState)`.

## Risks / notes

- **Behavioral change on refresh only.** A genuinely-missing key now drops from state on refresh and is recreated on the next up (the intended fix). No effect on plain `up`.
- One LiteLLM response variant — HTTP **200 with an `{error: …}` body** for a missing key — surfaces via `adminRequest`'s existing generic-error path, so `read()` preserves state rather than self-heals in that case. This is the **safe direction** (no false recreate) and is noted in code; deployed LiteLLM returns 4xx here.
- **Immediate remediation** for an already-drifted key (no deploy of this PR needed): `pulumi up --target '<urn>' --replace` (`diff()` sets `deleteBeforeReplace: true`).

## CI caveats (pre-existing, not from this change)

- `nix flake check` fails on **treefmt** due to pre-existing `renovate/*.json` drift (treefmt isn't in sector7's GitHub CI) and a `pnpm-deps` FOD hash mismatch (known pnpm-on-darwin FOD nondeterminism). This diff touches neither `package.json`/lockfile nor those files; the two changed files are treefmt-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
