### PR TITLE
fix(nix-image): force local builds of digest-bearing JSONs (always-allow-substitutes=false)

### DIFF
--- a/packages/sector7/scripts/nix-image-build-push.sh
+++ b/packages/sector7/scripts/nix-image-build-push.sh
@@ -106,10 +106,18 @@ if [ "${SCRIPT_MODE}" = "resolve" ]; then
       >"${DIGEST_FILE}"
 else
   # Build the image
+  #
+  # always-allow-substitutes=false: nix2container's digest-bearing JSONs are
+  # built with allowSubstitutes=false so their recorded layer digests always
+  # match the local store that skopeo streams from. Determinate Nix defaults
+  # always-allow-substitutes to true, overriding that — a substituted JSON
+  # built on another machine makes the push fail with "Digest did not match"
+  # whenever a layer dependency is not bit-reproducible.
   echo "--- nix build ---"
   echo "NIX_ATTR: ${NIX_ATTR}"
   echo "REPO_ROOT: ${REPO_ROOT}"
-  nix build "${REPO_ROOT}#${NIX_ATTR}" -o "${RESULT_LINK}" -L
+  nix build "${REPO_ROOT}#${NIX_ATTR}" -o "${RESULT_LINK}" -L \
+    --option always-allow-substitutes false
 
   IMAGE_PATH="nix:./${RESULT_LINK}"
 

--- a/packages/sector7/scripts/nix-output-resolve.sh
+++ b/packages/sector7/scripts/nix-output-resolve.sh
@@ -71,8 +71,19 @@ STORE_PATH=""
 if [ "${SCRIPT_MODE}" = "build" ]; then
   # Build the derivation. --print-out-paths writes the store path to stdout
   # (captured below); -L build logs go to stderr, redirected to the log fd.
+  #
+  # always-allow-substitutes=false: nix2container records layer tar digests in
+  # JSONs built with allowSubstitutes=false so they always match the local
+  # store the push later streams from. Determinate Nix defaults
+  # always-allow-substitutes to true, which overrides that and lets a cache
+  # serve JSONs built on another machine — if any layer dependency is not
+  # bit-reproducible (e.g. python bytecode), every push then fails with
+  # "Digest did not match". Forcing the option off restores the invariant;
+  # it only affects derivations that explicitly opted out of substitution,
+  # which are cheap by design.
   log "--- nix build ---"
-  STORE_PATH=$(nix build "${REPO_ROOT}#${FULL_ATTR}" --no-link --print-out-paths -L 2>&3)
+  STORE_PATH=$(nix build "${REPO_ROOT}#${FULL_ATTR}" --no-link --print-out-paths -L \
+    --option always-allow-substitutes false 2>&3)
 else
   # Resolve without building. nix eval --raw gives the store path on stdout;
   # any warnings/errors go to stderr, redirected to the log fd.


### PR DESCRIPTION
## Problem

Recurring `just deploy` failures pushing nix2container images:

```
writing blob: Patch "https://ghcr.io/v2/...": happened during read:
Digest did not match, expected sha256:852d49..., got sha256:907d3d...
```

### Root cause

nix2container records each layer's tar digest in JSON files built with `runCommandLocal` (`allowSubstitutes = false`), so the recorded digests are always computed against the same store that skopeo's `nix:` transport later re-tars at push time. That invariant is what makes archive-less pushes safe.

**Determinate Nix ships `always-allow-substitutes = true` by default, which overrides `allowSubstitutes = false`** and lets a binary cache (attic) serve layer/image JSONs that were built on a *different* machine. If any layer dependency is not bit-reproducible, the substituted JSON's digests can never match the local store, and every push fails deterministically — rebuilding doesn't help because the poisoned JSON is just re-substituted.

Diagnosed end-to-end on `cavinsresearch/zeus` autokiss deploys from itachi: the shared common-layer JSON was substituted from attic (built by CI, `ultimate: false`), while the local store held a locally-built `google-cloud-bigquery` whose `__pycache__/*.pyc` bytes differ wholesale from CI's build. One divergent package out of 193 paths in the layer → permanent digest mismatch.

## Fix

Pass `--option always-allow-substitutes false` to the image `nix build` in both `nix-output-resolve.sh` (build mode, used by `NixOutput`/`NixImage`) and `nix-image-build-push.sh`. This restores nix2container's invariant regardless of the host's nix configuration.

Cost: none in practice — the option only affects derivations that explicitly opted out of substitution, which are small JSON-generation steps that are cheap by design. Normal substitution of actual build artifacts is unaffected.

## Validation

- `bash -n` on both scripts.
- The equivalent manual fix was verified on itachi: deleting the substituted JSONs and rebuilding with `--option always-allow-substitutes false` produced locally-built JSONs (`ultimate: true`) whose digests match the store, after which `skopeo copy nix:<image.json> dir:...` completes cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)