### PR TITLE
fix(k8s): prefer bare specifier when loading @kubernetes/client-node

### DIFF
--- a/packages/sector7/k8s/port-forward.ts
+++ b/packages/sector7/k8s/port-forward.ts
@@ -7,26 +7,47 @@
 // This module MUST have no top-level *runtime* `import` of heavy third-party
 // packages. Pulumi serializes the provider callbacks that reference
 // `withPortForward` and re-evaluates them from the *consuming* workspace's
-// working directory — not from sector7's installed location. Under pnpm strict
-// isolation, a lazy `await import("@kubernetes/client-node")` in that context
-// resolves against the consumer's `node_modules`, where the package does NOT
-// exist, so the import fails (`Cannot find package '@kubernetes/client-node'`).
+// working directory — not from sector7's installed location.
 //
-// To stay resolvable in any consumer context we pre-resolve the absolute path
-// to the package here, at module load, using a `require` scoped to *this* file
-// (sector7's own installed location). The result is a plain string that Pulumi's
-// closure serializer captures as a free variable — the same mechanism that
-// already carries module-level consts into serialized functions. `import()`
-// with an absolute path then loads the package directly, bypassing the
-// consumer's module resolution entirely. `node:module` is a Node built-in, so
-// importing it at the top level does not violate the "no heavy third-party
-// imports" rule.
+// `@kubernetes/client-node` is loaded lazily inside `withPortForward` via TWO
+// routes, tried in order, so the load works regardless of how the consumer's
+// node_modules is laid out:
+//
+//   1. Bare specifier first: `await import("@kubernetes/client-node")`. This
+//      resolves against the *consumer's* working directory at runtime, so it
+//      works whenever the consumer declares the dependency (garden's litellm
+//      stack does). Because the specifier is a plain string carrying no
+//      absolute path, nothing machine- or directory-specific is captured.
+//
+//   2. Pre-resolved absolute path as fallback: for consumers that do NOT
+//      declare the dependency, the bare import fails with ERR_MODULE_NOT_FOUND
+//      and we fall back to an absolute path pre-resolved here at module load
+//      via a `require` scoped to *this* file (sector7's own installed
+//      location). Pulumi's closure serializer captures that path string as a
+//      free variable, and `import()` with an absolute path loads the package
+//      directly, bypassing the consumer's module resolution entirely.
+//
+// Why bare-first matters: an absolute path serialized into Pulumi stack state
+// outlives the directory that produced it. Resolve it once from a git worktree
+// and that worktree path is frozen into state forever; `pulumi refresh` then
+// fails with `Cannot find module '<deleted-worktree>/.../index.js'` once the
+// worktree is removed. The bare route resolves fresh against the live consumer
+// node_modules on every refresh, so it is immune to that failure. The
+// pre-resolved fallback is retained for consumers without the dependency.
+//
+// `node:module` is a Node built-in, so importing it at the top level does not
+// violate the "no heavy third-party imports" rule. `import type` (used for the
+// k8s return type below) is erased at compile time and likewise does not
+// violate the rule.
 
 import { createRequire } from "node:module";
 import type { Socket } from "node:net";
+import type * as K8sClientNode from "@kubernetes/client-node";
 
-// Pre-resolved at module load. The resolved path string is captured by Pulumi's
-// closure serializer; see the SERIALIZATION CONTRACT above.
+// Fallback resolution path, pre-resolved at module load for consumers that do
+// not declare @kubernetes/client-node themselves. The resolved path string is
+// captured by Pulumi's closure serializer; see the SERIALIZATION CONTRACT
+// above for why the bare specifier is preferred at runtime.
 const require_ = createRequire(import.meta.url);
 const k8sClientNodePath = require_.resolve("@kubernetes/client-node");
 
@@ -82,6 +103,53 @@ export function buildLabelSelector(
 	return [...labelParts, ...exprParts].join(",");
 }
 
+/** The loaded `@kubernetes/client-node` module shape. */
+export type K8sClient = typeof K8sClientNode;
+
+/**
+ * Whether an error signals that Node could not resolve a module specifier
+ * (rather than, say, the package throwing while loading). Used to decide whether
+ * falling back to the pre-resolved absolute path is worth attempting. A genuine
+ * load-time error from inside the package is rethrown so it is not masked.
+ */
+export function isModuleResolutionError(err: unknown): boolean {
+	return (
+		err instanceof Error &&
+		["ERR_MODULE_NOT_FOUND", "ERR_PACKAGE_PATH_NOT_EXPORTED"].includes(
+			(err as NodeJS.ErrnoException).code ?? "",
+		)
+	);
+}
+
+/**
+ * Load `@kubernetes/client-node`, preferring the bare specifier and falling
+ * back to the pre-resolved absolute path only when the bare import cannot be
+ * resolved. See the SERIALIZATION CONTRACT at the top of this file for why both
+ * routes exist.
+ *
+ * `importer` is an injection seam for tests: production callers omit it and get
+ * the real `import()`, whose closure serializes faithfully for Pulumi. Passing
+ * it lets a test observe the bare-first/fallback order and the error-code
+ * narrowing without depending on vitest module-mock internals (both routes
+ * resolve to the *same* package, so a module mock cannot tell them apart).
+ */
+export async function loadKubernetesClient(
+	importer: (specifier: string) => Promise<unknown> = (specifier) =>
+		// Dynamic import of the specifier string; a variable is fine here because
+		// Pulumi serializes function source text verbatim rather than doing
+		// bundler-style static analysis at refresh time.
+		import(specifier),
+): Promise<K8sClient> {
+	try {
+		return (await importer("@kubernetes/client-node")) as K8sClient;
+	} catch (err) {
+		if (isModuleResolutionError(err)) {
+			return (await importer(k8sClientNodePath)) as K8sClient;
+		}
+		throw err;
+	}
+}
+
 /**
  * Open a short-lived in-process port-forward to a ready pod of `target`'s
  * Deployment, invoke `fn` with a `http://127.0.0.1:<port>` base URL, then tear
@@ -97,7 +165,7 @@ export async function withPortForward<T>(
 	target: PortForwardTarget,
 	fn: (baseUrl: string) => Promise<T>,
 ): Promise<T> {
-	const k8s = await import(k8sClientNodePath);
+	const k8s = await loadKubernetesClient();
 	const net = await import("node:net");
 
 	const kc = new k8s.KubeConfig();

--- a/packages/sector7/tests/port-forward.test.ts
+++ b/packages/sector7/tests/port-forward.test.ts
@@ -1,6 +1,10 @@
 import { existsSync } from "node:fs";
 import { describe, expect, it } from "vitest";
-import { buildLabelSelector } from "../k8s/port-forward.ts";
+import {
+	buildLabelSelector,
+	isModuleResolutionError,
+	loadKubernetesClient,
+} from "../k8s/port-forward.ts";
 
 describe("buildLabelSelector", () => {
 	it("renders matchLabels", () => {
@@ -72,6 +76,112 @@ describe("k8sClientNodePath pre-resolution", () => {
 		expect(typeof mod.withPortForward).toBe("function");
 		// The function must not close over the heavy k8s module at load time.
 		// The module-level pre-resolution is a string; the actual import happens
-		// inside the function body via `await import(k8sClientNodePath)`.
+		// inside the function body via `loadKubernetesClient`, which is tried as a
+		// bare specifier first and falls back to the pre-resolved absolute path.
 	});
 });
+
+describe("loadKubernetesClient resolution routes", () => {
+	// A stand-in for the loaded @kubernetes/client-node module. `loadKubernetesClient`
+	// only forwards whatever the importer returns, so its shape is irrelevant here.
+	const fakeModule = { KubeConfig: class {} };
+
+	it("tries the bare specifier first and returns without the fallback", async () => {
+		const calls: string[] = [];
+		const k8s = await loadKubernetesClient((specifier) => {
+			calls.push(specifier);
+			return Promise.resolve(fakeModule);
+		});
+
+		expect(k8s).toBe(fakeModule);
+		// The bare specifier must be the only attempted load — the pre-resolved
+		// absolute path fallback is never consulted when the bare import resolves.
+		expect(calls).toEqual(["@kubernetes/client-node"]);
+	});
+
+	it("falls back to the pre-resolved path when the bare specifier cannot resolve", async () => {
+		const calls: string[] = [];
+		const k8s = await loadKubernetesClient((specifier) => {
+			calls.push(specifier);
+			if (specifier === "@kubernetes/client-node") {
+				// Node raises ERR_MODULE_NOT_FOUND when a bare specifier cannot be
+				// resolved from the consumer's working directory under pnpm.
+				const err: NodeJS.ErrnoException = new Error(
+					"Cannot find package '@kubernetes/client-node'",
+				);
+				err.code = "ERR_MODULE_NOT_FOUND";
+				return Promise.reject(err);
+			}
+			// The fallback uses the module-level pre-resolved absolute path, so its
+			// specifier starts with "/" (absolute) on every platform.
+			expect(specifier).toMatch(/@kubernetes[\\/]client-node/);
+			return Promise.resolve(fakeModule);
+		});
+
+		expect(k8s).toBe(fakeModule);
+		expect(calls).toEqual([
+			"@kubernetes/client-node",
+			expect.stringMatching(/@kubernetes[\\/]client-node/),
+		]);
+	});
+
+	it("does NOT fall back on a non-resolution error from inside the package", async () => {
+		// A genuine load-time failure (e.g. the package throws while executing)
+		// must surface rather than being masked by the absolute-path fallback,
+		// which would hit the same broken package and throw again anyway.
+		const boom = new Error("package blew up while loading");
+		const calls: string[] = [];
+		await expect(
+			loadKubernetesClient((specifier) => {
+				calls.push(specifier);
+				return Promise.reject(boom);
+			}),
+		).rejects.toBe(boom);
+		expect(calls).toEqual(["@kubernetes/client-node"]);
+	});
+
+	it("falls back on ERR_PACKAGE_PATH_NOT_EXPORTED as well as ERR_MODULE_NOT_FOUND", async () => {
+		const err: NodeJS.ErrnoException = new Error("Package subpath not exported");
+		err.code = "ERR_PACKAGE_PATH_NOT_EXPORTED";
+		const calls: string[] = [];
+		const k8s = await loadKubernetesClient((specifier) => {
+			calls.push(specifier);
+			return specifier === "@kubernetes/client-node"
+				? Promise.reject(err)
+				: Promise.resolve(fakeModule);
+		});
+		expect(k8s).toBe(fakeModule);
+		expect(calls).toHaveLength(2);
+	});
+});
+
+describe("isModuleResolutionError", () => {
+	it("recognizes ERR_MODULE_NOT_FOUND", () => {
+		const err: NodeJS.ErrnoException = new Error("not found");
+		err.code = "ERR_MODULE_NOT_FOUND";
+		expect(isModuleResolutionError(err)).toBe(true);
+	});
+
+	it("recognizes ERR_PACKAGE_PATH_NOT_EXPORTED", () => {
+		const err: NodeJS.ErrnoException = new Error("not exported");
+		err.code = "ERR_PACKAGE_PATH_NOT_EXPORTED";
+		expect(isModuleResolutionError(err)).toBe(true);
+	});
+
+	it("rejects unrelated error codes", () => {
+		const err: NodeJS.ErrnoException = new Error("boom");
+		err.code = "EACCES";
+		expect(isModuleResolutionError(err)).toBe(false);
+	});
+
+	it("rejects errors with no code", () => {
+		expect(isModuleResolutionError(new Error("boom"))).toBe(false);
+	});
+
+	it("rejects non-Error throwables", () => {
+		expect(isModuleResolutionError("a string")).toBe(false);
+		expect(isModuleResolutionError(null)).toBe(false);
+		expect(isModuleResolutionError(undefined)).toBe(false);
+	});
+});
+


### PR DESCRIPTION
## Problem

`withPortForward` loaded `@kubernetes/client-node` solely via an absolute path pre-resolved at module load with `createRequire().resolve(...)`. Pulumi's dynamic-provider closure serializer captures that path string into **stack state** as a free variable, where it outlives the directory that produced it.

Resolve it once from a git worktree and that worktree path is frozen into state forever. `pulumi refresh` then fails with `ERR_MODULE_NOT_FOUND` once the worktree is removed:

```
error: Cannot find module
  '/home/jack/git/.../garden/.worktrees/hermes-kimi3-deploy/node_modules/.pnpm/@kubernetes+client-node@1.4.0/.../dist/index.js'
```

This is exactly the breakage seen on the `litellm-prod` stack (5 `sector7:litellm:ApiKey` resources), where the originating worktree (`.worktrees/hermes-kimi3-deploy`) no longer exists.

## Fix

Load the package **bare-specifier first** (`import("@kubernetes/client-node")`), which resolves fresh against the live consumer `node_modules` on every refresh and carries no machine- or directory-specific path. Fall back to the pre-resolved absolute path **only** when the bare import cannot be resolved (`ERR_MODULE_NOT_FOUND` / `ERR_PACKAGE_PATH_NOT_EXPORTED`), preserving today's guarantee for consumers that do not declare the dependency. Genuine load errors from *inside* the package are rethrown rather than masked.

This is safe for garden's litellm stack, which declares `@kubernetes/client-node` as a direct dependency and resolves the bare specifier from `deploy/services/litellm/`.

## Changes

- `loadKubernetesClient()` — bare-first with narrowed-catch fallback. Production callers omit the `importer` param and get the real `import()`; tests inject a controlled loader to observe ordering and error-code narrowing without vitest module-mock internals (both routes resolve to the *same* package, so a module mock cannot tell them apart).
- `isModuleResolutionError()` — pure predicate for the two resolution-failure error codes.
- `withPortForward` now calls `loadKubernetesClient()`.
- The **SERIALIZATION CONTRACT** comment is rewritten (not dropped) to document both routes and *why* the absolute path alone is fragile.
- Tests cover: bare-tried-first; fallback on `ERR_MODULE_NOT_FOUND`; fallback on `ERR_PACKAGE_PATH_NOT_EXPORTED`; no fallback on a non-resolution error (rethrown); `isModuleResolutionError` over the error-code/null/string space.

## Validation

- `vitest run` → all port-forward tests pass (16). (One unrelated pre-existing failure in `renovate-pulumi.test.ts` — expects exactly one Pulumi renovate customManager, finds 2; not touched by this PR.)
- `tsc --noEmit -p tsconfig.json` → exit 0; real `prepack` build (`tsc -p tsconfig.build.json`) → exit 0.
- Runtime check against compiled `dist`: `loadKubernetesClient()` with the default importer loads the real module via the bare route.
- Compiled `dist/k8s/port-forward.js` preserves `import("@kubernetes/client-node")` as a string literal at the bare call site.

## Follow-ups (out of scope)

- This does **not** retroactively repair the 5 already-broken serialized closures in the live `litellm-prod` stack — that is a separate, riskier task.
- The stronger fix (drop `@kubernetes/client-node` from the closure entirely, via tailnet ingress or `child_process` + `kubectl`) and a real Pulumi provider plugin are both discussed and explicitly deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)