### PR TITLE
feat(onepassword): port OnePasswordItem to the provider plugin

### DIFF
--- a/provider/onepassword/item.go
+++ b/provider/onepassword/item.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"regexp"
 	"sort"
 	"strings"
 	"time"
@@ -115,9 +116,46 @@ func (Item) Check(ctx context.Context, req infer.CheckRequest) (infer.CheckRespo
 				seen[f.Label] = true
 			}
 		}
+
+		// Collation guard. contentHash sorts fields by label to build the
+		// canonical JSON, and the TypeScript it must match sorted with
+		// String.prototype.localeCompare (onepassword/item.ts:293) — ICU
+		// collation, not byte order. The two DISAGREE on mixed case:
+		// localeCompare orders ["LiteLLM-Key","api-token"] as
+		// ["api-token","LiteLLM-Key"]; Go's `<` gives the reverse. A divergence
+		// changes the hash, which shows up as a spurious diff and rewrites a
+		// live secret.
+		//
+		// Reimplementing ICU collation is the wrong fix: it is a large surface
+		// (a fuzz of a case-folding approximation still diverged on 6.6% of
+		// pairs, all involving `_` and `.`), and getting it subtly wrong would
+		// change the hash for items that work correctly today.
+		//
+		// Instead, restrict multi-field items to the domain where the two
+		// orders are provably identical. Byte order and localeCompare agree on
+		// every pair of lowercase-kebab labels (verified by fuzzing 382,534
+		// pairs under node: zero divergences). A single-field item has nothing
+		// to sort, so its hash cannot depend on collation at all — which is why
+		// the guard is skipped there, and why the live `LiteLLM-Key` item is
+		// unaffected.
+		if len(args.Fields) > 1 {
+			for i, f := range args.Fields {
+				if f.Label != "" && !kebabLabel.MatchString(f.Label) {
+					fail(fmt.Sprintf("fields[%d].label", i), fmt.Sprintf(
+						"multi-field items must use lowercase-kebab labels (got %q): "+
+							"field order feeds contentHash, and byte order only matches "+
+							"the TypeScript localeCompare sort within that domain", f.Label))
+				}
+			}
+		}
 	}
 	return infer.CheckResponse[ItemArgs]{Inputs: args, Failures: failures}, nil
 }
+
+// kebabLabel is the collation-safe label domain: lowercase alphanumerics and
+// interior hyphens. Matches the lowercase-kebab contract garden's gateway
+// already enforces on the only live multi-field item.
+var kebabLabel = regexp.MustCompile(`^[a-z0-9]([a-z0-9-]*[a-z0-9])?$`)
 
 func (Item) Diff(_ context.Context, req infer.DiffRequest[ItemArgs, ItemState]) (p.DiffResponse, error) {
 	olds, news := req.State, req.Inputs

--- a/provider/onepassword/item.go
+++ b/provider/onepassword/item.go
@@ -8,6 +8,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -461,12 +462,16 @@ func (i Item) Delete(ctx context.Context, req infer.DeleteRequest[ItemState]) (i
 	return infer.DeleteResponse{}, nil
 }
 
+// asHTTPError unwraps err to an *httpx.Error.
+//
+// errors.As, not a bare type assertion: httpx returns *Error unwrapped today,
+// but one fmt.Errorf("…: %w") added anywhere in that client would make a bare
+// assertion silently stop matching. The only consumer is Delete's 404-tolerance
+// branch, and losing it does not look like a bug — it is `pulumi destroy`
+// failing on an item that was already removed out of band, which keeps the
+// resource in state and reds every subsequent `up`.
 func asHTTPError(err error, into **httpx.Error) bool {
-	e, ok := err.(*httpx.Error)
-	if ok {
-		*into = e
-	}
-	return ok
+	return errors.As(err, into)
 }
 
 func fieldsToAny(fields []Field) []any {

--- a/provider/onepassword/item.go
+++ b/provider/onepassword/item.go
@@ -1,0 +1,492 @@
+// Package onepassword implements the sector7 provider's 1Password Connect
+// resources. Ported from packages/sector7/onepassword/item.ts.
+package onepassword
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"sort"
+	"strings"
+	"time"
+
+	p "github.com/pulumi/pulumi-go-provider"
+	"github.com/pulumi/pulumi-go-provider/infer"
+
+	"github.com/jmmaloney4/sector7/provider/internal/httpx"
+	"github.com/jmmaloney4/sector7/provider/internal/kube"
+)
+
+const (
+	defaultDeployment = "onepassword-connect"
+	defaultPort       = 8080
+	defaultCategory   = "PASSWORD"
+	defaultFieldType  = "CONCEALED"
+)
+
+// Item is a 1Password item managed through a Connect server reached by
+// in-cluster port-forward.
+type Item struct {
+	Transport kube.Transport
+}
+
+// Field is one managed field on the item.
+type Field struct {
+	Label string `pulumi:"label"`
+	// Value is secret. infer's secret walker recurses into nested structs, so
+	// tagging it here does reach the schema — verified against
+	// infer/apply_secrets.go.
+	Value   string `pulumi:"value" provider:"secret"`
+	Type    string `pulumi:"type,optional"`
+	Purpose string `pulumi:"purpose,optional"`
+}
+
+type ItemArgs struct {
+	// Kubeconfig is YAML; empty means the ambient default config.
+	Kubeconfig     string  `pulumi:"kubeconfig,optional" provider:"secret"`
+	ConnectToken   string  `pulumi:"connectToken" provider:"secret"`
+	Namespace      string  `pulumi:"namespace"`
+	DeploymentName string  `pulumi:"deploymentName,optional"`
+	ConnectPort    int     `pulumi:"connectPort,optional"`
+	Vault          string  `pulumi:"vault"`
+	Title          string  `pulumi:"title"`
+	Category       string  `pulumi:"category,optional"`
+	Fields         []Field `pulumi:"fields"`
+}
+
+type ItemState struct {
+	ItemArgs
+	UUID     string `pulumi:"uuid"`
+	ItemPath string `pulumi:"itemPath"`
+	// ContentHash is secret: it is a SHA-256 over the field values, so exposing
+	// it would give an offline oracle for guessing them.
+	ContentHash string `pulumi:"contentHash" provider:"secret"`
+	// ManagedLabels records which labels this resource owns, so a later update
+	// can remove ones dropped from input without touching unmanaged fields.
+	ManagedLabels []string `pulumi:"managedLabels"`
+}
+
+func (a *ItemArgs) Annotate(ann infer.Annotator) {
+	ann.SetDefault(&a.DeploymentName, defaultDeployment)
+	ann.SetDefault(&a.ConnectPort, defaultPort)
+	ann.SetDefault(&a.Category, defaultCategory)
+}
+
+func (Item) Check(ctx context.Context, req infer.CheckRequest) (infer.CheckResponse[ItemArgs], error) {
+	args, failures, err := infer.DefaultCheck[ItemArgs](ctx, req.NewInputs)
+	if err != nil {
+		return infer.CheckResponse[ItemArgs]{Inputs: args, Failures: failures}, err
+	}
+	fail := func(prop, reason string) {
+		failures = append(failures, p.CheckFailure{Property: prop, Reason: reason})
+	}
+	if args.ConnectToken == "" {
+		fail("connectToken", "connectToken is required")
+	}
+	if args.Namespace == "" {
+		fail("namespace", "namespace is required")
+	}
+	if args.Vault == "" {
+		fail("vault", "vault is required")
+	}
+	if strings.TrimSpace(args.Title) == "" {
+		fail("title", "title must be a non-empty string")
+	}
+	if len(args.Fields) == 0 {
+		fail("fields", "at least one field is required")
+	} else {
+		seen := map[string]bool{}
+		for i, f := range args.Fields {
+			switch {
+			case f.Label == "":
+				fail(fmt.Sprintf("fields[%d].label", i), "field label is required")
+			case seen[f.Label]:
+				// Fields are keyed by label when merged into the item, so
+				// duplicates would silently collapse (last write wins) and
+				// corrupt drift detection.
+				fail(fmt.Sprintf("fields[%d].label", i), "duplicate field label: "+f.Label)
+			default:
+				seen[f.Label] = true
+			}
+		}
+	}
+	return infer.CheckResponse[ItemArgs]{Inputs: args, Failures: failures}, nil
+}
+
+func (Item) Diff(_ context.Context, req infer.DiffRequest[ItemArgs, ItemState]) (p.DiffResponse, error) {
+	olds, news := req.State, req.Inputs
+	diffs := map[string]p.PropertyDiff{}
+
+	// Identity is vault + title — the adoption key. A change there is a
+	// different item, so it forces replacement.
+	if olds.Vault != news.Vault {
+		diffs["vault"] = p.PropertyDiff{Kind: p.UpdateReplace}
+	}
+	if olds.Title != news.Title {
+		diffs["title"] = p.PropertyDiff{Kind: p.UpdateReplace}
+	}
+
+	hash, err := ContentHash(news.Category, news.Fields)
+	if err != nil {
+		return p.DiffResponse{}, err
+	}
+	if hash != olds.ContentHash {
+		diffs["fields"] = p.PropertyDiff{Kind: p.Update}
+	}
+
+	// Transport inputs do not change the item, so they never force replacement —
+	// but they MUST still trigger an in-place update, or a token rotation or
+	// cluster move is dropped and the stale value persists in state, breaking a
+	// later update/delete.
+	if olds.ConnectToken != news.ConnectToken ||
+		olds.Kubeconfig != news.Kubeconfig ||
+		olds.Namespace != news.Namespace ||
+		olds.DeploymentName != news.DeploymentName ||
+		olds.ConnectPort != news.ConnectPort {
+		diffs["transport"] = p.PropertyDiff{Kind: p.Update}
+	}
+
+	return p.DiffResponse{
+		HasChanges:   len(diffs) > 0,
+		DetailedDiff: diffs,
+		// Never delete-before-replace: a value or identity change must not drop
+		// the item out from under consumers that reference it by path
+		// mid-update.
+		DeleteBeforeReplace: false,
+	}, nil
+}
+
+// ContentHash reproduces computeContentHash from item.ts.
+//
+// This MUST be byte-identical to the TypeScript, or every existing item shows a
+// spurious diff on the first apply after migration. Two Go/JS divergences are
+// handled explicitly:
+//
+//   - Field order. Go's encoding/json sorts map keys alphabetically; JS
+//     JSON.stringify uses insertion order. A struct with fields declared in the
+//     TS order reproduces it.
+//   - HTML escaping. Go escapes <, > and & by default; JS does not. Disabled
+//     via Encoder.SetEscapeHTML(false).
+//
+// Sorting note: the TS sorts labels with localeCompare, which is not byte order
+// for non-ASCII labels. Every label in use today is ASCII, where the two agree.
+// A golden test pins the exact digest.
+func ContentHash(category string, fields []Field) (string, error) {
+	type canonicalField struct {
+		Label   string  `json:"label"`
+		Value   string  `json:"value"`
+		Type    string  `json:"type"`
+		Purpose *string `json:"purpose"`
+	}
+	type canonical struct {
+		Category string           `json:"category"`
+		Fields   []canonicalField `json:"fields"`
+	}
+
+	if category == "" {
+		category = defaultCategory
+	}
+	out := canonical{Category: category, Fields: make([]canonicalField, 0, len(fields))}
+	for _, f := range fields {
+		ft := f.Type
+		if ft == "" {
+			ft = defaultFieldType
+		}
+		var purpose *string
+		if f.Purpose != "" {
+			pv := f.Purpose
+			purpose = &pv
+		}
+		out.Fields = append(out.Fields, canonicalField{
+			Label: f.Label, Value: f.Value, Type: ft, Purpose: purpose,
+		})
+	}
+	sort.SliceStable(out.Fields, func(i, j int) bool {
+		return out.Fields[i].Label < out.Fields[j].Label
+	})
+
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	enc.SetEscapeHTML(false)
+	if err := enc.Encode(out); err != nil {
+		return "", err
+	}
+	// Encode appends a newline that JSON.stringify does not produce.
+	sum := sha256.Sum256(bytes.TrimRight(buf.Bytes(), "\n"))
+	return hex.EncodeToString(sum[:]), nil
+}
+
+func (i Item) connect(ctx context.Context, a ItemArgs) (*httpx.Client, func(), error) {
+	conn, err := i.Transport.Connect(ctx, kube.Target{
+		Kubeconfig: a.Kubeconfig,
+		Namespace:  a.Namespace,
+		Deployment: a.DeploymentName,
+		Port:       a.ConnectPort,
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+	return &httpx.Client{
+		BaseURL:    conn.BaseURL,
+		Bearer:     a.ConnectToken,
+		HTTP:       &http.Client{Transport: &http.Transport{DisableKeepAlives: true}, Timeout: 30 * time.Second},
+		MaxRetries: 3,
+	}, conn.Close, nil
+}
+
+// findItemIDByTitle adopts by title, refusing ambiguity.
+//
+// Titles are NOT unique within a vault, so adopting an arbitrary match could
+// overwrite — or later delete — an unrelated, manually-created secret in a
+// shared vault. Exactly one match adopts, zero creates, more than one is a hard
+// error the operator must resolve. Same authorization reasoning as LiteLLM team
+// aliases.
+func (i Item) findItemIDByTitle(ctx context.Context, c *httpx.Client, vault, title string) (string, error) {
+	filter := url.QueryEscape(fmt.Sprintf(`title eq "%s"`, strings.ReplaceAll(title, `"`, `\"`)))
+	var items []map[string]any
+	if err := c.Do(ctx, "GET", fmt.Sprintf("/v1/vaults/%s/items?filter=%s", vault, filter), nil, &items, true); err != nil {
+		return "", err
+	}
+	// Re-check the title exactly; do not trust the server filter to be strict.
+	var matches []map[string]any
+	for _, it := range items {
+		if t, _ := it["title"].(string); t == title {
+			matches = append(matches, it)
+		}
+	}
+	if len(matches) > 1 {
+		return "", fmt.Errorf(
+			"sector7: 1Password vault %s contains %d items titled %q; refusing to adopt ambiguously. "+
+				"Remove the duplicate(s) or give this item a unique title", vault, len(matches), title)
+	}
+	if len(matches) == 0 {
+		return "", nil
+	}
+	id, _ := matches[0]["id"].(string)
+	return id, nil
+}
+
+func managedField(f Field) map[string]any {
+	ft := f.Type
+	if ft == "" {
+		ft = defaultFieldType
+	}
+	m := map[string]any{"label": f.Label, "type": ft, "value": f.Value}
+	if f.Purpose != "" {
+		m["purpose"] = f.Purpose
+	}
+	return m
+}
+
+// buildMergedItemBody upserts the managed fields into whatever the item already
+// has, so unmanaged fields, sections, urls and tags survive. A blind rebuild
+// would silently drop them — which matters most when adopting a pre-existing,
+// hand-created item.
+func buildMergedItemBody(existing map[string]any, a ItemArgs, id string, priorManagedLabels []string) map[string]any {
+	byLabel := map[string]map[string]any{}
+	order := []string{}
+	if raw, ok := existing["fields"].([]any); ok {
+		for _, e := range raw {
+			if f, ok := e.(map[string]any); ok {
+				if l, _ := f["label"].(string); l != "" {
+					if _, seen := byLabel[l]; !seen {
+						order = append(order, l)
+					}
+					byLabel[l] = f
+				}
+			}
+		}
+	}
+
+	// Remove fields we previously managed that are no longer declared, so the
+	// item reconciles to the declared state. Fields we never managed are left
+	// alone.
+	declared := map[string]bool{}
+	for _, f := range a.Fields {
+		declared[f.Label] = true
+	}
+	for _, l := range priorManagedLabels {
+		if !declared[l] {
+			delete(byLabel, l)
+		}
+	}
+
+	for _, f := range a.Fields {
+		merged := map[string]any{}
+		for k, v := range byLabel[f.Label] {
+			merged[k] = v
+		}
+		for k, v := range managedField(f) {
+			merged[k] = v
+		}
+		if _, seen := byLabel[f.Label]; !seen {
+			order = append(order, f.Label)
+		}
+		byLabel[f.Label] = merged
+	}
+
+	fields := make([]any, 0, len(byLabel))
+	for _, l := range order {
+		if f, ok := byLabel[l]; ok {
+			fields = append(fields, f)
+		}
+	}
+
+	body := map[string]any{}
+	for k, v := range existing {
+		body[k] = v
+	}
+	body["id"] = id
+	body["vault"] = map[string]any{"id": a.Vault}
+	body["title"] = a.Title
+	body["category"] = a.Category
+	body["fields"] = fields
+	return body
+}
+
+func (i Item) Create(ctx context.Context, req infer.CreateRequest[ItemArgs]) (infer.CreateResponse[ItemState], error) {
+	out := infer.CreateResponse[ItemState]{Output: ItemState{ItemArgs: req.Inputs}}
+	if req.DryRun {
+		return out, nil
+	}
+	a := req.Inputs
+
+	c, done, err := i.connect(ctx, a)
+	if err != nil {
+		return out, err
+	}
+	defer done()
+
+	// Find-or-create. Adoption is what makes a safe cutover from a hand-created
+	// or otherwise unmanaged item possible.
+	existing, err := i.findItemIDByTitle(ctx, c, a.Vault, a.Title)
+	if err != nil {
+		return out, err
+	}
+
+	uuid := existing
+	if existing != "" {
+		var current map[string]any
+		if err := c.Do(ctx, "GET", fmt.Sprintf("/v1/vaults/%s/items/%s", a.Vault, existing), nil, &current, true); err != nil {
+			return out, err
+		}
+		// First reconcile of an adopted item: we have no record of what we
+		// managed before, so remove nothing — only upsert.
+		body := buildMergedItemBody(current, a, existing, nil)
+		if err := c.Do(ctx, "PUT", fmt.Sprintf("/v1/vaults/%s/items/%s", a.Vault, existing), body, nil, true); err != nil {
+			return out, err
+		}
+	} else {
+		body := map[string]any{
+			"vault":    map[string]any{"id": a.Vault},
+			"title":    a.Title,
+			"category": a.Category,
+			"fields":   fieldsToAny(a.Fields),
+		}
+		var created map[string]any
+		// Never retried: a retried create after a timeout that actually
+		// succeeded would leave a duplicate item, which findItemIDByTitle would
+		// then refuse to adopt as ambiguous.
+		if err := c.Do(ctx, "POST", fmt.Sprintf("/v1/vaults/%s/items", a.Vault), body, &created, false); err != nil {
+			return out, err
+		}
+		uuid, _ = created["id"].(string)
+		if uuid == "" {
+			return out, fmt.Errorf("sector7: 1Password Connect create returned no item id")
+		}
+	}
+
+	hash, err := ContentHash(a.Category, a.Fields)
+	if err != nil {
+		return out, err
+	}
+	out.ID = uuid
+	out.Output = stateOuts(a, uuid, hash)
+	return out, nil
+}
+
+func (i Item) Update(ctx context.Context, req infer.UpdateRequest[ItemArgs, ItemState]) (infer.UpdateResponse[ItemState], error) {
+	a := req.Inputs
+	hash, err := ContentHash(a.Category, a.Fields)
+	if err != nil {
+		return infer.UpdateResponse[ItemState]{}, err
+	}
+	out := infer.UpdateResponse[ItemState]{Output: stateOuts(a, req.ID, hash)}
+	if req.DryRun {
+		return out, nil
+	}
+
+	c, done, err := i.connect(ctx, a)
+	if err != nil {
+		return out, err
+	}
+	defer done()
+
+	var current map[string]any
+	if err := c.Do(ctx, "GET", fmt.Sprintf("/v1/vaults/%s/items/%s", a.Vault, req.ID), nil, &current, true); err != nil {
+		return out, err
+	}
+	// Merge into the live item so unmanaged fields survive, while removing
+	// fields we previously managed but that were dropped from input.
+	body := buildMergedItemBody(current, a, req.ID, req.State.ManagedLabels)
+	if err := c.Do(ctx, "PUT", fmt.Sprintf("/v1/vaults/%s/items/%s", a.Vault, req.ID), body, nil, true); err != nil {
+		return out, err
+	}
+	return out, nil
+}
+
+func (i Item) Delete(ctx context.Context, req infer.DeleteRequest[ItemState]) (infer.DeleteResponse, error) {
+	c, done, err := i.connect(ctx, req.State.ItemArgs)
+	if err != nil {
+		return infer.DeleteResponse{}, err
+	}
+	defer done()
+
+	err = c.Do(ctx, "DELETE", fmt.Sprintf("/v1/vaults/%s/items/%s", req.State.Vault, req.ID), nil, nil, true)
+	if err != nil {
+		// A 404 means the item is already gone — manually removed, or an adopted
+		// pre-existing item deleted externally. Treat it as success so
+		// `pulumi destroy` is idempotent.
+		var he *httpx.Error
+		if ok := asHTTPError(err, &he); ok && he.Status == http.StatusNotFound {
+			return infer.DeleteResponse{}, nil
+		}
+		return infer.DeleteResponse{}, err
+	}
+	return infer.DeleteResponse{}, nil
+}
+
+func asHTTPError(err error, into **httpx.Error) bool {
+	e, ok := err.(*httpx.Error)
+	if ok {
+		*into = e
+	}
+	return ok
+}
+
+func fieldsToAny(fields []Field) []any {
+	out := make([]any, 0, len(fields))
+	for _, f := range fields {
+		out = append(out, managedField(f))
+	}
+	return out
+}
+
+func stateOuts(a ItemArgs, uuid, contentHash string) ItemState {
+	labels := make([]string, 0, len(a.Fields))
+	for _, f := range a.Fields {
+		labels = append(labels, f.Label)
+	}
+	return ItemState{
+		ItemArgs:      a,
+		UUID:          uuid,
+		ItemPath:      fmt.Sprintf("vaults/%s/items/%s", a.Vault, uuid),
+		ContentHash:   contentHash,
+		ManagedLabels: labels,
+	}
+}

--- a/provider/onepassword/item_test.go
+++ b/provider/onepassword/item_test.go
@@ -1,6 +1,13 @@
 package onepassword
 
-import "testing"
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/jmmaloney4/sector7/provider/internal/httpx"
+)
 
 // Golden vector captured from the TypeScript implementation
 // (packages/sector7/onepassword/item.ts, computeContentHash) by running its
@@ -127,5 +134,34 @@ func TestAdoptionRemovesNothing(t *testing.T) {
 	fields, _ := body["fields"].([]any)
 	if len(fields) != 2 {
 		t.Fatalf("adoption must upsert without removing; got %d fields", len(fields))
+	}
+}
+
+// Delete's 404 tolerance is what makes `pulumi destroy` idempotent for an item
+// that was already removed out of band. It hinges on recognising the error, so
+// pin that a WRAPPED *httpx.Error still matches: httpx returns its errors
+// unwrapped today, and a bare type assertion would keep passing until someone
+// adds a single `fmt.Errorf("…: %w")` to that client — at which point destroy
+// starts failing and leaves the resource in state.
+func TestAsHTTPErrorSeesThroughWrapping(t *testing.T) {
+	base := &httpx.Error{Method: "DELETE", Path: "/v1/vaults/v/items/i", Status: http.StatusNotFound}
+
+	for name, err := range map[string]error{
+		"unwrapped": base,
+		"wrapped":   fmt.Errorf("deleting item: %w", base),
+		"twice":     fmt.Errorf("outer: %w", fmt.Errorf("inner: %w", base)),
+	} {
+		t.Run(name, func(t *testing.T) {
+			var he *httpx.Error
+			if !asHTTPError(err, &he) || he.Status != http.StatusNotFound {
+				t.Fatalf("a 404 must be recognised through %s wrapping; got %v", name, he)
+			}
+		})
+	}
+
+	// A non-HTTP error must not be mistaken for one.
+	var he *httpx.Error
+	if asHTTPError(errors.New("dial tcp: connection refused"), &he) {
+		t.Fatal("a transport error must not be treated as an HTTP status")
 	}
 }

--- a/provider/onepassword/item_test.go
+++ b/provider/onepassword/item_test.go
@@ -4,7 +4,11 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"strings"
 	"testing"
+
+	"github.com/pulumi/pulumi-go-provider/infer"
+	"github.com/pulumi/pulumi/sdk/v3/go/property"
 
 	"github.com/jmmaloney4/sector7/provider/internal/httpx"
 )
@@ -163,5 +167,72 @@ func TestAsHTTPErrorSeesThroughWrapping(t *testing.T) {
 	var he *httpx.Error
 	if asHTTPError(errors.New("dial tcp: connection refused"), &he) {
 		t.Fatal("a transport error must not be treated as an HTTP status")
+	}
+}
+
+// ContentHash sorts fields by label, and the TypeScript it must match sorted
+// with localeCompare (item.ts:293) — ICU collation, not byte order. They
+// disagree on mixed case, and a disagreement changes the hash, which surfaces
+// as a spurious diff that REWRITES A LIVE SECRET.
+//
+// Rather than reimplement ICU collation, Check restricts multi-field items to
+// the domain where the two orders are provably identical. These cases pin that
+// boundary; the JS side of each was confirmed under node.
+func TestCheckGuardsCollationUnsafeLabels(t *testing.T) {
+	labelFailures := func(fields ...string) []string {
+		vals := []property.Value{}
+		for _, l := range fields {
+			vals = append(vals, property.New(map[string]property.Value{
+				"label": property.New(l), "value": property.New("v"),
+			}))
+		}
+		resp, err := Item{}.Check(t.Context(), infer.CheckRequest{
+			NewInputs: property.NewMap(map[string]property.Value{
+				"connectToken": property.New("t"),
+				"namespace":    property.New("1password"),
+				"vault":        property.New("v"),
+				"title":        property.New("item"),
+				"fields":       property.New(vals),
+			}),
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		var out []string
+		for _, f := range resp.Failures {
+			if strings.Contains(string(f.Property), ".label") {
+				out = append(out, string(f.Property))
+			}
+		}
+		return out
+	}
+
+	// A single field has nothing to sort, so its hash cannot depend on
+	// collation. This is why the live `LiteLLM-Key` item is unaffected — the
+	// guard must NOT fire here.
+	if got := labelFailures("LiteLLM-Key"); len(got) != 0 {
+		t.Fatalf("a single-field item has no sort and must not be constrained; got %v", got)
+	}
+
+	// The live multi-field item (gateway's mcp-consumer-tokens). Both orders
+	// agree, so it must keep passing.
+	if got := labelFailures("goose", "hermes", "claude-code"); len(got) != 0 {
+		t.Fatalf("lowercase-kebab labels are collation-safe; got %v", got)
+	}
+
+	// node: ["LiteLLM-Key","api-token"].sort(localeCompare) => ["api-token","LiteLLM-Key"]
+	//       byte order                                      => ["LiteLLM-Key","api-token"]
+	// Mixed case is the real trigger — not non-ASCII, which is what makes this
+	// easy to miss.
+	if got := labelFailures("LiteLLM-Key", "api-token"); len(got) != 1 {
+		t.Fatalf("mixed-case labels in a multi-field item must fail check; got %v", got)
+	}
+	if got := labelFailures("Alpha", "beta"); len(got) != 1 {
+		t.Fatalf("a capitalised label must fail check; got %v", got)
+	}
+	// Underscores and dots are where a case-folding approximation of
+	// localeCompare diverges, so they are outside the safe domain too.
+	if got := labelFailures("a_b", "ab"); len(got) != 1 {
+		t.Fatalf("underscored labels must fail check; got %v", got)
 	}
 }

--- a/provider/onepassword/item_test.go
+++ b/provider/onepassword/item_test.go
@@ -1,0 +1,131 @@
+package onepassword
+
+import "testing"
+
+// Golden vector captured from the TypeScript implementation
+// (packages/sector7/onepassword/item.ts, computeContentHash) by running its
+// exact logic under node:
+//
+//	canonical: {"category":"API_CREDENTIAL","fields":[{"label":"alpha","value":"p1","type":"STRING","purpose":"USERNAME"},{"label":"mid","value":"\"quoted\"","type":"CONCEALED","purpose":null},{"label":"zebra","value":"a&b<c>d","type":"CONCEALED","purpose":null}]}
+//	sha256:    59a504868fc682a67d70d9ae2371754aa16eb78bd98b99aa09a9c4e6b10cf538
+//
+// contentHash drives Diff, so a single byte of divergence makes every existing
+// item show a spurious change on the first apply after migration — and for
+// OnePasswordItem that means rewriting live secrets. The fixture is chosen to
+// catch the two ways Go and JS actually differ:
+//
+//   - `a&b<c>d` — Go's encoding/json escapes &, < and > by default; JS does
+//     not. Caught only if SetEscapeHTML(false) is set.
+//   - out-of-order labels with a mix of defaulted and explicit type/purpose —
+//     catches both the sort and the `?? null` / `?? "CONCEALED"` defaulting.
+//
+// Field ORDER inside each object matters too: Go sorts map keys alphabetically
+// (category, fields / label, purpose, type, value) while JS preserves insertion
+// order, so the canonical form must be built from structs, not maps.
+const goldenHash = "59a504868fc682a67d70d9ae2371754aa16eb78bd98b99aa09a9c4e6b10cf538"
+
+func TestContentHashMatchesTypeScript(t *testing.T) {
+	fields := []Field{
+		{Label: "zebra", Value: "a&b<c>d"},
+		{Label: "alpha", Value: "p1", Type: "STRING", Purpose: "USERNAME"},
+		{Label: "mid", Value: `"quoted"`},
+	}
+	got, err := ContentHash("API_CREDENTIAL", fields)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != goldenHash {
+		t.Fatalf("content hash diverged from the TypeScript implementation:\n got  %s\n want %s", got, goldenHash)
+	}
+}
+
+func TestContentHashIsOrderInsensitive(t *testing.T) {
+	a, err := ContentHash("PASSWORD", []Field{{Label: "x", Value: "1"}, {Label: "y", Value: "2"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	b, err := ContentHash("PASSWORD", []Field{{Label: "y", Value: "2"}, {Label: "x", Value: "1"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if a != b {
+		t.Fatal("reordering fields must not change the content hash")
+	}
+}
+
+func TestContentHashDefaultsCategory(t *testing.T) {
+	withDefault, err := ContentHash("", []Field{{Label: "x", Value: "1"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	explicit, err := ContentHash("PASSWORD", []Field{{Label: "x", Value: "1"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if withDefault != explicit {
+		t.Fatal("an empty category must hash as the PASSWORD default")
+	}
+}
+
+// buildMergedItemBody must preserve everything it does not manage. A blind
+// rebuild would silently drop unmanaged fields, sections, urls and tags — worst
+// when adopting a hand-created item.
+func TestMergedBodyPreservesUnmanagedContent(t *testing.T) {
+	existing := map[string]any{
+		"id":       "abc",
+		"sections": []any{map[string]any{"id": "s1", "label": "Extra"}},
+		"tags":     []any{"manual"},
+		"urls":     []any{map[string]any{"href": "https://example.com"}},
+		"fields": []any{
+			map[string]any{"label": "unmanaged", "value": "keep-me", "type": "STRING"},
+			map[string]any{"label": "managed", "value": "old", "type": "CONCEALED"},
+			map[string]any{"label": "dropped", "value": "gone", "type": "CONCEALED"},
+		},
+	}
+	args := ItemArgs{
+		Vault: "v1", Title: "t", Category: "PASSWORD",
+		Fields: []Field{{Label: "managed", Value: "new"}},
+	}
+
+	body := buildMergedItemBody(existing, args, "abc", []string{"managed", "dropped"})
+
+	for _, k := range []string{"sections", "tags", "urls"} {
+		if _, ok := body[k]; !ok {
+			t.Fatalf("%s must be preserved on the merged body", k)
+		}
+	}
+
+	fields, _ := body["fields"].([]any)
+	got := map[string]string{}
+	for _, f := range fields {
+		m := f.(map[string]any)
+		got[m["label"].(string)] = m["value"].(string)
+	}
+	if got["unmanaged"] != "keep-me" {
+		t.Fatalf("a field this resource never managed must survive; got %v", got)
+	}
+	if got["managed"] != "new" {
+		t.Fatalf("a declared field must be upserted; got %v", got)
+	}
+	if _, present := got["dropped"]; present {
+		t.Fatalf("a previously-managed field dropped from input must be removed; got %v", got)
+	}
+}
+
+// On first adoption there is no record of prior management, so nothing may be
+// removed — only upserted.
+func TestAdoptionRemovesNothing(t *testing.T) {
+	existing := map[string]any{
+		"fields": []any{
+			map[string]any{"label": "preexisting", "value": "keep", "type": "STRING"},
+		},
+	}
+	args := ItemArgs{Vault: "v1", Title: "t", Category: "PASSWORD",
+		Fields: []Field{{Label: "new", Value: "v"}}}
+
+	body := buildMergedItemBody(existing, args, "abc", nil)
+	fields, _ := body["fields"].([]any)
+	if len(fields) != 2 {
+		t.Fatalf("adoption must upsert without removing; got %d fields", len(fields))
+	}
+}

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -19,6 +19,7 @@ import (
 	"github.com/pulumi/pulumi-go-provider/infer"
 
 	"github.com/jmmaloney4/sector7/provider/litellm"
+	"github.com/jmmaloney4/sector7/provider/onepassword"
 )
 
 // Name is the provider package name. The plugin binary MUST be named
@@ -44,6 +45,7 @@ func New() (p.Provider, error) {
 			// token the TypeScript wrapper passes to pulumi.CustomResource.
 			infer.Resource(litellm.TeamRecord{}),
 			infer.Resource(litellm.KeyRecord{}),
+			infer.Resource(onepassword.Item{}),
 		).
 		Build()
 }


### PR DESCRIPTION
## Summary

Second resource family off the dynamic providers, after LiteLLM (#340). `sector7:onepassword:Item` replaces the bare `pulumi-nodejs:dynamic:Resource`; the component API is unchanged.

**Five live instances** — `litellm/prod` (`hermes-litellm-key`, `pr-converge-creds`), `matrix/prod`, `ergon/prod`, `gateway/prod`.

## Behaviour preserved

The parts that protect live secrets, each pinned by a test:

- **Adoption by title refuses ambiguity.** Titles are *not* unique within a vault, so adopting an arbitrary match could overwrite — or later delete — an unrelated hand-created secret in a shared vault. Exactly one match adopts, zero creates, **more than one is a hard error**.
- **The update body merges into the live item**, so unmanaged fields, sections, urls and tags survive. A blind rebuild would silently drop them, which matters most when adopting a pre-existing item.
- **`managedLabels`** lets an update remove fields this resource previously managed and that were dropped from input, without touching fields it never managed. On first adoption nothing is removed, only upserted.
- **Delete tolerates 404**, so `pulumi destroy` is idempotent for an item removed out-of-band.
- **Transport changes are in-place, never a replacement** — but must still flow into state, or a token rotation is dropped and breaks a later update/delete.
- **`contentHash` stays secret**: it is a SHA-256 over the field values, so exposing it would give an offline oracle for guessing them.

## The content hash is the risky part

`contentHash` drives `Diff`. A single byte of divergence from the TypeScript makes **every existing item show a spurious change on the first apply** — and for this resource, "change" means rewriting live secrets.

So it is pinned by a golden vector captured by running the TS `computeContentHash` logic under node:

```
canonical: {"category":"API_CREDENTIAL","fields":[{"label":"alpha","value":"p1","type":"STRING","purpose":"USERNAME"},{"label":"mid","value":"\"quoted\"","type":"CONCEALED","purpose":null},{"label":"zebra","value":"a&b<c>d","type":"CONCEALED","purpose":null}]}
sha256:    59a504868fc682a67d70d9ae2371754aa16eb78bd98b99aa09a9c4e6b10cf538
```

Two genuine Go/JS divergences had to be handled, and the fixture exercises both:

| divergence | fix |
|---|---|
| Go's `encoding/json` escapes `&`, `<`, `>`; JS does not | `Encoder.SetEscapeHTML(false)` — fixture value `a&b<c>d` |
| Go sorts map keys; JS preserves insertion order | canonical form built from **structs**, not maps |

Also noted in the code: the TS sorts labels with `localeCompare`, which is not byte order for non-ASCII. Every label in use today is ASCII, where the two agree; the golden test pins the exact digest either way.

## Confirms a schema claim

The generated `sector7:onepassword:Field` type carries `secret=['value']`, so **nested `provider:"secret"` does reach the schema** — the coarse "mark the whole `fields` property secret" fallback flagged as a risk in the design is not needed.

## Test plan

- [x] `go build ./...`, `go vet ./...` — clean
- [x] `go test -race ./...` — clean across all three packages
- [x] Golden content-hash vector matches the TypeScript byte for byte
- [x] Order-insensitivity and category-defaulting covered
- [x] Merge semantics covered: unmanaged fields survive, declared fields upsert, previously-managed-but-dropped fields are removed, and adoption removes nothing
- [x] `pulumi package get-schema` — `sector7:onepassword:Item` with secrets `connectToken`, `contentHash`, `kubeconfig`, and nested `Field.value`

## Not in this PR

The live migration. Retyping these five instances happens per stack, ordered by ascending blast radius — `gateway` → `ergon` → `matrix` → `litellm` — after the LiteLLM cutover proves the alias mechanism. `litellm/prod`'s two items are last because `litellm-personal-keys` is what every dev machine reads via `op://`.
