### PR TITLE
fix(actions): parse JSON runs-on in pulumi workflow

### DIFF
--- a/.github/workflows/pulumi.yml
+++ b/.github/workflows/pulumi.yml
@@ -70,7 +70,7 @@ on:
 jobs:
   detect-pulumi-stacks:
     name: "🧩 detect pulumi stacks"
-    runs-on: ${{ inputs.runs-on }}
+    runs-on: ${{ startsWith(inputs.runs-on, '[') && fromJson(inputs.runs-on) || inputs.runs-on }}
     permissions:
       contents: read
       id-token: write
@@ -104,7 +104,7 @@ jobs:
   pulumi-preview-and-deploy:
     name: "🔍☁️ pulumi preview + deploy"
     needs: detect-pulumi-stacks
-    runs-on: ${{ inputs.runs-on }}
+    runs-on: ${{ startsWith(inputs.runs-on, '[') && fromJson(inputs.runs-on) || inputs.runs-on }}
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Summary

The pulumi reusable workflow never picks up runners when callers pass `runs-on` as a JSON array string (e.g., `'["self-hosted","room-of-requirement"]'`). Every pulumi job sits in `queued` indefinitely.

**Root cause**: `runs-on: ${{ inputs.runs-on }}` treats the entire JSON string as a single literal label. GitHub Actions sees one label called `["self-hosted","room-of-requirement"]` (with brackets and quotes), which no runner has.

The nix workflow already handles this correctly:
```yaml
runs-on: ${{ startsWith(inputs.runs-on, '[') && fromJson(inputs.runs-on) || inputs.runs-on }}
```

This PR applies the same expression to both job-level `runs-on` declarations in `pulumi.yml`:
- `detect-pulumi-stacks` (job that discovers Pulumi stacks)
- `pulumi-preview-and-deploy` (matrix job that runs preview/deploy)

## Evidence

Discovered in `jmmaloney4/garden`, which passes `runs-on: '["self-hosted","room-of-requirement"]'` to both nix and pulumi reusable workflows.

The GitHub API confirms the label malformation:

| Workflow | Job labels (from API) |
|----------|----------------------|
| nix `detect` | `["self-hosted", "room-of-requirement"]` — 2 correct labels |
| pulumi `detect` | `["[\"self-hosted\",\"room-of-requirement\"]"]` — 1 literal JSON string |

Nix jobs schedule and run. Pulumi jobs have **never completed** — every run in the history is `queued`.

## Test plan

- [x] `actionlint` passes on the patched workflow (exit 0, no findings)
- [x] YAML structure validated — both job-level `runs-on` use the `fromJson` expression
- [x] Composite action `with: runs-on:` inputs left unchanged (those are string inputs to actions, not runner labels)
- [x] Expression matches `nix.yml` exactly (the proven-working pattern)
- [ ] Live validation: after merge, trigger a pulumi workflow in garden and confirm the job gets assigned to a runner

## Broader pattern

The same `runs-on: ${{ inputs.runs-on }}` vulnerability exists in other sector7 reusable workflows: `pnpm.yml`, `rust.yml`, `claude.yml`, `claude-review.yml`, and `adr-management.yml`. Those should get the same fix in a follow-up, but this PR is scoped to the pulumi workflow that is actively broken.
