### PR TITLE
fix(nix-output): keep non-UTF-8 build-log bytes out of captured stdout

### DIFF
--- a/packages/sector7/scripts/nix-output-resolve.sh
+++ b/packages/sector7/scripts/nix-output-resolve.sh
@@ -12,6 +12,19 @@
 #   SUB_PATH          - sub-path within the resolved store path (e.g. "assets/style.css")
 #   SCRIPT_MODE       - "resolve" (default) or "build"
 #   COMMAND_LOG_STEM  - log directory path (default: .pulumi/command-logs)
+#
+# UTF-8 safety (sector7#318): this script is invoked by a
+# `command.local.Command` resource, whose captured stdout/stderr become Pulumi
+# resource output properties. Pulumi marshals those as protobuf strings, which
+# MUST be valid UTF-8 — but `nix build -L` logs are arbitrary bytes (a fixup
+# phase can leak a raw gzip stream, compiler output can carry non-UTF-8 paths,
+# etc.). Merging that log into the captured streams crashed `pulumi up` with
+# "grpc: error while marshaling: string field contains invalid UTF-8".
+#
+# To stay marshal-safe, all verbose build output is routed to LOG_FILE (via a
+# dedicated file descriptor), never to the stdout/stderr Pulumi captures. The
+# only thing on stdout is the ASCII STORE_PATH_OUTPUT protocol line, and the
+# only thing on stderr is ASCII diagnostics — both always valid UTF-8.
 
 set -euo pipefail
 
@@ -32,26 +45,39 @@ if [ -n "${SUB_OUTPUT:-}" ]; then
   FULL_ATTR="${NIX_ATTR}^${SUB_OUTPUT}"
 fi
 
-# Set up logging
+# Set up logging. fd 3 is the verbose log sink: everything that can carry
+# arbitrary bytes (nix build/eval output) goes here and nowhere else.
 LOG_DIR="${COMMAND_LOG_STEM}"
 mkdir -p "${LOG_DIR}"
 LOG_FILE="${LOG_DIR}/$(date +%Y%m%d-%H%M%S)-nix-output-${SCRIPT_MODE}.log"
-exec > >(tee -a "${LOG_FILE}") 2>&1
+exec 3>>"${LOG_FILE}"
 
-echo "=== nix-output ${SCRIPT_MODE} ${FULL_ATTR} ==="
-echo "REPO_ROOT: ${REPO_ROOT}"
+# log <msg> — write a diagnostic line to the verbose log only.
+log() { printf '%s\n' "$*" >&3; }
+
+# On any failure, point at the full log on stderr. Keep this message
+# ASCII-only: the log may contain non-UTF-8 bytes and must never leak onto the
+# captured stderr stream.
+on_err() {
+  echo "nix-output ${SCRIPT_MODE} failed for ${FULL_ATTR}; see ${LOG_FILE}" >&2
+}
+trap on_err ERR
+
+log "=== nix-output ${SCRIPT_MODE} ${FULL_ATTR} ==="
+log "REPO_ROOT: ${REPO_ROOT}"
 
 STORE_PATH=""
 
 if [ "${SCRIPT_MODE}" = "build" ]; then
-  # Build the derivation
-  echo "--- nix build ---"
-  STORE_PATH=$(nix build "${REPO_ROOT}#${FULL_ATTR}" --no-link --print-out-paths -L)
+  # Build the derivation. --print-out-paths writes the store path to stdout
+  # (captured below); -L build logs go to stderr, redirected to the log fd.
+  log "--- nix build ---"
+  STORE_PATH=$(nix build "${REPO_ROOT}#${FULL_ATTR}" --no-link --print-out-paths -L 2>&3)
 else
-  # Resolve without building
-  echo "--- nix eval ---"
-  # nix eval --raw gives the store path for a derivation output
-  STORE_PATH=$(nix eval --raw "${REPO_ROOT}#${FULL_ATTR}")
+  # Resolve without building. nix eval --raw gives the store path on stdout;
+  # any warnings/errors go to stderr, redirected to the log fd.
+  log "--- nix eval ---"
+  STORE_PATH=$(nix eval --raw "${REPO_ROOT}#${FULL_ATTR}" 2>&3)
 fi
 
 if [ -z "${STORE_PATH}" ]; then
@@ -70,5 +96,9 @@ if [ -n "${SUB_PATH:-}" ]; then
   STORE_PATH=$(cd "$(dirname "${FULL_PATH}")" && pwd)/$(basename "${FULL_PATH}")
 fi
 
-echo "=== Resolved: ${STORE_PATH} ==="
+log "=== Resolved: ${STORE_PATH} ==="
+
+# The ONLY line on real stdout: the machine-readable store path. Store paths
+# are ASCII (/nix/store/<hash>-<name>), so the Command's captured stdout is
+# always valid UTF-8 and safe for Pulumi to marshal.
 echo "STORE_PATH_OUTPUT:${STORE_PATH}"

--- a/packages/sector7/tests/nix-output-resolve.test.ts
+++ b/packages/sector7/tests/nix-output-resolve.test.ts
@@ -1,0 +1,147 @@
+import { spawnSync } from "node:child_process";
+import {
+	chmodSync,
+	mkdtempSync,
+	readdirSync,
+	readFileSync,
+	writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, describe, expect, it } from "vitest";
+
+// Integration test for scripts/nix-output-resolve.sh. It runs the real script
+// with a stubbed `nix` on PATH that emits invalid-UTF-8 bytes on its build log
+// (stderr), reproducing sector7#318: a `nix build -L` fixup phase leaking a raw
+// gzip stream. The regression the script guards against is those bytes reaching
+// the stdout/stderr that Pulumi captures as Command resource properties, where
+// they crash marshaling ("string field contains invalid UTF-8").
+
+const SCRIPT_PATH = fileURLToPath(
+	new URL("../scripts/nix-output-resolve.sh", import.meta.url),
+);
+const STORE_PATH = "/nix/store/abc123-myapp-1.0.0";
+// 0x8b is an invalid UTF-8 start byte; 0xff/0xfe never appear in valid UTF-8.
+const INVALID_UTF8 = Buffer.from([0x1f, 0x8b, 0xff, 0xfe]);
+
+const tempDirs: string[] = [];
+
+function makeTempDir(prefix: string): string {
+	const dir = mkdtempSync(join(tmpdir(), prefix));
+	tempDirs.push(dir);
+	return dir;
+}
+
+/** Write an executable `nix` stub into a fresh dir and return that dir. */
+function stubNix(body: string): string {
+	const binDir = makeTempDir("nix-stub-");
+	const nixPath = join(binDir, "nix");
+	writeFileSync(nixPath, `#!/usr/bin/env bash\n${body}\n`);
+	chmodSync(nixPath, 0o755);
+	return binDir;
+}
+
+function runScript(binDir: string, logDir: string) {
+	return spawnSync("bash", [SCRIPT_PATH], {
+		env: {
+			...process.env,
+			PATH: `${binDir}:${process.env.PATH ?? ""}`,
+			NIX_ATTR: "packages.x86_64-linux.myapp",
+			REPO_ROOT: "/home/user/my-repo",
+			SCRIPT_MODE: "build",
+			COMMAND_LOG_STEM: logDir,
+		},
+		// Buffer encoding so we can inspect raw bytes, not a lossy decode.
+		encoding: "buffer",
+	});
+}
+
+function isValidUtf8(buf: Buffer): boolean {
+	try {
+		new TextDecoder("utf-8", { fatal: true }).decode(buf);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+function readOnlyLog(logDir: string): Buffer {
+	const entries = readdirSync(logDir).filter((n) => n.endsWith(".log"));
+	expect(entries).toHaveLength(1);
+	return readFileSync(join(logDir, entries[0]));
+}
+
+afterEach(() => {
+	for (const dir of tempDirs.splice(0)) {
+		// best-effort cleanup; leaked temp dirs are harmless
+		try {
+			spawnSync("rm", ["-rf", dir]);
+		} catch {
+			/* ignore */
+		}
+	}
+});
+
+describe("nix-output-resolve.sh UTF-8 safety", () => {
+	it("keeps invalid build-log bytes out of stdout/stderr on success", () => {
+		const binDir = stubNix(
+			[
+				// stdout: the store path (what --print-out-paths emits)
+				`printf '%s\\n' '${STORE_PATH}'`,
+				// stderr: the -L build log, with invalid UTF-8 bytes
+				"printf 'python-garden-dev> gzipping man pages\\n' >&2",
+				"printf 'python-garden-dev> \\037\\213\\377\\376 raw gzip leak\\n' >&2",
+			].join("\n"),
+		);
+		const logDir = makeTempDir("nix-logs-");
+
+		const result = runScript(binDir, logDir);
+		const stdout = result.stdout as Buffer;
+		const stderr = result.stderr as Buffer;
+
+		expect(result.status).toBe(0);
+
+		// stdout carries only the ASCII protocol line — valid UTF-8, no raw bytes.
+		expect(isValidUtf8(stdout)).toBe(true);
+		expect(stdout.toString("utf8")).toContain(
+			`STORE_PATH_OUTPUT:${STORE_PATH}`,
+		);
+		expect(stdout.includes(0x8b)).toBe(false);
+		expect(stdout.includes(0xff)).toBe(false);
+
+		// stderr must also be marshal-safe (it is a captured resource property too).
+		expect(isValidUtf8(stderr)).toBe(true);
+		expect(stderr.includes(0x8b)).toBe(false);
+
+		// The raw bytes are preserved in the log file, not discarded.
+		const log = readOnlyLog(logDir);
+		expect(log.includes(INVALID_UTF8[1])).toBe(true); // 0x8b survives in the log
+	});
+
+	it("keeps the failure diagnostic ASCII-only when the build log has invalid bytes", () => {
+		const binDir = stubNix(
+			[
+				"printf 'python-garden-dev> \\037\\213\\377\\376 raw gzip leak\\n' >&2",
+				"exit 1",
+			].join("\n"),
+		);
+		const logDir = makeTempDir("nix-logs-");
+
+		const result = runScript(binDir, logDir);
+		const stdout = result.stdout as Buffer;
+		const stderr = result.stderr as Buffer;
+
+		expect(result.status).not.toBe(0);
+
+		// No store path was resolved.
+		expect(stdout.toString("utf8")).not.toContain("STORE_PATH_OUTPUT:");
+
+		// The error surfaced on stderr is a plain ASCII pointer to the log,
+		// never the raw build-log bytes.
+		expect(isValidUtf8(stderr)).toBe(true);
+		expect(stderr.includes(0x8b)).toBe(false);
+		expect(stderr.includes(0xff)).toBe(false);
+		expect(stderr.toString("utf8")).toContain("see");
+	});
+});

--- a/packages/sector7/tests/nix-output-resolve.test.ts
+++ b/packages/sector7/tests/nix-output-resolve.test.ts
@@ -4,6 +4,7 @@ import {
 	mkdtempSync,
 	readdirSync,
 	readFileSync,
+	rmSync,
 	writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
@@ -76,7 +77,7 @@ afterEach(() => {
 	for (const dir of tempDirs.splice(0)) {
 		// best-effort cleanup; leaked temp dirs are harmless
 		try {
-			spawnSync("rm", ["-rf", dir]);
+			rmSync(dir, { recursive: true, force: true });
 		} catch {
 			/* ignore */
 		}
@@ -114,9 +115,10 @@ describe("nix-output-resolve.sh UTF-8 safety", () => {
 		expect(isValidUtf8(stderr)).toBe(true);
 		expect(stderr.includes(0x8b)).toBe(false);
 
-		// The raw bytes are preserved in the log file, not discarded.
+		// The raw bytes are preserved in the log file, not discarded — the whole
+		// invalid sequence survives verbatim, not just one byte of it.
 		const log = readOnlyLog(logDir);
-		expect(log.includes(INVALID_UTF8[1])).toBe(true); // 0x8b survives in the log
+		expect(log.includes(INVALID_UTF8)).toBe(true);
 	});
 
 	it("keeps the failure diagnostic ASCII-only when the build log has invalid bytes", () => {


### PR DESCRIPTION
## Summary

`NixOutput` (`mode: "build"`) can crash `pulumi up` with:

```
command:local:Command (…-resolve):
  error: grpc: error while marshaling: string field contains invalid UTF-8
```

**Root cause:** `scripts/nix-output-resolve.sh` did `exec > >(tee -a "$LOG_FILE") 2>&1`, merging the entire `nix build -L` log into the stdout captured by the `command.local.Command` resource. Pulumi marshals a Command's `stdout`/`stderr` as protobuf **string** properties, which must be valid UTF-8 — but nix build logs are arbitrary bytes (in the observed case a `python-garden-dev` fixup phase leaked a raw gzip stream; `0x8b` is an invalid UTF-8 start byte). The build itself succeeds; only marshaling the captured stdout fails, which fails the whole update. It's stochastic: any `up` that has to build an uncached dependency whose log contains binary bytes trips it, and re-running "fixes" it because the dep is then cached.

**Fix:** route all verbose build/eval output to `LOG_FILE` via a dedicated file descriptor (`fd 3`), and put **only** the ASCII `STORE_PATH_OUTPUT:` protocol line on stdout (plus ASCII-only diagnostics on stderr). Both captured streams are now always valid UTF-8, with no dependency on `iconv`/`tr` being present. The full raw log — including the binary bytes — is still preserved in the command-log file, and Pulumi state no longer stores multi-KB build logs.

This implements option 1 from the issue's suggested fixes.

## Test plan

- New `tests/nix-output-resolve.test.ts` runs the real script with a stubbed `nix` on `PATH` that emits invalid UTF-8 (`\x1f\x8b\xff\xfe`) on its build log, and asserts:
  - stdout is valid UTF-8, contains `STORE_PATH_OUTPUT:…`, and contains **no** `0x8b`/`0xff` bytes;
  - stderr is valid UTF-8 with no raw bytes (it's a captured property too);
  - the raw bytes **survive** in the log file (nothing is silently lost);
  - the failure path surfaces only an ASCII "see <log>" pointer, never the raw bytes.
- Verified the test **fails against the old** `exec > >(tee) 2>&1` behavior (0x8b leaks to stdout) and **passes** with the fix.
- `pnpm test`: my 2 new tests pass; all 295 other tests pass.
- `tsc --noEmit` clean; `biome check` clean.

## Risks

- **Behavior change:** build progress no longer streams live to the `pulumi up` console during `mode: "build"` — it goes to the command-log file only. On failure, stderr shows an ASCII pointer to that log. This is an intentional trade for marshal-safety; full logs remain on disk.
- **Pre-existing base failure (not from this PR):** `tests/renovate-pulumi.test.ts` fails on pristine `origin/main` ("expected exactly one Pulumi customManager, found 2"), so the `vitest` flake check will be red for reasons unrelated to this change. This PR touches only `nix-output-resolve.sh` + its new test. Tracking/fixing that is out of scope here.

Closes #318