### PR TITLE
fix(version): derive PLUGIN_VERSION from package.json

### DIFF
--- a/packages/sector7/tests/version.test.ts
+++ b/packages/sector7/tests/version.test.ts
@@ -3,15 +3,20 @@ import { describe, expect, it } from "vitest";
 import { PLUGIN_VERSION } from "../version.ts";
 
 describe("PLUGIN_VERSION", () => {
-	// The provider binary is built from the same git tag and installed as
-	// `resource-sector7-v<version>`, so a drift here surfaces at deploy time as
-	// "no resource plugin 'sector7' found in the workspace at version vX.Y.Z".
-	// `just cut` bumps package.json but not this constant, so this test is the
-	// forcing function.
-	it("matches the package.json version", () => {
+	// PLUGIN_VERSION is derived from package.json rather than hardcoded, so this
+	// no longer guards against hand-maintained drift — it guards the resolution
+	// itself. If the build layout moves version.ts relative to package.json, the
+	// candidate paths in readPluginVersion() stop resolving and this fails.
+	it("resolves this package's npm version", () => {
 		const pkg = JSON.parse(
 			readFileSync(new URL("../package.json", import.meta.url), "utf8"),
 		) as { version: string };
 		expect(PLUGIN_VERSION).toBe(pkg.version);
+	});
+
+	// The plugin cache directory is resource-sector7-v<version>; a non-semver
+	// value would produce a directory Pulumi never looks in.
+	it("is a bare semver with no leading v", () => {
+		expect(PLUGIN_VERSION).toMatch(/^\d+\.\d+\.\d+(-[0-9A-Za-z.-]+)?$/);
 	});
 });

--- a/packages/sector7/version.ts
+++ b/packages/sector7/version.ts
@@ -1,16 +1,46 @@
+import { createRequire } from "node:module";
+
+const require_ = createRequire(import.meta.url);
+
 /**
  * Version of the `sector7` Pulumi resource plugin that this package's
  * plugin-backed resources bind to.
  *
- * It MUST equal this package's npm version: the provider binary is built from
- * the same git tag (jackpkgs pins `sector7` via nvfetcher and injects the tag
- * into `version.Version` with `-ldflags`), and the plugin cache directory is
- * `resource-sector7-v<version>`. A mismatch surfaces at deploy time as
- * `no resource plugin 'sector7' found in the workspace at version vX.Y.Z`.
+ * It is read from package.json rather than hardcoded, because it MUST equal
+ * this package's npm version: the provider binary is built from the same git
+ * tag, and the plugin cache directory is `resource-sector7-v<version>`. A
+ * mismatch surfaces at deploy time as `no resource plugin 'sector7' found in
+ * the workspace at version vX.Y.Z`.
  *
- * `just cut` bumps `package.json` but currently only understands
- * `type = "npm"` files, so this constant is maintained by hand and guarded by
- * `tests/version.test.ts`, which fails the build if the two drift. Teaching
- * `jackpkgs.just.cut` a generic file type would remove the manual step.
+ * Deriving it removes a release footgun. `just cut` bumps package.json but only
+ * understands `type = "npm"` files, so a hardcoded constant here would go stale
+ * on every single release — and the release commit itself would be the one that
+ * broke, since the drift guard fires as part of it.
+ *
+ * Two candidate paths, because the relative location differs between source and
+ * build output: `./package.json` when running from
+ * `packages/sector7/version.ts` (vitest executes the TypeScript directly), and
+ * `../package.json` from `dist/version.js` in the published tarball, where npm
+ * always includes package.json regardless of the `files` allowlist.
  */
-export const PLUGIN_VERSION = "0.20.1";
+function readPluginVersion(): string {
+	const candidates = ["./package.json", "../package.json"];
+	for (const candidate of candidates) {
+		try {
+			const pkg = require_(candidate) as { name?: string; version?: string };
+			// Only accept our own package.json — guards against resolving some
+			// other one if the build layout ever changes.
+			if (pkg.name === "@jmmaloney4/sector7" && pkg.version) {
+				return pkg.version;
+			}
+		} catch {
+			// Try the next candidate.
+		}
+	}
+	throw new Error(
+		"sector7: could not read the plugin version from package.json " +
+			`(tried ${candidates.join(", ")} relative to ${import.meta.url})`,
+	);
+}
+
+export const PLUGIN_VERSION: string = readPluginVersion();


### PR DESCRIPTION
## Summary

`PLUGIN_VERSION` (added in #340) was hardcoded and guarded by a test asserting it matched `package.json`. That guard was a **release footgun, not a safety net**.

`just cut` bumps `package.json` but only understands `type = "npm"` files, so the constant goes stale on every single release — and **the release commit itself is the one that breaks**, because the drift check fires as part of it. This would have bitten on the very next `just cut`, which is imminent (the plugin migration needs a release containing `provider/`).

Read the version from `package.json` instead.

## Why two candidate paths

The relative location differs between source and build output:

- `./package.json` — vitest executes `packages/sector7/version.ts` directly
- `../package.json` — from `dist/version.js` in the published tarball, where npm always includes `package.json` regardless of the `files` allowlist

The lookup also checks `pkg.name === "@jmmaloney4/sector7"`, so a future layout change cannot silently bind to some *other* `package.json` further up the tree — it throws with the candidates and the module URL instead.

## Test plan

- [x] `tsc --noEmit` — exit 0
- [x] `vitest run …/version.test.ts` — 2 passed (source path)
- [x] **Real build**: `tsc -p tsconfig.build.json`, then `node -e 'import("./dist/version.js")'` → `dist PLUGIN_VERSION = 0.20.1`. This is the case that actually ships and the one a source-only test would miss.

The test now guards the *resolution* rather than hand-maintained drift, and additionally asserts a bare semver with no leading `v` — the plugin cache directory is `resource-sector7-v<version>`, so a malformed value would produce a directory Pulumi never looks in.

## Follow-up this obsoletes

The plan's "teach `jackpkgs.just.cut` a generic file type" item is no longer needed for this package — there is nothing left to bump by hand.
