### PR TITLE
fix(k8s): pre-resolve client-node import path for port-forward providers

### DIFF
--- a/packages/sector7/k8s/port-forward.ts
+++ b/packages/sector7/k8s/port-forward.ts
@@ -4,16 +4,31 @@
 // authenticates to, so the target needs no tailnet/public ingress.
 //
 // SERIALIZATION CONTRACT — do not break:
-// This module MUST have no top-level *runtime* `import` statements. Every Node/k8s
-// import is a lazy `await import()` *inside* `withPortForward`. Dynamic resource
-// providers (e.g. `onepassword/item.ts`, and `litellm/admin.ts` once it adopts
-// this) reference `withPortForward` from their provider callbacks; Pulumi
-// serializes that closure, capturing this function and its (import-free) module
-// scope. A top-level `import * as k8s from "@kubernetes/client-node"` here would
-// be pulled into every such closure and break serialization. `import type` is
-// fine — it is erased at compile time and produces no runtime import.
+// This module MUST have no top-level *runtime* `import` of heavy third-party
+// packages. Pulumi serializes the provider callbacks that reference
+// `withPortForward` and re-evaluates them from the *consuming* workspace's
+// working directory — not from sector7's installed location. Under pnpm strict
+// isolation, a lazy `await import("@kubernetes/client-node")` in that context
+// resolves against the consumer's `node_modules`, where the package does NOT
+// exist, so the import fails (`Cannot find package '@kubernetes/client-node'`).
+//
+// To stay resolvable in any consumer context we pre-resolve the absolute path
+// to the package here, at module load, using a `require` scoped to *this* file
+// (sector7's own installed location). The result is a plain string that Pulumi's
+// closure serializer captures as a free variable — the same mechanism that
+// already carries module-level consts into serialized functions. `import()`
+// with an absolute path then loads the package directly, bypassing the
+// consumer's module resolution entirely. `node:module` is a Node built-in, so
+// importing it at the top level does not violate the "no heavy third-party
+// imports" rule.
 
+import { createRequire } from "node:module";
 import type { Socket } from "node:net";
+
+// Pre-resolved at module load. The resolved path string is captured by Pulumi's
+// closure serializer; see the SERIALIZATION CONTRACT above.
+const require_ = createRequire(import.meta.url);
+const k8sClientNodePath = require_.resolve("@kubernetes/client-node");
 
 /** Where to open an in-process port-forward. */
 export interface PortForwardTarget {
@@ -82,7 +97,7 @@ export async function withPortForward<T>(
 	target: PortForwardTarget,
 	fn: (baseUrl: string) => Promise<T>,
 ): Promise<T> {
-	const k8s = await import("@kubernetes/client-node");
+	const k8s = await import(k8sClientNodePath);
 	const net = await import("node:net");
 
 	const kc = new k8s.KubeConfig();

--- a/packages/sector7/tests/port-forward.test.ts
+++ b/packages/sector7/tests/port-forward.test.ts
@@ -1,3 +1,4 @@
+import { existsSync } from "node:fs";
 import { describe, expect, it } from "vitest";
 import { buildLabelSelector } from "../k8s/port-forward.ts";
 
@@ -49,5 +50,28 @@ describe("buildLabelSelector", () => {
 		expect(buildLabelSelector({ matchLabels: {}, matchExpressions: [] })).toBe(
 			"",
 		);
+	});
+});
+
+describe("k8sClientNodePath pre-resolution", () => {
+	it("resolves @kubernetes/client-node to an absolute path inside sector7's deps", async () => {
+		// Loading the module exercises the module-level createRequire().resolve
+		// call; if the package were not resolvable from sector7's installed
+		// location, the import would throw before this assertion runs.
+		await import("../k8s/port-forward.ts");
+		const { createRequire } = await import("node:module");
+		const require_ = createRequire(import.meta.url);
+		const resolved = require_.resolve("@kubernetes/client-node");
+
+		expect(resolved).toMatch(/@kubernetes[\\/]client-node/);
+		expect(existsSync(resolved)).toBe(true);
+	});
+
+	it("keeps withPortForward as a serializable function reference", async () => {
+		const mod = await import("../k8s/port-forward.ts");
+		expect(typeof mod.withPortForward).toBe("function");
+		// The function must not close over the heavy k8s module at load time.
+		// The module-level pre-resolution is a string; the actual import happens
+		// inside the function body via `await import(k8sClientNodePath)`.
 	});
 });


### PR DESCRIPTION
## Summary

Dynamic resource providers that use `withPortForward` (for example `OnePasswordItem`, the LiteLLM admin resource, and the Attic providers) lazy-import `@kubernetes/client-node` at runtime inside their serialized callbacks. Pulumi re-evaluates those callbacks from the **consuming workspace's** working directory, and under pnpm strict isolation the package is not resolvable there — so `pulumi up` fails with:

```text
Cannot find package '@kubernetes/client-node' imported from /path/to/consumer/workspace/
```

This has hit `matrix`, `litellm`, and `gateway` in garden. The workaround has been to add `@kubernetes/client-node` as an explicit dependency of every consuming stack — a leaky abstraction.

This change pre-resolves the absolute path to `@kubernetes/client-node` at module load time, using a `require` scoped to sector7's own installed location. The resolved path is a plain string captured by Pulumi's closure serializer, and `import()` with an absolute path bypasses consumer module resolution entirely.

## Why this does not break the serialization contract

The contract is about avoiding top-level runtime imports of heavy third-party packages into the closure graph. `node:module` is a Node built-in. The `createRequire().resolve()` call executes at module load; only the resulting **string** crosses the closure boundary — the same mechanism that already carries module-level consts like `DEFAULT_DEPLOYMENT` and `DEFAULT_PORT` into serialized functions.

## Test plan

- [x] `pnpm --filter @jmmaloney4/sector7 exec vitest run tests/port-forward.test.ts` — 7/7 pass (5 existing + 2 new regression tests)
- [x] `pnpm --filter @jmmaloney4/sector7 run build` — tsc build clean
- [ ] Consumer validation from garden `matrix` without the consumer-side `@kubernetes/client-node` dep (tracked in #319, post-merge)

The pre-existing `tests/renovate-pulumi.test.ts` failure on `origin/main` is unrelated to this change.

Closes #319.

## Risk

Low. The behavior change is purely about *how* the k8s client module is resolved — it changes a bare specifier `import("@kubernetes/client-node")` to an absolute-path `import(k8sClientNodePath)`. The loaded module is identical. No public API changes. If the resolution somehow fails in a consumer context, the error message will still be clear (Node's dynamic import error on an absolute path).

## Follow-up

After release, the consumer-side workaround in garden (`@kubernetes/client-node` in `deploy/services/{matrix,litellm}/package.json` and `deploy/platform/gateway/package.json`) can be removed.
