### PR TITLE
fix(nix-output): default drvPath change detection so content changes redeploy

### DIFF
--- a/docs/internal/designs/021-nix-output-component.md
+++ b/docs/internal/designs/021-nix-output-component.md
@@ -161,11 +161,48 @@ The `NixOutput` component runs `nix-output-resolve.sh`. The refactored `NixImage
 
 ## Trigger semantics
 
-Default trigger for `NixOutput` is `nixAttr` (the attribute path as a string). This means changing the attribute — e.g. from `packages.x86_64-linux.lens-api-image` to `packages.x86_64-linux.lens-api-v2-image` — will trigger a rebuild.
+> **Amended 2026-07-02.** The original design triggered only on `nixAttr`
+> (plus caller-supplied `triggers`). In practice no consumer passed extra
+> triggers, so `command.local.Command` never re-ran after the first
+> deploy: content changes silently served the stale store path from
+> Pulumi state (observed on the theoreticaledge.com dev stack, where a
+> `pulumi up` after new posts merged reported "unchanged" and deployed
+> nothing). Correct-by-default replaces opt-in triggering.
 
-Consumers who need finer-grained triggering (e.g. flake lock hash, git commit SHA) can pass `triggers` directly.
+`NixOutput` computes a **derivation-path trigger** by default
+(`changeDetection: "drv"`): at program time it runs
+`nix eval --raw <repoRoot>#<nixAttr>.drvPath` and includes the result in
+the child command's `triggers`. The drv path is nix's own hash over every
+transitive build input (sources as nix would copy them, lockfiles, flake
+inputs, toolchain), so:
 
-For `NixImage`, the default trigger remains `imageTag` since that's the deployment-level signal that matters. Additional triggers can be layered in.
+- the command re-runs **iff** the build would produce a different result;
+- `pulumi preview` stays clean when nothing relevant changed;
+- Pulumi never needs to know which files feed the build — nix answers that.
+
+Cost: one flake evaluation per preview/up. Nix's eval is the same work a
+no-op `nix build` would do, so this does not meaningfully slow deploys.
+An eval failure fails the program with a descriptive error (the build
+could not have succeeded either).
+
+`changeDetection: "none"` restores the legacy attr-only triggering for
+consumers whose evaluation is prohibitively slow and who manage triggers
+manually. `nixAttr` remains a trigger in both modes, and caller-supplied
+`triggers` are appended after the computed ones.
+
+For `NixImage` (build mode), the composed `NixOutput` inherits the same
+default, and the push command already re-triggers off `storePath`, so a
+drv change propagates build → push automatically. `NixImage` exposes a
+`changeDetection` passthrough for opt-out.
+
+Alternatives considered for the trigger value:
+
+- **Source narHash / git SHA**: cheaper to compute but wrong in both
+  directions — over-triggers on unrelated monorepo changes and cannot see
+  flake-input or toolchain changes that alter the output.
+- **Always re-run (timestamp/nonce trigger)**: correct results (nix
+  caches), but every preview shows a diff and state churns on every up.
+- **drvPath (selected)**: exact change semantics at the cost of one eval.
 
 # Consequences
 
@@ -213,6 +250,7 @@ Balances declarative intent ("output" of the nix system) with generality. An out
 
 - 2026-05-13: Proposed
 - 2026-05-13: Accepted — all open questions resolved, implementation in progress
+- 2026-07-02: Amended — default drvPath change detection (`changeDetection: "drv"`) replaces attr-only triggering after a stale-deploy incident
 
 # Resolved Questions
 

--- a/packages/sector7/nix-image/nix-image.ts
+++ b/packages/sector7/nix-image/nix-image.ts
@@ -48,6 +48,13 @@ export interface NixImageArgs {
 	/** Additional trigger values (added alongside imageTag) */
 	triggers?: pulumi.Input<string>[];
 	/**
+	 * Change-detection strategy for the underlying NixOutput build step
+	 * (build mode only). "drv" (default) re-runs the build when the
+	 * derivation path changes; "none" restores the legacy
+	 * imageTag/triggers-only behavior. See NixOutputArgs.changeDetection.
+	 */
+	changeDetection?: "drv" | "none";
+	/**
 	 * "build" = build+push the image (default)
 	 * "resolve" = skip build, just resolve the digest of the already-pushed tag
 	 */
@@ -156,6 +163,7 @@ export class NixImage extends pulumi.ComponentResource {
 					repoRoot: args.repoRoot,
 					mode: "build",
 					triggers: [args.imageTag, ...(args.triggers ?? [])],
+					changeDetection: args.changeDetection,
 					env: args.env,
 				},
 				{ parent: this },

--- a/packages/sector7/nix-output/nix-output.ts
+++ b/packages/sector7/nix-output/nix-output.ts
@@ -26,8 +26,26 @@ export interface NixOutputArgs {
 	 * The path must exist within the output derivation.
 	 */
 	subPath?: pulumi.Input<string>;
-	/** Additional trigger values (added alongside nixAttr). */
+	/** Additional trigger values (added alongside the computed triggers). */
 	triggers?: pulumi.Input<string>[];
+	/**
+	 * How the component detects that the nix output changed so the child
+	 * command re-runs on `pulumi up`.
+	 *
+	 * "drv" (default) evaluates the derivation path
+	 * (`nix eval --raw <repoRoot>#<nixAttr>.drvPath`) at program time and
+	 * includes it in the command's triggers. The drv hash covers every
+	 * transitive build input — sources, lockfiles, flake inputs — so the
+	 * command re-runs exactly when the build would produce a different
+	 * result, and previews stay clean when nothing changed. Costs one
+	 * flake evaluation per preview/up.
+	 *
+	 * "none" restores the legacy behavior: the command re-runs only when
+	 * `nixAttr` or a caller-supplied trigger changes. With no custom
+	 * triggers this means content changes never re-resolve — the store
+	 * path is served from Pulumi state until an input string changes.
+	 */
+	changeDetection?: "drv" | "none";
 	/**
 	 * "resolve" = resolve the output path without building (default).
 	 * Fast — just evaluates the flake to find the store path.
@@ -69,6 +87,36 @@ function parseStorePath(stdout: string, name: string): string {
 		);
 	}
 	return line.slice(prefix.length);
+}
+
+/**
+ * Evaluate the derivation path for a flake attribute. The drv path is
+ * nix's own content hash over every transitive build input, which makes
+ * it the precise "did anything relevant change?" trigger — Pulumi cannot
+ * know which files feed a build, but nix can.
+ *
+ * Exported for testing.
+ */
+export function resolveDrvPathTrigger(
+	repoRoot: string,
+	nixAttr: string,
+): string {
+	try {
+		return execFileSync(
+			"nix",
+			["eval", "--raw", `${repoRoot}#${nixAttr}.drvPath`],
+			{ encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] },
+		).trim();
+	} catch (error) {
+		const stderr =
+			error instanceof Error && "stderr" in error
+				? String((error as { stderr?: unknown }).stderr ?? "")
+				: "";
+		throw new Error(
+			`NixOutput: failed to evaluate drvPath for ${repoRoot}#${nixAttr}` +
+				` (changeDetection: "drv"): ${stderr || String(error)}`,
+		);
+	}
 }
 
 function isStringRecord(
@@ -136,12 +184,26 @@ export class NixOutput extends pulumi.ComponentResource {
 			...(args.subPath ? { SUB_PATH: args.subPath } : {}),
 		};
 
+		const changeDetection = args.changeDetection ?? "drv";
+		const drvPathTrigger =
+			changeDetection === "drv"
+				? pulumi
+						.all([args.repoRoot, args.nixAttr])
+						.apply(([repoRoot, nixAttr]) =>
+							resolveDrvPathTrigger(repoRoot, nixAttr),
+						)
+				: undefined;
+
 		const cmd = new command.local.Command(
 			`${name}-resolve`,
 			{
 				create: pulumi.interpolate`bash "${scriptPath}"`,
 				environment: env,
-				triggers: [args.nixAttr, ...(args.triggers ?? [])],
+				triggers: [
+					args.nixAttr,
+					...(drvPathTrigger !== undefined ? [drvPathTrigger] : []),
+					...(args.triggers ?? []),
+				],
 			},
 			{ parent: this },
 		);

--- a/packages/sector7/tests/nix-image.test.ts
+++ b/packages/sector7/tests/nix-image.test.ts
@@ -1,8 +1,17 @@
+import { execFileSync } from "node:child_process";
 import * as command from "@pulumi/command";
 import * as pulumi from "@pulumi/pulumi";
-import { beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { NixImage } from "../nix-image/nix-image";
 import { NixImagePushGroup } from "../nix-image/push-group";
+
+vi.mock("node:child_process", () => ({
+	execFileSync: vi.fn(),
+}));
+
+// The NixOutput child's default changeDetection ("drv") evaluates the
+// drvPath via execFileSync during resource construction.
+const MOCK_DRV_PATH = "/nix/store/drvhash123-my-image.drv";
 
 type MockResource = {
 	type: string;
@@ -50,6 +59,7 @@ beforeAll(() => {
 
 beforeEach(() => {
 	resources.length = 0;
+	vi.mocked(execFileSync).mockReturnValue(`${MOCK_DRV_PATH}\n`);
 });
 
 function resolveOutput<T>(value: pulumi.Input<T>): Promise<T> {
@@ -178,11 +188,15 @@ describe("NixImage", () => {
 
 		await resolveOutput(img.digest);
 
-		// NixOutput child triggers: [nixAttr, imageTag]
+		// NixOutput child triggers: [nixAttr, drvPath, imageTag]
 		const buildCmds = byName("test-triggers-default-build-resolve");
 		expect(buildCmds).toHaveLength(1);
 		const buildTriggers = buildCmds[0].inputs.triggers as string[];
-		expect(buildTriggers).toEqual(["packages.x86_64-linux.my-image", "dev"]);
+		expect(buildTriggers).toEqual([
+			"packages.x86_64-linux.my-image",
+			MOCK_DRV_PATH,
+			"dev",
+		]);
 
 		// Push command should also have imageTag as trigger
 		const pushCmds = byName("test-triggers-default-push");

--- a/packages/sector7/tests/nix-output.test.ts
+++ b/packages/sector7/tests/nix-output.test.ts
@@ -1,7 +1,11 @@
 import { execFileSync } from "node:child_process";
 import * as pulumi from "@pulumi/pulumi";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { NixOutput, resolvePreviewStorePath } from "../nix-output/nix-output";
+import {
+	NixOutput,
+	resolveDrvPathTrigger,
+	resolvePreviewStorePath,
+} from "../nix-output/nix-output";
 
 vi.mock("node:child_process", () => ({
 	execFileSync: vi.fn(),
@@ -59,10 +63,15 @@ function installMocks(preview = false): void {
 	);
 }
 
+const MOCK_DRV_PATH = "/nix/store/drvhash123-myapp-1.0.0.drv";
+
 beforeEach(() => {
 	resources.length = 0;
 	vi.clearAllMocks();
 	vi.restoreAllMocks();
+	// Default changeDetection ("drv") evaluates the drvPath via execFileSync
+	// during resource construction, so give it a stable answer.
+	vi.mocked(execFileSync).mockReturnValue(`${MOCK_DRV_PATH}\n`);
 	installMocks(false);
 });
 
@@ -176,7 +185,7 @@ describe("NixOutput", () => {
 		});
 	});
 
-	it("uses nixAttr as default trigger", async () => {
+	it("includes the drvPath trigger by default", async () => {
 		const output = new NixOutput("test-trigger-default", {
 			nixAttr: "packages.x86_64-linux.myapp",
 			repoRoot: "/home/user/my-repo",
@@ -188,10 +197,36 @@ describe("NixOutput", () => {
 		expect(cmds).toHaveLength(1);
 
 		const triggers = cmds[0].inputs.triggers as string[];
-		expect(triggers).toEqual(["packages.x86_64-linux.myapp"]);
+		expect(triggers).toEqual(["packages.x86_64-linux.myapp", MOCK_DRV_PATH]);
+		expect(execFileSync).toHaveBeenCalledWith(
+			"nix",
+			[
+				"eval",
+				"--raw",
+				"/home/user/my-repo#packages.x86_64-linux.myapp.drvPath",
+			],
+			expect.objectContaining({ encoding: "utf8" }),
+		);
 	});
 
-	it("appends custom triggers after nixAttr", async () => {
+	it("omits the drvPath trigger with changeDetection none", async () => {
+		const output = new NixOutput("test-trigger-none", {
+			nixAttr: "packages.x86_64-linux.myapp",
+			repoRoot: "/home/user/my-repo",
+			changeDetection: "none",
+		});
+
+		await resolveOutput(output.storePath);
+
+		const cmds = byName("test-trigger-none-resolve");
+		expect(cmds).toHaveLength(1);
+
+		const triggers = cmds[0].inputs.triggers as string[];
+		expect(triggers).toEqual(["packages.x86_64-linux.myapp"]);
+		expect(execFileSync).not.toHaveBeenCalled();
+	});
+
+	it("appends custom triggers after nixAttr and the drvPath trigger", async () => {
 		const output = new NixOutput("test-trigger-custom", {
 			nixAttr: "packages.x86_64-linux.myapp",
 			repoRoot: "/home/user/my-repo",
@@ -206,9 +241,36 @@ describe("NixOutput", () => {
 		const triggers = cmds[0].inputs.triggers as string[];
 		expect(triggers).toEqual([
 			"packages.x86_64-linux.myapp",
+			MOCK_DRV_PATH,
 			"commit-sha-abc",
 			"v2.0.0",
 		]);
+	});
+
+	it("resolveDrvPathTrigger trims the evaluated drv path", () => {
+		vi.mocked(execFileSync).mockReturnValue("/nix/store/deadbeef-site.drv\n");
+
+		const drvPath = resolveDrvPathTrigger("/repo", "site-html");
+		expect(drvPath).toBe("/nix/store/deadbeef-site.drv");
+		expect(execFileSync).toHaveBeenCalledWith(
+			"nix",
+			["eval", "--raw", "/repo#site-html.drvPath"],
+			expect.objectContaining({ encoding: "utf8" }),
+		);
+	});
+
+	it("resolveDrvPathTrigger surfaces stderr on eval failure", () => {
+		vi.mocked(execFileSync).mockImplementation(() => {
+			const error = new Error("Command failed") as Error & {
+				stderr: string;
+			};
+			error.stderr = "error: attribute 'missing' not found";
+			throw error;
+		});
+
+		expect(() => resolveDrvPathTrigger("/repo", "missing")).toThrow(
+			/failed to evaluate drvPath for \/repo#missing.*attribute 'missing' not found/s,
+		);
 	});
 
 	it("passes extra env vars to the command", async () => {


### PR DESCRIPTION
## Summary

Fixes a stale-deploy footgun in `NixOutput`: the underlying `command.local.Command` only re-ran when its `triggers` changed, and the only default trigger was the attr *name*. No consumer passes extra triggers, so after the first `pulumi up` the command never re-ran — content changes silently deployed nothing, with the store path served from Pulumi state.

**Observed in production today** on `theoreticaledge.com` (garden): new posts merged to main, `pulumi up -s dev` reported `126 unchanged` and deployed a store path frozen in state from the stack's first up.

### The fix: derivation-path change detection, on by default

Pulumi cannot know which files feed a nix build — but nix can: that is exactly what the drv hash is. New `changeDetection` arg on `NixOutputArgs`:

- **`"drv"` (default):** at program time, evaluate `nix eval --raw <repoRoot>#<nixAttr>.drvPath` and include the result in the command's `triggers`. The drv path covers every transitive build input (sources as nix copies them, lockfiles, flake inputs, toolchain), so the command re-runs **iff** the build would produce a different result, and previews stay clean otherwise. Cost: one flake eval per preview/up (~6s measured on the garden monorepo flake); a no-op `nix build` does the same eval anyway. Eval failure fails the program with a descriptive error including nix's stderr.
- **`"none"`:** legacy attr-only triggering, for consumers with prohibitively slow evals who manage `triggers` manually.

`nixAttr` remains a trigger in both modes; caller `triggers` append after the computed ones. `subOutput` deliberately does not participate in the eval — all outputs share one drv.

### NixImage

`NixImage` (build mode) composes `NixOutput`, so it inherits the fix; its push command already re-triggers off `storePath`, so drv change → rebuild → re-push propagates end to end. Added a `changeDetection` passthrough on `NixImageArgs` for opt-out.

### ADR

ADR-021's "Trigger semantics" section amended: documents the incident, the new default, and the rejected alternatives (source narHash / git SHA — wrong in both directions; always-re-run nonce — correct results but permanent preview diffs and state churn).

## Behavior change / rollout note

This is intentionally a behavior change (correct-by-default). On the first `pulumi up` after upgrading, every `NixOutput`/`NixImage(build)` re-runs once (the trigger set changed) — that one-time re-run is itself the fix deploying. Consumers also start paying one flake eval per preview/up; `changeDetection: "none"` opts out.

## Test plan

- [x] `pnpm -C packages/sector7 test` — 291/291 pass. (`tests/renovate-pulumi.test.ts` fails to collect identically on untouched `main` — pre-existing, unrelated.)
- [x] New tests: default drv trigger present with exact `nix eval` invocation; `changeDetection: "none"` omits it and never execs; trigger ordering `[nixAttr, drv, ...custom]`; `resolveDrvPathTrigger` trims output and surfaces nix stderr on failure; `nix-image` build-mode trigger composition `[nixAttr, drv, imageTag]`.
- [x] `pnpm -C packages/sector7 build` (tsc) clean.
- [x] Shorthand attr resolution + eval cost verified against the real garden flake: `nix eval --raw '<garden>#theoretical-edge-html-dev.drvPath'` → drv path in ~6s.

## Risks

- Consumers with very expensive flake evals see slower previews; mitigated by opt-out.
- The drv eval runs at program construction (synchronous `execFileSync` inside an `apply`); on stacks where `repoRoot`/`nixAttr` are unknown during preview the trigger stays unknown, which Pulumi handles as a potential-change — same fallback semantics as `previewStrategy: "resource"`.

## Links

- ADR-021 (amended in this PR)
- Incident: jmmaloney4/garden theoreticaledge.com dev stack stale deploy, 2026-07-02
