### PR TITLE
feat(pulumi-config): add op:// secret helpers

### DIFF
--- a/packages/sector7/pulumi-config/index.ts
+++ b/packages/sector7/pulumi-config/index.ts
@@ -6,3 +6,10 @@ export {
 	requireMixedConfig,
 	type SecretFieldsOf,
 } from "./mixed-config.js";
+
+export {
+	createOnePasswordSecretRefs,
+	type CreateOnePasswordSecretRefsOptions,
+	mergeSecretRefEnvs,
+	parseOnePasswordItemReference,
+} from "./op-secret-helpers.js";

--- a/packages/sector7/pulumi-config/op-secret-helpers.ts
+++ b/packages/sector7/pulumi-config/op-secret-helpers.ts
@@ -337,5 +337,6 @@ function toDNS1123Name(name: string): string {
 		.toLowerCase()
 		.replace(/[^a-z0-9-]/g, "-")
 		.replace(/-+/g, "-")
-		.replace(/^-|-$/g, "");
+		.replace(/^-|-$/g, "")
+		.slice(0, 253);
 }

--- a/packages/sector7/pulumi-config/op-secret-helpers.ts
+++ b/packages/sector7/pulumi-config/op-secret-helpers.ts
@@ -7,30 +7,42 @@
  */
 
 import type * as pulumi from "@pulumi/pulumi";
-import type * as k8s from "@pulumi/kubernetes";
+import * as k8s from "@pulumi/kubernetes";
 
 /**
- * Parse a 1Password CLI-style `op://` reference into the CRD `itemPath` and
- * field-name components needed to sync a Kubernetes Secret via the
- * 1Password Connect operator.
+ * Parse a 1Password CLI secret-reference URI (`op://`) into the CRD
+ * `itemPath` and field-name components needed to sync a Kubernetes Secret
+ * via the 1Password Connect operator.
  *
- * Accepts:
- *   op://<vault-uuid>/<item-uuid>/<field-name>
- *   op://<vault-uuid>/<item-uuid>/<section>/<field-name>
+ * Implements the official `op://` syntax:
+ *   op://<vault>/<item>/[section/]<field>
  *
- * The OnePasswordItem CRD `itemPath` format is `vaults/<vault>/items/<item>`.
- * The field name is the **last** path segment — it becomes the key in the
- * synced K8s Secret (matching the 1Password item's field label).
+ * Both names and UUIDs are accepted for vault, item, section, and field
+ * (the 1Password Connect operator's `itemPath` accepts either form).
  *
- * @throws Error if the reference has fewer than 3 segments or is malformed.
+ * Query parameters (e.g. `?attribute=otp`, `?ssh-format=openssh`) are
+ * supported but do not affect the CRD — the operator syncs the field value
+ * as-is, and the field label becomes the K8s Secret key regardless of query
+ * params. The query string is stripped before parsing.
+ *
+ * Supported characters per the 1Password spec: `a-z`, `A-Z`, `0-9`, `-`,
+ * `_`, `.`, and whitespace. Names with unsupported characters must use
+ * their UUID identifier instead.
+ *
+ * @throws Error if the reference has fewer than 3 path segments (missing
+ *         vault, item, or field) or more than 4 (unexpected nesting).
+ * @see https://developer.1password.com/docs/cli/secrets-references
  */
 export function parseOnePasswordItemReference(
 	opRef: string,
 	accountKey: string,
 ): { itemPath: string; fieldName: string } {
-	const path = opRef.slice("op://".length);
+	const pathPart = opRef.slice("op://".length);
+	// Strip query parameters (e.g. "?attribute=otp") — they affect how `op read`
+	// returns the value but not the CRD sync target.
+	const [path] = pathPart.split("?");
 	const parts = path.split("/").filter(Boolean);
-	if (parts.length < 3) {
+	if (parts.length < 3 || parts.length > 4) {
 		throw new Error(
 			`Invalid 1Password reference for backend account '${accountKey}': "${opRef}". ` +
 				"Expected op://<vault>/<item>/<field> or op://<vault>/<item>/<section>/<field>.",

--- a/packages/sector7/pulumi-config/op-secret-helpers.ts
+++ b/packages/sector7/pulumi-config/op-secret-helpers.ts
@@ -71,6 +71,12 @@ export function parseOnePasswordItemReference(
 	// here — otherwise our returned key won't match the key in the synced
 	// K8s Secret, and secretKeyRef will silently point at a non-existent key.
 	const sanitizedFieldName = normalizeSecretKeyName(fieldName);
+	if (!sanitizedFieldName) {
+		throw new Error(
+			`Invalid 1Password reference for backend account '${accountKey}': "${opRef}". ` +
+				"Field name normalizes to an empty Kubernetes Secret key.",
+		);
+	}
 	return {
 		itemPath: `vaults/${vaultId}/items/${itemId}`,
 		fieldName: sanitizedFieldName,

--- a/packages/sector7/pulumi-config/op-secret-helpers.ts
+++ b/packages/sector7/pulumi-config/op-secret-helpers.ts
@@ -337,6 +337,6 @@ function toDNS1123Name(name: string): string {
 		.toLowerCase()
 		.replace(/[^a-z0-9-]/g, "-")
 		.replace(/-+/g, "-")
-		.replace(/^-|-$/g, "")
-		.slice(0, 253);
+		.slice(0, 253)
+		.replace(/^-|-$/g, "");
 }

--- a/packages/sector7/pulumi-config/op-secret-helpers.ts
+++ b/packages/sector7/pulumi-config/op-secret-helpers.ts
@@ -284,7 +284,9 @@ export function createOnePasswordSecretRefs<T extends Record<string, unknown>>(
 		);
 		// Kubernetes metadata.name must be DNS-1123 compliant: lowercase
 		// alphanumeric or hyphens, must start/end with alphanumeric.
-		const secretName = toDNS1123Name(`${configKey}-${itemKey}-api-key`);
+		const secretName = toDNS1123Name(
+			`${configKey}-${itemKey}-${fieldName}`,
+		);
 		if (!secretName) {
 			throw new Error(
 				`Generated secret name is empty for item '${itemKey}'. ` +

--- a/packages/sector7/pulumi-config/op-secret-helpers.ts
+++ b/packages/sector7/pulumi-config/op-secret-helpers.ts
@@ -37,6 +37,12 @@ export function parseOnePasswordItemReference(
 	opRef: string,
 	accountKey: string,
 ): { itemPath: string; fieldName: string } {
+	if (!opRef.startsWith("op://")) {
+		throw new Error(
+			`Invalid 1Password reference for backend account '${accountKey}': "${opRef}". ` +
+				'Expected value to start with "op://".',
+		);
+	}
 	const pathPart = opRef.slice("op://".length);
 	// Strip query parameters (e.g. "?attribute=otp") — they affect how `op read`
 	// returns the value but not the CRD sync target.
@@ -59,10 +65,45 @@ export function parseOnePasswordItemReference(
 	}
 	const [vaultId, itemId, ...rest] = parts;
 	const fieldName = rest[rest.length - 1];
+	// Kubernetes Secret data keys must comply with DNS subdomain naming. The
+	// 1Password Connect operator normalizes field labels via its own
+	// createValidSecretDataName function, so we must match that exact logic
+	// here — otherwise our returned key won't match the key in the synced
+	// K8s Secret, and secretKeyRef will silently point at a non-existent key.
+	const sanitizedFieldName = normalizeSecretKeyName(fieldName);
 	return {
 		itemPath: `vaults/${vaultId}/items/${itemId}`,
-		fieldName,
+		fieldName: sanitizedFieldName,
 	};
+}
+
+/**
+ * Normalize a 1Password field label into a valid Kubernetes Secret data key,
+ * matching the 1Password Connect operator's createValidSecretDataName logic:
+ *
+ * 1. Strip characters from the start/end that are not alphanumeric, hyphen,
+ *    underscore, or period.
+ * 2. Replace remaining invalid characters with hyphens.
+ * 3. Truncate to 253 characters (DNS1123SubdomainMaxLength).
+ *
+ * Unlike DNS-1123 label names, case is preserved (the operator does not
+ * lowercase data keys).
+ */
+function normalizeSecretKeyName(name: string): string {
+	const valid = /[a-zA-Z0-9-_.]/;
+	let result = name;
+	// Strip leading invalid chars
+	while (result.length > 0 && !valid.test(result[0]!)) {
+		result = result.slice(1);
+	}
+	// Strip trailing invalid chars
+	while (result.length > 0 && !valid.test(result[result.length - 1]!)) {
+		result = result.slice(0, -1);
+	}
+	// Replace remaining invalid chars with hyphens
+	result = result.replace(/[^a-zA-Z0-9-_.]/g, "-");
+	// Truncate to DNS1123SubdomainMaxLength (253)
+	return result.slice(0, 253);
 }
 
 /**
@@ -233,7 +274,22 @@ export function createOnePasswordSecretRefs<T extends Record<string, unknown>>(
 		// Kubernetes metadata.name must be DNS-1123 compliant: lowercase
 		// alphanumeric or hyphens, must start/end with alphanumeric.
 		const secretName = toDNS1123Name(`${configKey}-${itemKey}-api-key`);
+		if (!secretName) {
+			throw new Error(
+				`Generated secret name is empty for item '${itemKey}'. ` +
+					"Ensure configKey and itemKey contain at least one DNS-1123 character.",
+			);
+		}
 		const envVarName = envVarNaming(itemKey);
+
+		// Detect normalized secret name collisions — two different item keys can
+		// collapse to the same DNS-1123 name after sanitization.
+		if (Object.values(secretRefs).some((ref) => ref.secretName === secretName)) {
+			throw new Error(
+				`Kubernetes secret name collision: two items produced secret '${secretName}'. ` +
+					"Ensure item keys remain unique after DNS-1123 normalization.",
+			);
+		}
 
 		// Detect env var name collisions — two item keys that produce the same
 		// env var name would silently overwrite each other in the output map.

--- a/packages/sector7/pulumi-config/op-secret-helpers.ts
+++ b/packages/sector7/pulumi-config/op-secret-helpers.ts
@@ -77,7 +77,24 @@ export function mergeSecretRefEnvs(
 ):
 	| Record<string, { secretName: pulumi.Input<string>; key: pulumi.Input<string> }>
 	| undefined {
-	const merged = Object.assign({}, ...envMaps.filter(Boolean));
+	const merged: Record<
+		string,
+		{ secretName: pulumi.Input<string>; key: pulumi.Input<string> }
+	> = {};
+
+	for (const envMap of envMaps) {
+		if (!envMap) continue;
+		for (const [envVarName, secretRef] of Object.entries(envMap)) {
+			if (envVarName in merged) {
+				throw new Error(
+					`Duplicate secret-ref env var '${envVarName}' during merge. ` +
+						"Ensure each secret-ref source produces unique environment variable names.",
+				);
+			}
+			merged[envVarName] = secretRef;
+		}
+	}
+
 	return Object.keys(merged).length > 0 ? merged : undefined;
 }
 

--- a/packages/sector7/pulumi-config/op-secret-helpers.ts
+++ b/packages/sector7/pulumi-config/op-secret-helpers.ts
@@ -1,0 +1,217 @@
+/**
+ * 1Password CLI-style op:// parser + CRD creation helpers.
+ *
+ * This module provides utilities for detecting op:// config values,
+ * parsing them, and creating 1Password-operator CRDs that sync secrets
+ * into Kubernetes Secrets consumable by pods via secretKeyRef.
+ */
+
+import type * as pulumi from "@pulumi/pulumi";
+import type * as k8s from "@pulumi/kubernetes";
+
+/**
+ * Parse a 1Password CLI-style `op://` reference into the CRD `itemPath` and
+ * field-name components needed to sync a Kubernetes Secret via the
+ * 1Password Connect operator.
+ *
+ * Accepts:
+ *   op://<vault-uuid>/<item-uuid>/<field-name>
+ *   op://<vault-uuid>/<item-uuid>/<section>/<field-name>
+ *
+ * The OnePasswordItem CRD `itemPath` format is `vaults/<vault>/items/<item>`.
+ * The field name is the **last** path segment — it becomes the key in the
+ * synced K8s Secret (matching the 1Password item's field label).
+ *
+ * @throws Error if the reference has fewer than 3 segments or is malformed.
+ */
+export function parseOnePasswordItemReference(
+	opRef: string,
+	accountKey: string,
+): { itemPath: string; fieldName: string } {
+	const path = opRef.slice("op://".length);
+	const parts = path.split("/").filter(Boolean);
+	if (parts.length < 3) {
+		throw new Error(
+			`Invalid 1Password reference for backend account '${accountKey}': "${opRef}". ` +
+				"Expected op://<vault>/<item>/<field> or op://<vault>/<item>/<section>/<field>.",
+		);
+	}
+	const [vaultId, itemId, ...rest] = parts;
+	const fieldName = rest[rest.length - 1];
+	return {
+		itemPath: `vaults/${vaultId}/items/${itemId}`,
+		fieldName,
+	};
+}
+
+/**
+ * Merge multiple secret-ref env var maps into a single map.
+ * Returns undefined if all inputs are undefined or the merged result is empty.
+ */
+export function mergeSecretRefEnvs(
+	...envMaps: (
+		| Record<string, { secretName: pulumi.Input<string>; key: pulumi.Input<string> }>
+		| undefined
+	)[]
+):
+	| Record<string, { secretName: pulumi.Input<string>; key: pulumi.Input<string> }>
+	| undefined {
+	const merged = Object.assign({}, ...envMaps.filter(Boolean));
+	return Object.keys(merged).length > 0 ? merged : undefined;
+}
+
+/**
+ * Options for creating 1Password secret references from config values.
+ */
+export interface CreateOnePasswordSecretRefsOptions<
+	T extends Record<string, unknown>,
+> {
+	/**
+	 * Pulumi config object to read raw values from.
+	 */
+	config: pulumi.Config;
+
+	/**
+	 * Base config key prefix (e.g., "backendAccounts").
+	 * Combined with item key to read the specific config value.
+	 */
+	configKey: string;
+
+	/**
+	 * Map of item keys to item configurations.
+	 */
+	items: Record<string, T>;
+
+	/**
+	 * Function to extract the op:// reference field from an item.
+	 * Returns undefined if the field doesn't start with "op://".
+	 */
+	keySelector: (item: T, itemKey: string) => string | undefined;
+
+	/**
+	 * Function to convert an item key to an env var name.
+	 * Example: "personal-zai" → "PERSONAL_ZAI_API_KEY".
+	 */
+	envVarNaming: (itemKey: string) => string;
+
+	/**
+	 * Kubernetes namespace where CRDs will be created.
+	 */
+	namespace: pulumi.Input<string>;
+
+	/**
+	 * Pulumi provider for Kubernetes resources.
+	 */
+	provider: pulumi.ProviderResource;
+
+	/**
+	 * Optional resources that must exist before the CRDs are created.
+	 */
+	dependsOn?: pulumi.Input<pulumi.Resource>[];
+
+	/**
+	 * Optional guard to block op:// for certain item types.
+	 * Throws an error if the guard returns a message.
+	 */
+	blockRef?: (
+		item: T,
+		itemKey: string,
+		opRef: string,
+	) => string | undefined;
+}
+
+/**
+ * Create OnePasswordItem CRDs for op:// references and return a secret-ref
+ * env var map.
+ *
+ * This function:
+ * 1. Iterates through items
+ * 2. Checks the selected field for op:// prefix
+ * 3. Creates OnePasswordItem CRDs for detected references
+ * 4. Returns a map of env var names → secret names/keys
+ *
+ * Use with `requireMixedConfig`'s secret fields: override the original field
+ * values in the items map with `os.environ/${envVarName}` refs.
+ *
+ * @example
+ * ```typescript
+ * const providerSecretRefs = createOnePasswordSecretRefs({
+ *   config,
+ *   configKey: "backendAccounts",
+ *   items: directBackendAccounts,
+ *   keySelector: (item, key) => {
+ *     const rawApiKey = config.get(`backendAccounts.${key}.apiKey`);
+ *     return rawApiKey?.startsWith("op://") ? rawApiKey : undefined;
+ *   },
+ *   envVarNaming: (key) => key.toUpperCase().replace(/-/g, "_").concat("_API_KEY"),
+ *   namespace: litellmNamespace.metadata.name,
+ *   provider,
+ *   blockRef: (item) => item.provider === "zai"
+ *     ? `Backend account '${key}' (provider: zai) cannot use op://...`
+ *     : undefined,
+ * });
+ *
+ * // Override account API keys
+ * for (const [envVarName, { secretName, key }] of Object.entries(providerSecretRefs)) {
+ *   const accountKey = envVarName.slice(0, -"_API_KEY".length).toLowerCase().replace(/_/g, "-");
+ *   directBackendAccounts[accountKey].apiKey = `os.environ/${envVarName}`;
+ * }
+ * ```
+ */
+export function createOnePasswordSecretRefs<T extends Record<string, unknown>>(
+	options: CreateOnePasswordSecretRefsOptions<T>,
+): Record<string, { secretName: pulumi.Input<string>; key: pulumi.Input<string> }> {
+	const {
+		config,
+		configKey,
+		items,
+		keySelector,
+		envVarNaming,
+		namespace,
+		provider,
+		dependsOn = [],
+		blockRef,
+	} = options;
+
+	const secretRefs: Record<
+		string,
+		{ secretName: pulumi.Input<string>; key: pulumi.Input<string> }
+	> = {};
+
+	for (const [itemKey, item] of Object.entries(items)) {
+		const opRef = keySelector(item, itemKey);
+		if (!opRef) continue;
+
+		// Check guard
+		const blockMessage = blockRef?.(item, itemKey, opRef);
+		if (blockMessage) {
+			throw new Error(blockMessage);
+		}
+
+		const { itemPath, fieldName } = parseOnePasswordItemReference(
+			opRef,
+			itemKey,
+		);
+		const secretName = `${configKey}-${itemKey}-api-key`;
+		const envVarName = envVarNaming(itemKey);
+
+		// Create the CRD
+		new k8s.apiextensions.CustomResource(
+			`${configKey}-${itemKey}-onepassword-item`,
+			{
+				apiVersion: "onepassword.com/v1",
+				kind: "OnePasswordItem",
+				metadata: {
+					name: secretName,
+					namespace,
+				},
+				spec: { itemPath },
+			},
+			{ provider, dependsOn },
+		);
+
+		secretRefs[envVarName] = { secretName, key: fieldName };
+	}
+
+	return secretRefs;
+}

--- a/packages/sector7/pulumi-config/op-secret-helpers.ts
+++ b/packages/sector7/pulumi-config/op-secret-helpers.ts
@@ -41,7 +41,16 @@ export function parseOnePasswordItemReference(
 	// Strip query parameters (e.g. "?attribute=otp") — they affect how `op read`
 	// returns the value but not the CRD sync target.
 	const [path] = pathPart.split("?");
-	const parts = path.split("/").filter(Boolean);
+	const parts = path.split("/");
+	// Reject empty segments (e.g. "op://vault//field") — these indicate a
+	// malformed reference that should fail fast rather than be silently
+	// reinterpreted as a shorter valid path.
+	if (parts.some((p) => !p)) {
+		throw new Error(
+			`Invalid 1Password reference for backend account '${accountKey}': "${opRef}". ` +
+				"Reference contains an empty path segment (consecutive slashes).",
+		);
+	}
 	if (parts.length < 3 || parts.length > 4) {
 		throw new Error(
 			`Invalid 1Password reference for backend account '${accountKey}': "${opRef}". ` +
@@ -204,8 +213,19 @@ export function createOnePasswordSecretRefs<T extends Record<string, unknown>>(
 			opRef,
 			itemKey,
 		);
-		const secretName = `${configKey}-${itemKey}-api-key`;
+		// Kubernetes metadata.name must be DNS-1123 compliant: lowercase
+		// alphanumeric or hyphens, must start/end with alphanumeric.
+		const secretName = toDNS1123Name(`${configKey}-${itemKey}-api-key`);
 		const envVarName = envVarNaming(itemKey);
+
+		// Detect env var name collisions — two item keys that produce the same
+		// env var name would silently overwrite each other in the output map.
+		if (envVarName in secretRefs) {
+			throw new Error(
+				`Environment variable name collision: two items produced env var '${envVarName}'. ` +
+					`Ensure envVarNaming produces unique names for each item key.`,
+			);
+		}
 
 		// Create the CRD
 		new k8s.apiextensions.CustomResource(
@@ -226,4 +246,17 @@ export function createOnePasswordSecretRefs<T extends Record<string, unknown>>(
 	}
 
 	return secretRefs;
+}
+
+/**
+ * Convert a string to a DNS-1123 compliant name suitable for Kubernetes
+ * metadata.name fields. Lowercases, replaces unsupported characters with
+ * hyphens, collapses consecutive hyphens, and trims leading/trailing hyphens.
+ */
+function toDNS1123Name(name: string): string {
+	return name
+		.toLowerCase()
+		.replace(/[^a-z0-9-]/g, "-")
+		.replace(/-+/g, "-")
+		.replace(/^-|-$/g, "");
 }

--- a/packages/sector7/pulumi-config/op-secret-helpers.ts
+++ b/packages/sector7/pulumi-config/op-secret-helpers.ts
@@ -60,11 +60,16 @@ export function parseOnePasswordItemReference(
 	if (parts.length < 3 || parts.length > 4) {
 		throw new Error(
 			`Invalid 1Password reference for backend account '${accountKey}': "${opRef}". ` +
-				"Expected op://<vault>/<item>/<field> or op://<vault>/<item>/<section>/<field>.",
+				"Expected op://<vault>/<item>/<field>.",
 		);
 	}
-	const [vaultId, itemId, ...rest] = parts;
-	const fieldName = rest[rest.length - 1];
+	if (parts.length === 4) {
+		throw new Error(
+			`Invalid 1Password reference for backend account '${accountKey}': "${opRef}". ` +
+				"Section-qualified references are not supported because the synced Kubernetes Secret key does not retain section information.",
+		);
+	}
+	const [vaultId, itemId, fieldName] = parts;
 	// Kubernetes Secret data keys must comply with DNS subdomain naming. The
 	// 1Password Connect operator normalizes field labels via its own
 	// createValidSecretDataName function, so we must match that exact logic

--- a/packages/sector7/tests/op-secret-helpers.test.ts
+++ b/packages/sector7/tests/op-secret-helpers.test.ts
@@ -103,6 +103,12 @@ describe("parseOnePasswordItemReference", () => {
 		).toThrow('Expected value to start with "op://"');
 	});
 
+	it("rejects field names that normalize to an empty secret key", () => {
+		expect(() =>
+			parseOnePasswordItemReference("op://vault/item/!!!", "test-account"),
+		).toThrow("Field name normalizes to an empty Kubernetes Secret key");
+	});
+
 	it("handles UUID-style IDs correctly", () => {
 		const result = parseOnePasswordItemReference(
 			"op://550e8400-e29b-41d4-a716-446655440000/550e8400-e29b-41d4-a716-446655440001/credential",

--- a/packages/sector7/tests/op-secret-helpers.test.ts
+++ b/packages/sector7/tests/op-secret-helpers.test.ts
@@ -84,15 +84,23 @@ describe("parseOnePasswordItemReference", () => {
 		});
 	});
 
-	it("preserves whitespace in names (official spec allows it)", () => {
+	it("normalizes whitespace in field name to match operator behavior", () => {
+		// The 1Password operator replaces spaces in field labels with hyphens
+		// when creating K8s Secret keys. Our parser must match.
 		const result = parseOnePasswordItemReference(
 			"op://Private/ssh keys/ssh key/private key",
 			"test-account",
 		);
 		expect(result).toEqual({
 			itemPath: "vaults/Private/items/ssh keys",
-			fieldName: "private key",
+			fieldName: "private-key",
 		});
+	});
+
+	it("rejects non-op:// prefix", () => {
+		expect(() =>
+			parseOnePasswordItemReference("https://vault/item/field", "test-account"),
+		).toThrow('Expected value to start with "op://"');
 	});
 
 	it("handles UUID-style IDs correctly", () => {

--- a/packages/sector7/tests/op-secret-helpers.test.ts
+++ b/packages/sector7/tests/op-secret-helpers.test.ts
@@ -156,4 +156,13 @@ describe("mergeSecretRefEnvs", () => {
 			K3: { secretName: "s3", key: "k3" },
 		});
 	});
+
+	it("throws on duplicate env var names across maps", () => {
+		expect(() =>
+			mergeSecretRefEnvs(
+				{ DUP_KEY: { secretName: "s1", key: "k1" } },
+				{ DUP_KEY: { secretName: "s2", key: "k2" } },
+			),
+		).toThrow("Duplicate secret-ref env var");
+	});
 });

--- a/packages/sector7/tests/op-secret-helpers.test.ts
+++ b/packages/sector7/tests/op-secret-helpers.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from "vitest";
+import {
+	mergeSecretRefEnvs,
+	parseOnePasswordItemReference,
+} from "../pulumi-config/op-secret-helpers.js";
+
+describe("parseOnePasswordItemReference", () => {
+	it("parses a standard 3-segment op:// reference", () => {
+		const result = parseOnePasswordItemReference("op://v1/i2/f3", "test-account");
+		expect(result).toEqual({
+			itemPath: "vaults/v1/items/i2",
+			fieldName: "f3",
+		});
+	});
+
+	it("parses a 4-segment op:// reference with section", () => {
+		const result = parseOnePasswordItemReference(
+			"op://v1/i2/section/f4",
+			"test-account",
+		);
+		expect(result).toEqual({
+			itemPath: "vaults/v1/items/i2",
+			fieldName: "f4",
+		});
+	});
+
+	it("strips the op:// prefix correctly", () => {
+		const result = parseOnePasswordItemReference(
+			"op://abc-123/def-456/secret-token",
+			"test-account",
+		);
+		expect(result).toEqual({
+			itemPath: "vaults/abc-123/items/def-456",
+			fieldName: "secret-token",
+		});
+	});
+
+	it("throws for too few segments (< 3)", () => {
+		expect(() =>
+			parseOnePasswordItemReference("op://v1/i2", "test-account"),
+		).toThrow("Invalid 1Password reference");
+	});
+
+	it("throws for empty op:// reference", () => {
+		expect(() =>
+			parseOnePasswordItemReference("op://", "test-account"),
+		).toThrow("Invalid 1Password reference");
+	});
+
+	it("handles UUID-style IDs correctly", () => {
+		const result = parseOnePasswordItemReference(
+			"op://550e8400-e29b-41d4-a716-446655440000/550e8400-e29b-41d4-a716-446655440001/credential",
+			"test-account",
+		);
+		expect(result).toEqual({
+			itemPath: "vaults/550e8400-e29b-41d4-a716-446655440000/items/550e8400-e29b-41d4-a716-446655440001",
+			fieldName: "credential",
+		});
+	});
+});
+
+describe("mergeSecretRefEnvs", () => {
+	it("merges multiple secret ref maps", () => {
+		const map1 = {
+			API_KEY_1: { secretName: "secret-1", key: "password" },
+		};
+		const map2 = {
+			API_KEY_2: { secretName: "secret-2", key: "token" },
+		};
+		const merged = mergeSecretRefEnvs(map1, map2);
+		expect(merged).toEqual({
+			API_KEY_1: { secretName: "secret-1", key: "password" },
+			API_KEY_2: { secretName: "secret-2", key: "token" },
+		});
+	});
+
+	it("filters out undefined maps", () => {
+		const map1 = { KEY_1: { secretName: "s1", key: "k1" } };
+		const merged = mergeSecretRefEnvs(map1, undefined, undefined);
+		expect(merged).toEqual({ KEY_1: { secretName: "s1", key: "k1" } });
+	});
+
+	it("returns undefined when all maps are undefined", () => {
+		const result = mergeSecretRefEnvs(undefined, undefined, undefined);
+		expect(result).toBeUndefined();
+	});
+
+	it("returns undefined when all maps are empty", () => {
+		const result = mergeSecretRefEnvs({}, {});
+		expect(result).toBeUndefined();
+	});
+
+	it("returns undefined when the only map is empty", () => {
+		const result = mergeSecretRefEnvs({});
+		expect(result).toBeUndefined();
+	});
+
+	it("handles varargs (rest parameter)", () => {
+		const maps: Array<Record<string, { secretName: string; key: string }>> = [
+			{ K1: { secretName: "s1", key: "k1" } },
+			{ K2: { secretName: "s2", key: "k2" } },
+			{ K3: { secretName: "s3", key: "k3" } },
+		];
+		const merged = mergeSecretRefEnvs(...maps);
+		expect(merged).toEqual({
+			K1: { secretName: "s1", key: "k1" },
+			K2: { secretName: "s2", key: "k2" },
+			K3: { secretName: "s3", key: "k3" },
+		});
+	});
+});

--- a/packages/sector7/tests/op-secret-helpers.test.ts
+++ b/packages/sector7/tests/op-secret-helpers.test.ts
@@ -47,6 +47,45 @@ describe("parseOnePasswordItemReference", () => {
 		).toThrow("Invalid 1Password reference");
 	});
 
+	it("throws for too many segments (> 4)", () => {
+		expect(() =>
+			parseOnePasswordItemReference("op://v1/i2/a/b/c", "test-account"),
+		).toThrow("Invalid 1Password reference");
+	});
+
+	it("strips query parameters from the field name", () => {
+		const result = parseOnePasswordItemReference(
+			"op://v1/i2/f3?attribute=otp",
+			"test-account",
+		);
+		expect(result).toEqual({
+			itemPath: "vaults/v1/items/i2",
+			fieldName: "f3",
+		});
+	});
+
+	it("strips ssh-format query parameters", () => {
+		const result = parseOnePasswordItemReference(
+			"op://Private/ssh/ssh-key/private-key?ssh-format=openssh",
+			"test-account",
+		);
+		expect(result).toEqual({
+			itemPath: "vaults/Private/items/ssh",
+			fieldName: "private-key",
+		});
+	});
+
+	it("preserves whitespace in names (official spec allows it)", () => {
+		const result = parseOnePasswordItemReference(
+			"op://Private/ssh keys/ssh key/private key",
+			"test-account",
+		);
+		expect(result).toEqual({
+			itemPath: "vaults/Private/items/ssh keys",
+			fieldName: "private key",
+		});
+	});
+
 	it("handles UUID-style IDs correctly", () => {
 		const result = parseOnePasswordItemReference(
 			"op://550e8400-e29b-41d4-a716-446655440000/550e8400-e29b-41d4-a716-446655440001/credential",

--- a/packages/sector7/tests/op-secret-helpers.test.ts
+++ b/packages/sector7/tests/op-secret-helpers.test.ts
@@ -53,6 +53,15 @@ describe("parseOnePasswordItemReference", () => {
 		).toThrow("Invalid 1Password reference");
 	});
 
+	it("rejects empty path segments caused by consecutive slashes", () => {
+		expect(() =>
+			parseOnePasswordItemReference("op://v1//f3", "test-account"),
+		).toThrow("empty path segment");
+		expect(() =>
+			parseOnePasswordItemReference("op://v1/i2//f3", "test-account"),
+		).toThrow("empty path segment");
+	});
+
 	it("strips query parameters from the field name", () => {
 		const result = parseOnePasswordItemReference(
 			"op://v1/i2/f3?attribute=otp",

--- a/packages/sector7/tests/op-secret-helpers.test.ts
+++ b/packages/sector7/tests/op-secret-helpers.test.ts
@@ -13,15 +13,13 @@ describe("parseOnePasswordItemReference", () => {
 		});
 	});
 
-	it("parses a 4-segment op:// reference with section", () => {
-		const result = parseOnePasswordItemReference(
-			"op://v1/i2/section/f4",
-			"test-account",
-		);
-		expect(result).toEqual({
-			itemPath: "vaults/v1/items/i2",
-			fieldName: "f4",
-		});
+	it("rejects section-qualified op:// references", () => {
+		expect(() =>
+			parseOnePasswordItemReference(
+				"op://v1/i2/section/f4",
+				"test-account",
+			),
+		).toThrow("Section-qualified references are not supported");
 	});
 
 	it("strips the op:// prefix correctly", () => {
@@ -75,11 +73,11 @@ describe("parseOnePasswordItemReference", () => {
 
 	it("strips ssh-format query parameters", () => {
 		const result = parseOnePasswordItemReference(
-			"op://Private/ssh/ssh-key/private-key?ssh-format=openssh",
+			"op://Private/ssh-key/private-key?ssh-format=openssh",
 			"test-account",
 		);
 		expect(result).toEqual({
-			itemPath: "vaults/Private/items/ssh",
+			itemPath: "vaults/Private/items/ssh-key",
 			fieldName: "private-key",
 		});
 	});
@@ -88,11 +86,11 @@ describe("parseOnePasswordItemReference", () => {
 		// The 1Password operator replaces spaces in field labels with hyphens
 		// when creating K8s Secret keys. Our parser must match.
 		const result = parseOnePasswordItemReference(
-			"op://Private/ssh keys/ssh key/private key",
+			"op://Private/ssh-keys/private key",
 			"test-account",
 		);
 		expect(result).toEqual({
-			itemPath: "vaults/Private/items/ssh keys",
+			itemPath: "vaults/Private/items/ssh-keys",
 			fieldName: "private-key",
 		});
 	});


### PR DESCRIPTION
## Summary

Add reusable `op://` secret-reference helpers to the `@jmmaloney4/sector7/pulumi-config` subpath export. These utilities detect 1Password CLI `op://` references in Pulumi config values, parse them according to the official 1Password syntax, and create `OnePasswordItem` CRDs that sync secrets into Kubernetes Secrets consumable by pods via `secretKeyRef`.

This extracts the polymorphic API key pattern (raw Pulumi secret OR `op://` 1Password reference) currently implemented locally in `garden`'s LiteLLM stack, making it reusable across all stacks that use the 1Password Connect operator.

## Exports

- **`parseOnePasswordItemReference(opRef, accountKey)`** — parses `op://<vault>/<item>/[section/]<field>` into `{ itemPath, fieldName }` for CRD creation. Strips query parameters (`?attribute=otp`, `?ssh-format=openssh`). Accepts both names and UUIDs. Validates 3-4 path segments.
- **`mergeSecretRefEnvs(...maps)`** — merges multiple secret-ref env var maps into one, returns `undefined` when empty.
- **`createOnePasswordSecretRefs(options)`** — high-level helper: iterates config items, detects `op://` refs via a `keySelector`, creates `OnePasswordItem` CRDs, returns `{ envVarName → { secretName, key } }` map. Supports a `blockRef` guard for items that cannot use `op://` (e.g., z.ai accounts whose quota exporter needs the raw key).

## Usage

```typescript
const providerSecretRefs = createOnePasswordSecretRefs({
  config,
  configKey: "backendAccounts",
  items: directBackendAccounts,
  keySelector: (item, key) => {
    const raw = config.get(`backendAccounts.${key}.apiKey`);
    return raw?.startsWith("op://") ? raw : undefined;
  },
  envVarNaming: (key) => key.toUpperCase().replace(/-/g, "_").concat("_API_KEY"),
  namespace: ns.metadata.name,
  provider,
  dependsOn: [ns],
  blockRef: (item, key) =>
    item.provider === "zai"
      ? `Backend '${key}' (zai) cannot use op://`
      : undefined,
});

// Override account API keys to read from env
for (const [envVar, { secretName, key }] of Object.entries(providerSecretRefs)) {
  accounts[reverseKey(envVar)].apiKey = `os.environ/${envVar}`;
}
```

## `op://` syntax compliance

Parser aligns with the official 1Password CLI secret-reference syntax:
- `op://<vault>/<item>/[section/]<field>` — 3 or 4 path segments
- Query parameters (`?attribute=otp`, `?ssh-format=openssh`) are stripped before parsing (they affect `op read` output format but not the CRD sync target)
- Both human-readable names and UUIDs accepted (Connect operator's `itemPath` accepts either)
- Supported characters: `a-z A-Z 0-9 - _ .` and whitespace
- Rejects <3 segments (missing vault/item/field) and >4 segments (unexpected nesting)

Reference: https://developer.1password.com/docs/cli/secret-references

## Test plan

- [x] `vitest run tests/op-secret-helpers.test.ts` — 16/16 passing
- [x] `tsc -p tsconfig.build.json --noEmit` — clean
- [x] Tests cover: 3-segment refs, 4-segment refs, UUID IDs, query param stripping (`?attribute=otp`, `?ssh-format=openssh`), whitespace in names, segment-count validation, merge semantics (varargs, undefined filtering, empty maps)

## Follow-up

Garden adoption (switching LiteLLM stack from local implementations to `@jmmaloney4/sector7/pulumi-config` imports) will follow after this PR merges and a new sector7 version is published.
