### PR TITLE
feat(renovate): group Helm chart minor/patch updates into one PR

### DIFF
--- a/renovate/minor-patch-automerge.json
+++ b/renovate/minor-patch-automerge.json
@@ -51,6 +51,14 @@
 			"addLabels": ["deps/docker"]
 		},
 		{
+			"description": "Group Helm chart minor/patch bumps (helm datasource, e.g. annotated versions in Pulumi config or HelmChart CRD manifests) into one PR. Not automerged: chart bumps only take effect at pulumi up, matching the Docker Images policy.",
+			"groupName": "Helm Releases",
+			"matchDatasources": ["helm"],
+			"matchUpdateTypes": ["minor", "patch"],
+			"automerge": false,
+			"addLabels": ["deps/helm"]
+		},
+		{
 			"groupName": "GitHub Actions",
 			"matchManagers": ["github-actions"],
 			"matchDatasources": ["github-tags", "github-digest"],


### PR DESCRIPTION
## Problem

Helm chart updates in consuming repos (e.g. garden) each get their own Renovate PR — six were open at once this morning (mimir-distributed, kube-state-metrics, langfuse, grafana, alloy, loki), all minor/patch bumps.

These updates come from the custom regex managers in `renovate/pulumi.json` and `renovate/yaml-manifests.json` (`# renovate: datasource=helm` annotations). Every group rule in `minor-patch-automerge.json` matches on managers like `npm`/`cargo` or datasources like `docker` — nothing has ever matched the `helm` datasource, so each chart falls through to an individual ungrouped PR.

## Fix

Add a **Helm Releases** group rule matching `datasource=helm` minor/patch updates, mirroring the Docker Images policy:

- grouped into one PR per run
- `deps/helm` label
- `automerge: false` — chart bumps only take effect at `pulumi up`, same reasoning as Docker Images

Majors remain individual per `major-updates.json` (its rule un-groups them with `groupName: null`).

## Effect

Next scheduled Renovate run in garden (Friday 4am) collapses the six open helm PRs into one `deps: update Helm Releases` PR.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)