### PR TITLE
feat(renovate): track container images stored as Pulumi config values

### DIFF
--- a/renovate/pulumi.json
+++ b/renovate/pulumi.json
@@ -1,9 +1,10 @@
 {
 	"$schema": "https://docs.renovatebot.com/renovate-schema.json",
-	"description": "Pulumi-specific Renovate configuration. Tracks dependency versions annotated inline in Pulumi YAML config files (`Pulumi.yaml`, `Pulumi.<stack>.yaml`) as `someVersion: X.Y.Z # renovate: datasource=<ds> depName=<name> registryUrl=<url>` — e.g. Helm chart versions consumed by Pulumi programs. Replacement deliberately relies on Renovate's default in-place behaviour, which rewrites only the matched `currentValue` and preserves the rest of the line. Do NOT add an `autoReplaceStringTemplate` that references the `versionKey` capture group: Renovate only carries its recognised match fields (depName, packageName, currentValue, currentDigest, datasource, versioning, extractVersion, registryUrl, depType, indentation) plus the computed new* fields onto the upgrade object that renders the replace template, so `{{{versionKey}}}` resolves to an empty string. That produced a malformed line (`  : X.Y.Z # ...`) which failed Renovate's post-replace re-extraction (confirmIfDepUpdated) and aborted every update with WORKER_FILE_UPDATE_FAILED, surfacing on the dependency dashboard as 'Error updating branch: update failure'.",
+	"description": "Pulumi-specific Renovate configuration. Tracks two kinds of dependency pins annotated inline in Pulumi YAML config files (`Pulumi.yaml`, `Pulumi.<stack>.yaml`). (1) Helm chart (and other semver) versions written as `someVersion: X.Y.Z # renovate: datasource=<ds> depName=<name> registryUrl=<url>`. Replacement deliberately relies on Renovate's default in-place behaviour, which rewrites only the matched `currentValue` and preserves the rest of the line. Do NOT add an `autoReplaceStringTemplate` that references the `versionKey` capture group: Renovate only carries its recognised match fields (depName, packageName, currentValue, currentDigest, datasource, versioning, extractVersion, registryUrl, depType, indentation) plus the computed new* fields onto the upgrade object that renders the replace template, so `{{{versionKey}}}` resolves to an empty string. That produced a malformed line (`  : X.Y.Z # ...`) which failed Renovate's post-replace re-extraction (confirmIfDepUpdated) and aborted every update with WORKER_FILE_UPDATE_FAILED, surfacing on the dependency dashboard as 'Error updating branch: update failure'. (2) Container image references stored as Pulumi config values — `<name>Image: \"<registry>/<repo>:<tag>[@sha256:...]\" # renovate: datasource=docker [versioning=<scheme>]` — for Pulumi programs that read the image from config rather than from a TypeScript literal (which renovate/docker-images.json already covers). depName is derived from the image string itself (the repository up to the tag), so it can never drift from the value being rewritten; the value may be quoted or unquoted and may carry a pinned `@sha256:` digest. Both managers are opt-in: only lines carrying the inline `# renovate:` comment are touched — no heuristic scanning.",
 	"customManagers": [
 		{
 			"customType": "regex",
+			"description": "Annotated Helm chart / semver versions in Pulumi YAML config",
 			"managerFilePatterns": ["/(^|.*\\/)?Pulumi(\\..+)?\\.yaml$/"],
 			"matchStrings": [
 				"(?<versionKey>[A-Za-z0-9_:-]*Version):\\s*(?<currentValue>\\d+\\.\\d+\\.\\d+)\\s*#\\s*renovate:\\s*datasource=(?<datasource>\\S+)\\s+depName=(?<depName>\\S+)\\s+registryUrl=(?<registryUrl>\\S+)"
@@ -12,6 +13,17 @@
 			"depNameTemplate": "{{{depName}}}",
 			"registryUrlTemplate": "{{{registryUrl}}}",
 			"versioningTemplate": "semver"
+		},
+		{
+			"customType": "regex",
+			"description": "Annotated container image references stored as Pulumi config values; depName is derived from the image literal so it cannot drift from the rewritten string",
+			"managerFilePatterns": ["/(^|.*\\/)?Pulumi(\\..+)?\\.yaml$/"],
+			"matchStrings": [
+				":\\s*[\"']?(?<depName>(?:[^\"'@\\s]+/)*[^\"'@\\s/]+):(?<currentValue>[^\"'@\\s:]+)(?:@(?<currentDigest>sha256:[a-f0-9]{64}))?[\"']?\\s*#\\s*renovate:\\s*datasource=docker(?:\\s+versioning=(?<versioning>\\S+))?"
+			],
+			"datasourceTemplate": "docker",
+			"depNameTemplate": "{{{depName}}}",
+			"versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}docker{{/if}}"
 		}
 	]
 }


### PR DESCRIPTION
## Summary

Adds a second custom manager to the `pulumi.json` Renovate preset so it tracks **container image references stored as Pulumi config values** in `Pulumi.*.yaml`, e.g.:

```yaml
runnerImage: "ghcr.io/actions/actions-runner:2.335.1" # renovate: datasource=docker
```

## Why

The preset previously matched only annotated Helm/semver `*Version` keys. Image refs that live as Pulumi *config values* (`<name>Image: "<ref>"`) were tracked by **nothing**:

- `renovate/docker-images.json` scans only `.ts` string literals,
- `renovate/yaml-manifests.json` keys off a literal `image:` manifest field (not a `<name>Image:` config key),
- `renovate/pulumi.json` matched only `*Version` keys with bare semver.

So when a consumer (jmmaloney4/garden) refactored ~23 image pins from TypeScript defaults into Pulumi config, they **all silently fell out of Renovate** — including `ghcr.io/actions/actions-runner`, which then went stale past GitHub's minimum runner version and wedged the self-hosted CI fleet.

## Design

- `depName` is derived from the image literal itself (repository up to the tag), mirroring `docker-images.json` — so it can never drift from the string being rewritten.
- Value may be quoted or unquoted, and may carry a pinned `@sha256:` digest.
- Opt-in: only lines with an inline `# renovate: datasource=docker [versioning=<scheme>]` comment are touched (no heuristic scanning), consistent with the other annotated managers.
- RE2-safe (no lookahead).

## Test plan

Validated the `matchString` against **every** real image line in jmmaloney4/garden's Pulumi config (15 distinct lines: quoted/unquoted, digest-pinned `@sha256`, and tag formats like `2.335.1`, `latest`, `main-stable`, `8-alpine`, `2026.5.31-7159b8aed`, `0.36.0-github_app`). All extract the correct `depName`/`currentValue`/`currentDigest`. Negative cases — `datasource=helm` chart lines and unannotated image lines — are correctly ignored.

## Rollout

The companion garden PR adds the `# renovate: datasource=docker` annotations (and bumps the runner image). This preset change must land on `main` first, since garden resolves `github>jmmaloney4/sector7//renovate/all.json` from the default branch.