### PR TITLE
fix(renovate): use addLabels in major-updates preset to preserve chore/deps

### DIFF
--- a/renovate/major-updates.json
+++ b/renovate/major-updates.json
@@ -10,7 +10,7 @@
 			"groupName": null,
 			"prPriority": 10,
 			"reviewers": ["jmmaloney4"],
-			"labels": ["major-update", "deps/major", "chore/deps", "renovate"]
+			"addLabels": ["major-update", "deps/major"]
 		}
 	]
 }


### PR DESCRIPTION
## Problem

The `major-updates` preset used `labels: ["major-update", "deps/major", "chore/deps", "renovate"]` which **replaces** the global labels from `default.json` (`["chore/deps", "renovate"]`) instead of appending.

It accidentally worked by duplicating the global labels, but it's fragile and inconsistent with the rest of the presets which use `addLabels`.

## Fix

Switch to `addLabels: ["major-update", "deps/major"]` so global labels are preserved additively.

This also fixes repos where local `packageRules` use `labels:` instead of `addLabels:` — e.g. `cavinsresearch/zeus#1430` missing `chore/deps` because its local rules override the global labels.

Related: https://github.com/cavinsresearch/zeus/pull/1430