### PR TITLE
release: bump sector7 to 0.18.0

### DIFF
--- a/packages/sector7/package.json
+++ b/packages/sector7/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@jmmaloney4/sector7",
-	"version": "0.17.0",
+	"version": "0.18.0",
 	"description": "Reusable Pulumi components for infrastructure management",
 	"license": "MPL-2.0",
 	"publishConfig": {


### PR DESCRIPTION
Version-only bump for the v0.18.0 release (first release carrying #316 — NixOutput default drvPath change detection, ADR-021 amendment). Tag + release tarball follow the merge. Lockfile unchanged (verified: `pnpm install` produced no lockfile diff); tarball built and inspected — `dist/nix-output/nix-output.js` carries `changeDetection`/`resolveDrvPathTrigger`.