### PR TITLE
release: bump sector7 to 0.18.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@jmmaloney4/sector7",
 	"private": true,
-	"version": "0.18.1",
+	"version": "0.18.2",
 	"description": "Sector7 monorepo",
 	"license": "MPL-2.0",
 	"workspaces": [

--- a/packages/sector7/package.json
+++ b/packages/sector7/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@jmmaloney4/sector7",
-	"version": "0.18.1",
+	"version": "0.18.2",
 	"description": "Reusable Pulumi components for infrastructure management",
 	"license": "MPL-2.0",
 	"publishConfig": {


### PR DESCRIPTION
## Summary

Cut **v0.18.2** to ship the nix-output UTF-8 marshaling fix (#321).

`nix-output-resolve.sh` now routes all verbose `nix build/eval` output to the log file via a dedicated fd and emits only the ASCII `STORE_PATH_OUTPUT:` line on stdout, so a `command.local.Command`'s captured stdout/stderr are always valid UTF-8 — no more `grpc: error while marshaling: string field contains invalid UTF-8` when a build log leaks binary bytes.

## Test plan

- `pnpm install --frozen-lockfile` passes on the bumped versions.
- `pnpm pack` builds cleanly; verified the packed `dist/scripts/nix-output-resolve.sh` contains the fix (`exec 3>>`, `on_err`, no `tee -a` merge).

## Follow-up

After merge: tag `v0.18.2` on main, attach the `jmmaloney4-sector7-0.18.2.tgz` tarball to the GH release, then bump garden's pin (separate PR).