### PR TITLE
fix(renovate): don't pin digests for sector7 self-references

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,5 +1,22 @@
 {
   extends: [
-    "github>jmmaloney4/sector7//renovate/all.json"
-  ]
+    "github>jmmaloney4/sector7//renovate/all.json",
+  ],
+  packageRules: [
+    {
+      // sector7's own reusable workflows and composite actions are intentionally
+      // referenced @main (see .github/workflows/*.yml and .github/actions/*) so
+      // that our dogfood workflows always run the latest commit. Pinning these
+      // self-references to a digest creates a perpetual "always one behind" lag:
+      // every push to a reusable workflow/action would require a follow-up
+      // Renovate PR to bump the SHA. Keep them floating on @main instead.
+      //
+      // This override is deliberately repo-local (not in renovate/default.json),
+      // because other repos consuming sector7's actions may legitimately want
+      // digest pinning for stability. It only affects sector7 renovating itself.
+      description: "Do not pin digests for internal sector7 actions/workflows — they intentionally track @main to avoid always-one-behind lag.",
+      matchPackageNames: ["/^jmmaloney4\\/sector7($|\\/)/"],
+      pinDigests: false,
+    },
+  ],
 }


### PR DESCRIPTION
## Summary

Stops Renovate from digest-pinning sector7's own reusable workflows and composite actions, which we intentionally reference `@main`.

### Why Renovate was doing it (re: #294)

The live repo-local config is `.github/renovate.json5`, which extends `github>jmmaloney4/sector7//renovate/all.json` → `renovate/default.json`. That preset sets a global **`pinDigests: true`** and pulls in **`helpers:pinGitHubActionDigestsToSemver`**, so *every* GitHub Action ref — including `uses: jmmaloney4/sector7/...@main` self-references — gets pinned to a commit SHA.

The existing sector7 packageRule in `renovate/default.json` only nulls the stability delay (`minimumReleaseAge`); its own description notes "digest pinning still applies via the global pinDigests policy." So the self-references were pinned by design, producing the perpetual **"always one behind"** lag in PR #294: every push to a reusable workflow/action needs a follow-up Renovate PR to bump the SHA.

### Fix

Add a **repo-local** packageRule (`pinDigests: false`) matching `jmmaloney4/sector7`, so these refs float on `@main`.

Kept out of `renovate/default.json` deliberately, per request — other repos that consume sector7's actions may legitimately want digest pinning for stability. This override only affects sector7 renovating itself.

## Test plan

- [x] `renovate-config-validator .github/renovate.json5` → "Config validated successfully"
- [ ] After merge: confirm Renovate updates/closes #294 so the `jmmaloney4/sector7 @main` entries are no longer pinned (the `nixpkgs` digest pin in #294 is unrelated and should remain).

## Notes / follow-up

While investigating I found a **dead second config file**: `.github/renovate.json` (higher file-precedence than `.json5`) extends `github>jmmaloney4/.github//renovate/default.json5`, but that preset path does not exist in the `jmmaloney4/.github` repo. All live Renovate behavior (PR labels, the helm-regex error in #290, the `nix run github:` `.sh` detections, and the digest pinning itself) traces to the `.json5 → sector7 presets` chain, confirming the `.json` is not the active config. Its `nix run github:` customManager is also already duplicated in `renovate/nix.json`. Recommend deleting `.github/renovate.json` (or populating the `jmmaloney4/.github` preset) in a separate change — left untouched here to avoid scope creep and in case the `jmmaloney4/.github` migration is intentional.

🤖 Generated with [Claude Code](https://claude.com/claude-code)