### PR TITLE
release: bump sector7 to 0.19.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@jmmaloney4/sector7",
 	"private": true,
-	"version": "0.18.2",
+	"version": "0.19.0",
 	"description": "Sector7 monorepo",
 	"license": "MPL-2.0",
 	"workspaces": [

--- a/packages/sector7/package.json
+++ b/packages/sector7/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@jmmaloney4/sector7",
-	"version": "0.18.2",
+	"version": "0.19.0",
 	"description": "Reusable Pulumi components for infrastructure management",
 	"license": "MPL-2.0",
 	"publishConfig": {


### PR DESCRIPTION
## Summary

Version bump 0.18.2 → 0.19.0. Ships the WorkerSite Workers Static Assets serving mode (#323, ADR-034): `staticAssets` arg with provider-native manifest uploads, replacing per-file `R2Object` resources for static sites.

## Test plan

Version-only bump (2 lines). #323 validated at merge: tsc clean, 303/303 vitest, flake check failing only on pre-existing renovate treefmt drift identical to main.

After merge: tag `v0.19.0` on the merge commit → the pnpm dogfood workflow publishes the release tarball. First consumer: garden theoreticaledge migration (dev stack).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FmExDa72NCSsWxd4Mm9QYn