### PR TITLE
fix(actions): parse JSON runs-on in reusable workflows

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -30,7 +30,7 @@ permissions:
   contents: read
 jobs:
   add-to-project:
-    runs-on: ${{ inputs.runs-on }}
+    runs-on: ${{ startsWith(inputs.runs-on, '[') && fromJson(inputs.runs-on) || inputs.runs-on }}
     steps:
       - name: Add issue or PR to project
         uses: jmmaloney4/sector7/.github/actions/add-to-project@main

--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -30,7 +30,7 @@ permissions:
   contents: read
 jobs:
   add-to-project:
-    runs-on: ${{ startsWith(inputs.runs-on, '[') && fromJson(inputs.runs-on) || inputs.runs-on }}
+    runs-on: ${{ (startsWith(inputs.runs-on, '[') || startsWith(inputs.runs-on, '{')) && fromJson(inputs.runs-on) || inputs.runs-on }}
     steps:
       - name: Add issue or PR to project
         uses: jmmaloney4/sector7/.github/actions/add-to-project@main

--- a/.github/workflows/adr-management.yml
+++ b/.github/workflows/adr-management.yml
@@ -48,7 +48,7 @@ jobs:
   manage-adrs:
     name: "push placeholder to ${{ inputs.base_ref }}"
     if: github.actor != 'github-actions[bot]'
-    runs-on: ${{ inputs.runs-on }}
+    runs-on: ${{ startsWith(inputs.runs-on, '[') && fromJson(inputs.runs-on) || inputs.runs-on }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/adr-management.yml
+++ b/.github/workflows/adr-management.yml
@@ -48,7 +48,7 @@ jobs:
   manage-adrs:
     name: "push placeholder to ${{ inputs.base_ref }}"
     if: github.actor != 'github-actions[bot]'
-    runs-on: ${{ startsWith(inputs.runs-on, '[') && fromJson(inputs.runs-on) || inputs.runs-on }}
+    runs-on: ${{ (startsWith(inputs.runs-on, '[') || startsWith(inputs.runs-on, '{')) && fromJson(inputs.runs-on) || inputs.runs-on }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -21,7 +21,7 @@ on:
         required: true
 jobs:
   claude-review:
-    runs-on: ${{ startsWith(inputs.runs-on, '[') && fromJson(inputs.runs-on) || inputs.runs-on }}
+    runs-on: ${{ (startsWith(inputs.runs-on, '[') || startsWith(inputs.runs-on, '{')) && fromJson(inputs.runs-on) || inputs.runs-on }}
     permissions:
       contents: read
       pull-requests: read

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -21,7 +21,7 @@ on:
         required: true
 jobs:
   claude-review:
-    runs-on: ${{ inputs.runs-on }}
+    runs-on: ${{ startsWith(inputs.runs-on, '[') && fromJson(inputs.runs-on) || inputs.runs-on }}
     permissions:
       contents: read
       pull-requests: read

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -17,7 +17,7 @@ on:
         type: string
 jobs:
   claude:
-    runs-on: ${{ startsWith(inputs.runs-on, '[') && fromJson(inputs.runs-on) || inputs.runs-on }}
+    runs-on: ${{ (startsWith(inputs.runs-on, '[') || startsWith(inputs.runs-on, '{')) && fromJson(inputs.runs-on) || inputs.runs-on }}
     permissions:
       contents: read
       pull-requests: read

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -17,7 +17,7 @@ on:
         type: string
 jobs:
   claude:
-    runs-on: ${{ inputs.runs-on }}
+    runs-on: ${{ startsWith(inputs.runs-on, '[') && fromJson(inputs.runs-on) || inputs.runs-on }}
     permissions:
       contents: read
       pull-requests: read

--- a/.github/workflows/pnpm.yml
+++ b/.github/workflows/pnpm.yml
@@ -52,7 +52,7 @@ on:
 jobs:
   analyze:
     name: "🧱 analyze pnpm packages"
-    runs-on: ${{ startsWith(inputs.runs-on, '[') && fromJson(inputs.runs-on) || inputs.runs-on }}
+    runs-on: ${{ (startsWith(inputs.runs-on, '[') || startsWith(inputs.runs-on, '{')) && fromJson(inputs.runs-on) || inputs.runs-on }}
     permissions:
       contents: read
       packages: read
@@ -99,7 +99,7 @@ jobs:
           echo '${{ toJson(fromJson(steps.analyze.outputs.matrix || '[]')) }}'
   verify-lockfile:
     name: "🔒 verify pnpm-lock.yaml"
-    runs-on: ${{ startsWith(inputs.runs-on, '[') && fromJson(inputs.runs-on) || inputs.runs-on }}
+    runs-on: ${{ (startsWith(inputs.runs-on, '[') || startsWith(inputs.runs-on, '{')) && fromJson(inputs.runs-on) || inputs.runs-on }}
     permissions:
       contents: read
     steps:
@@ -124,7 +124,7 @@ jobs:
   publish-packages:
     name: "🚀 publish (${{ inputs.target }}): ${{ matrix.name }}"
     needs: [analyze, verify-lockfile]
-    runs-on: ${{ startsWith(inputs.runs-on, '[') && fromJson(inputs.runs-on) || inputs.runs-on }}
+    runs-on: ${{ (startsWith(inputs.runs-on, '[') || startsWith(inputs.runs-on, '{')) && fromJson(inputs.runs-on) || inputs.runs-on }}
     if: needs.analyze.outputs.has_packages == 'true'
     strategy:
       fail-fast: false

--- a/.github/workflows/pnpm.yml
+++ b/.github/workflows/pnpm.yml
@@ -52,7 +52,7 @@ on:
 jobs:
   analyze:
     name: "🧱 analyze pnpm packages"
-    runs-on: ${{ inputs.runs-on }}
+    runs-on: ${{ startsWith(inputs.runs-on, '[') && fromJson(inputs.runs-on) || inputs.runs-on }}
     permissions:
       contents: read
       packages: read
@@ -99,7 +99,7 @@ jobs:
           echo '${{ toJson(fromJson(steps.analyze.outputs.matrix || '[]')) }}'
   verify-lockfile:
     name: "🔒 verify pnpm-lock.yaml"
-    runs-on: ${{ inputs.runs-on }}
+    runs-on: ${{ startsWith(inputs.runs-on, '[') && fromJson(inputs.runs-on) || inputs.runs-on }}
     permissions:
       contents: read
     steps:
@@ -124,7 +124,7 @@ jobs:
   publish-packages:
     name: "🚀 publish (${{ inputs.target }}): ${{ matrix.name }}"
     needs: [analyze, verify-lockfile]
-    runs-on: ${{ inputs.runs-on }}
+    runs-on: ${{ startsWith(inputs.runs-on, '[') && fromJson(inputs.runs-on) || inputs.runs-on }}
     if: needs.analyze.outputs.has_packages == 'true'
     strategy:
       fail-fast: false

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -25,7 +25,7 @@ permissions:
 jobs:
   cargo-check:
     name: "🔬 cargo check"
-    runs-on: ${{ inputs.runs-on }}
+    runs-on: ${{ startsWith(inputs.runs-on, '[') && fromJson(inputs.runs-on) || inputs.runs-on }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -45,7 +45,7 @@ jobs:
   cargo-test:
     name: "🧪 cargo test"
     needs: cargo-check
-    runs-on: ${{ inputs.runs-on }}
+    runs-on: ${{ startsWith(inputs.runs-on, '[') && fromJson(inputs.runs-on) || inputs.runs-on }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -79,7 +79,7 @@ jobs:
   cargo-clippy:
     name: "🧑‍🏫 cargo clippy"
     needs: cargo-check
-    runs-on: ${{ inputs.runs-on }}
+    runs-on: ${{ startsWith(inputs.runs-on, '[') && fromJson(inputs.runs-on) || inputs.runs-on }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -25,7 +25,7 @@ permissions:
 jobs:
   cargo-check:
     name: "🔬 cargo check"
-    runs-on: ${{ startsWith(inputs.runs-on, '[') && fromJson(inputs.runs-on) || inputs.runs-on }}
+    runs-on: ${{ (startsWith(inputs.runs-on, '[') || startsWith(inputs.runs-on, '{')) && fromJson(inputs.runs-on) || inputs.runs-on }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -45,7 +45,7 @@ jobs:
   cargo-test:
     name: "🧪 cargo test"
     needs: cargo-check
-    runs-on: ${{ startsWith(inputs.runs-on, '[') && fromJson(inputs.runs-on) || inputs.runs-on }}
+    runs-on: ${{ (startsWith(inputs.runs-on, '[') || startsWith(inputs.runs-on, '{')) && fromJson(inputs.runs-on) || inputs.runs-on }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -79,7 +79,7 @@ jobs:
   cargo-clippy:
     name: "🧑‍🏫 cargo clippy"
     needs: cargo-check
-    runs-on: ${{ startsWith(inputs.runs-on, '[') && fromJson(inputs.runs-on) || inputs.runs-on }}
+    runs-on: ${{ (startsWith(inputs.runs-on, '[') || startsWith(inputs.runs-on, '{')) && fromJson(inputs.runs-on) || inputs.runs-on }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:


### PR DESCRIPTION
## Summary

Follow-up to #314. Applies the same `runs-on` JSON-array parsing fix to all remaining reusable workflows that were still using `runs-on: ${{ inputs.runs-on }}` at the job level.

When a caller passes `runs-on` as a JSON array string (e.g., `'["self-hosted","room-of-requirement"]'`), the raw expression treats the entire string as a single literal label. No runner matches it, so jobs sit in `queued` forever.

### Workflows fixed (10 job-level `runs-on` across 6 files)

| Workflow | Jobs fixed |
|----------|-----------|
| `claude.yml` | `claude` |
| `claude-review.yml` | `claude-review` |
| `adr-management.yml` | `manage-adrs` |
| `pnpm.yml` | `analyze`, `verify-lockfile`, `publish-packages` |
| `rust.yml` | `cargo-check`, `cargo-test`, `cargo-clippy` |
| `add-to-project.yml` | `add-to-project` |

The fix is the same expression already proven in `nix.yml` and `pulumi.yml`:
```yaml
runs-on: ${{ startsWith(inputs.runs-on, '[') && fromJson(inputs.runs-on) || inputs.runs-on }}
```

Composite-action `with: runs-on:` inputs are left unchanged — those pass the raw string to action inputs (used for `contains()` cache checks), not to the GitHub runner scheduler.

## Test plan

- [x] `actionlint` passes on all patched workflows (only pre-existing shellcheck noise in `pnpm.yml`, no new findings)
- [x] Verified only 4-space-indented job-level `runs-on` lines changed — 10-space `with:` inputs untouched
- [x] Expression matches `nix.yml` / `pulumi.yml` exactly

## Related

- #314 (pulumi workflow fix, merged)
