### PR TITLE
feat(provider): port the remaining sector7 dynamic providers (Attic, D1, R2)

### DIFF
--- a/provider/attic/cache.go
+++ b/provider/attic/cache.go
@@ -2,6 +2,7 @@ package attic
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -301,8 +302,9 @@ func (c Cache) Create(ctx context.Context, req infer.CreateRequest[CacheArgs]) (
 // isCacheAlreadyExists recognises Attic's create-collision response: a 400
 // whose body names CacheAlreadyExists.
 func isCacheAlreadyExists(err error) bool {
-	e, ok := err.(*httpx.Error)
-	return ok && e.Status == http.StatusBadRequest && strings.Contains(e.Body, "CacheAlreadyExists")
+	var e *httpx.Error
+	return errors.As(err, &e) && e.Status == http.StatusBadRequest &&
+		strings.Contains(e.Body, "CacheAlreadyExists")
 }
 
 func (c Cache) Update(ctx context.Context, req infer.UpdateRequest[CacheArgs, CacheState]) (infer.UpdateResponse[CacheState], error) {
@@ -349,7 +351,8 @@ func (c Cache) Delete(ctx context.Context, req infer.DeleteRequest[CacheState]) 
 	if err != nil {
 		// Idempotent delete: a cache already removed out of band means the
 		// desired end state is reached, so do not fail destroy or a replacement.
-		if e, ok := err.(*httpx.Error); ok && e.Status == http.StatusNotFound {
+		var e *httpx.Error
+		if errors.As(err, &e) && e.Status == http.StatusNotFound {
 			return infer.DeleteResponse{}, nil
 		}
 		return infer.DeleteResponse{}, err

--- a/provider/attic/cache.go
+++ b/provider/attic/cache.go
@@ -1,0 +1,358 @@
+package attic
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	p "github.com/pulumi/pulumi-go-provider"
+	"github.com/pulumi/pulumi-go-provider/infer"
+
+	"github.com/jmmaloney4/sector7/provider/internal/diffutil"
+	"github.com/jmmaloney4/sector7/provider/internal/httpx"
+	"github.com/jmmaloney4/sector7/provider/internal/kube"
+)
+
+const (
+	defaultDeployment = "attic"
+	defaultPort       = 8080
+	defaultStoreDir   = "/nix/store"
+)
+
+// Least-privilege admin token scopes, minted per operation. The token is
+// self-contained (no server contact) and scoped to the single cache being
+// operated on.
+var (
+	adminCreateFlags = CachePermissionFlags{Pull: true, CreateCache: true, ConfigureCache: true, ConfigureCacheRetention: true}
+	adminUpdateFlags = CachePermissionFlags{Pull: true, ConfigureCache: true, ConfigureCacheRetention: true}
+	adminDeleteFlags = CachePermissionFlags{Pull: true, DestroyCache: true}
+)
+
+// Cache is an Attic binary cache, administered through the cache-config API
+// reached by in-cluster port-forward.
+type Cache struct {
+	Transport kube.Transport
+}
+
+type CacheArgs struct {
+	Namespace string `pulumi:"namespace"`
+	// HS256SecretBase64 is the server's signing secret; admin tokens are minted
+	// from it locally.
+	HS256SecretBase64     string   `pulumi:"hs256SecretBase64" provider:"secret"`
+	DeploymentName        string   `pulumi:"deploymentName,optional"`
+	Port                  int      `pulumi:"port,optional"`
+	CacheName             string   `pulumi:"cacheName"`
+	IsPublic              bool     `pulumi:"isPublic,optional"`
+	Priority              int      `pulumi:"priority,optional"`
+	StoreDir              string   `pulumi:"storeDir,optional"`
+	UpstreamCacheKeyNames []string `pulumi:"upstreamCacheKeyNames,optional"`
+	// RetentionPeriodSeconds unset means the server default ("Global").
+	RetentionPeriodSeconds *int `pulumi:"retentionPeriodSeconds,optional"`
+}
+
+type CacheState struct {
+	CacheArgs
+	// PublicKey is the NAR-signing key, read back from the cache config. Every
+	// client's trusted-public-keys depends on it, which is why adoption must
+	// never regenerate the keypair.
+	PublicKey string `pulumi:"publicKey"`
+}
+
+func (a *CacheArgs) Annotate(ann infer.Annotator) {
+	ann.SetDefault(&a.DeploymentName, defaultDeployment)
+	ann.SetDefault(&a.Port, defaultPort)
+	ann.SetDefault(&a.StoreDir, defaultStoreDir)
+	ann.SetDefault(&a.IsPublic, true)
+}
+
+func (Cache) Check(ctx context.Context, req infer.CheckRequest) (infer.CheckResponse[CacheArgs], error) {
+	args, failures, err := infer.DefaultCheck[CacheArgs](ctx, req.NewInputs)
+	if err != nil {
+		return infer.CheckResponse[CacheArgs]{Inputs: args, Failures: failures}, err
+	}
+	fail := func(prop, reason string) {
+		failures = append(failures, p.CheckFailure{Property: prop, Reason: reason})
+	}
+	if args.Namespace == "" {
+		fail("namespace", "namespace is required")
+	}
+	if args.HS256SecretBase64 == "" {
+		fail("hs256SecretBase64", "hs256SecretBase64 is required")
+	}
+	if args.CacheName == "" {
+		fail("cacheName", "cacheName is required")
+	}
+	if args.RetentionPeriodSeconds != nil && *args.RetentionPeriodSeconds <= 0 {
+		fail("retentionPeriodSeconds", "retentionPeriodSeconds must be a positive number of seconds")
+	}
+	return infer.CheckResponse[CacheArgs]{Inputs: args, Failures: failures}, nil
+}
+
+func (Cache) Diff(_ context.Context, req infer.DiffRequest[CacheArgs, CacheState]) (p.DiffResponse, error) {
+	olds, news := req.State, req.Inputs
+	diffs := map[string]p.PropertyDiff{}
+
+	// Renaming a cache or changing its store dir is a different cache.
+	if olds.CacheName != news.CacheName {
+		diffs["cacheName"] = p.PropertyDiff{Kind: p.UpdateReplace}
+	}
+	if olds.StoreDir != news.StoreDir {
+		diffs["storeDir"] = p.PropertyDiff{Kind: p.UpdateReplace}
+	}
+
+	// An admin-target change does not alter the remote cache, but must flow into
+	// state so a later update/delete targets the new deployment and mints under
+	// the new secret.
+	if olds.Namespace != news.Namespace ||
+		olds.DeploymentName != news.DeploymentName ||
+		olds.Port != news.Port ||
+		olds.HS256SecretBase64 != news.HS256SecretBase64 {
+		diffs["adminTarget"] = p.PropertyDiff{Kind: p.Update}
+	}
+	if olds.IsPublic != news.IsPublic {
+		diffs["isPublic"] = p.PropertyDiff{Kind: p.Update}
+	}
+	if olds.Priority != news.Priority {
+		diffs["priority"] = p.PropertyDiff{Kind: p.Update}
+	}
+	if !diffutil.StringsEqual(olds.UpstreamCacheKeyNames, news.UpstreamCacheKeyNames) {
+		diffs["upstreamCacheKeyNames"] = p.PropertyDiff{Kind: p.Update}
+	}
+	if !intPtrEqual(olds.RetentionPeriodSeconds, news.RetentionPeriodSeconds) {
+		diffs["retentionPeriodSeconds"] = p.PropertyDiff{Kind: p.Update}
+	}
+
+	return p.DiffResponse{
+		HasChanges:          len(diffs) > 0,
+		DetailedDiff:        diffs,
+		DeleteBeforeReplace: false,
+	}, nil
+}
+
+func intPtrEqual(a, b *int) bool {
+	switch {
+	case a == nil && b == nil:
+		return true
+	case a == nil || b == nil:
+		return false
+	default:
+		return *a == *b
+	}
+}
+
+// RetentionPeriod renders the optional retention into Attic's
+// RetentionPeriodConfig wire form.
+func RetentionPeriod(seconds *int) any {
+	if seconds == nil {
+		return "Global"
+	}
+	return map[string]any{"Period": *seconds}
+}
+
+func buildPatchBody(a CacheArgs) map[string]any {
+	// Deliberately omits keypair (never rotate) and store_dir (immutable in this
+	// model — a change is a replacement), so adoption preserves the existing
+	// signing key and therefore every client's trusted-public-keys.
+	return map[string]any{
+		"is_public":                a.IsPublic,
+		"priority":                 a.Priority,
+		"upstream_cache_key_names": orEmpty(a.UpstreamCacheKeyNames),
+		"retention_period":         RetentionPeriod(a.RetentionPeriodSeconds),
+	}
+}
+
+func orEmpty(s []string) []string {
+	if s == nil {
+		return []string{}
+	}
+	return s
+}
+
+func (c Cache) connect(ctx context.Context, a CacheArgs, flags CachePermissionFlags) (*httpx.Client, func(), error) {
+	now := time.Now().Unix()
+	token, err := MintToken(MintArgs{
+		SecretBase64:     a.HS256SecretBase64,
+		Sub:              "sector7-provider",
+		IssuedAtSeconds:  now,
+		ExpiresAtSeconds: now + 300, // short-lived; this is an admin credential
+		Caches:           map[string]CachePermissionFlags{a.CacheName: flags},
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+
+	conn, err := c.Transport.Connect(ctx, kube.Target{
+		Namespace:  a.Namespace,
+		Deployment: a.DeploymentName,
+		Port:       a.Port,
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+	return &httpx.Client{
+		BaseURL: conn.BaseURL,
+		Bearer:  token,
+		// Attic validates the Host header against its allowed-hosts config, so
+		// the in-cluster Service FQDN must be sent even though the connection is
+		// to 127.0.0.1. Node's fetch treats Host as forbidden and silently drops
+		// it, which is why the TypeScript had to drop to node:http; Go's
+		// net/http honours req.Host, so that workaround disappears.
+		Host:       conn.Host,
+		HTTP:       &http.Client{Transport: &http.Transport{DisableKeepAlives: true}, Timeout: 30 * time.Second},
+		MaxRetries: 3,
+	}, conn.Close, nil
+}
+
+func (c Cache) readPublicKey(ctx context.Context, cl *httpx.Client, cacheName string) (string, error) {
+	var config map[string]any
+	path := "/_api/v1/cache-config/" + cacheName
+	if err := cl.Do(ctx, "GET", path, nil, &config, true); err != nil {
+		return "", err
+	}
+	// Fail fast on a missing key: silently returning "" would persist an
+	// unusable signing key in state and hide a broken or incompatible Attic API.
+	key, _ := config["public_key"].(string)
+	if key == "" {
+		return "", fmt.Errorf("sector7: Attic GET %s returned no public_key — cannot resolve the cache signing key", path)
+	}
+	return key, nil
+}
+
+func (c Cache) Create(ctx context.Context, req infer.CreateRequest[CacheArgs]) (infer.CreateResponse[CacheState], error) {
+	out := infer.CreateResponse[CacheState]{Output: CacheState{CacheArgs: req.Inputs}}
+	if req.DryRun {
+		return out, nil
+	}
+	a := req.Inputs
+
+	cl, done, err := c.connect(ctx, a, adminCreateFlags)
+	if err != nil {
+		return out, err
+	}
+	defer done()
+
+	path := "/_api/v1/cache-config/" + a.CacheName
+	createBody := map[string]any{
+		"keypair":                  "Generate",
+		"is_public":                a.IsPublic,
+		"store_dir":                a.StoreDir,
+		"priority":                 a.Priority,
+		"upstream_cache_key_names": orEmpty(a.UpstreamCacheKeyNames),
+	}
+
+	// Never retried: a retried create after a timeout that actually succeeded
+	// would hit the CacheAlreadyExists path and adopt a cache we just made,
+	// which is harmless — but the create itself is not idempotent server-side.
+	err = cl.Do(ctx, "POST", path, createBody, nil, false)
+	switch {
+	case err == nil:
+		// Created fresh. CreateCacheRequest has no retention field, so a
+		// requested retention needs a follow-up PATCH.
+		if a.RetentionPeriodSeconds != nil {
+			body := map[string]any{"retention_period": RetentionPeriod(a.RetentionPeriodSeconds)}
+			if err := cl.Do(ctx, "PATCH", path, body, nil, true); err != nil {
+				return out, err
+			}
+		}
+
+	case isCacheAlreadyExists(err):
+		// Idempotent adoption: reconcile the existing cache's config in place.
+		// POST is create-only, so going through PATCH preserves the keypair —
+		// and therefore every client's trusted-public-keys.
+		//
+		// First verify the immutable store_dir matches. buildPatchBody omits
+		// store_dir (a change is modelled as a replacement), so adopting a
+		// same-named cache pointing at a different store dir would silently
+		// record the desired storeDir in state while the remote kept its own.
+		//
+		// Fail CLOSED: if the GET does not report a string store_dir we cannot
+		// confirm the immutable field, so refuse rather than adopt an unverified
+		// cache and record an assumed storeDir.
+		var existing map[string]any
+		if err := cl.Do(ctx, "GET", path, nil, &existing, true); err != nil {
+			return out, err
+		}
+		storeDir, ok := existing["store_dir"].(string)
+		if !ok || storeDir != a.StoreDir {
+			return out, fmt.Errorf(
+				"sector7: Attic cache %q already exists but its store_dir (%v) is absent or differs from the requested %q. "+
+					"store_dir is immutable — refusing to adopt; align storeDir or choose a different cacheName",
+				a.CacheName, existing["store_dir"], a.StoreDir)
+		}
+		if err := cl.Do(ctx, "PATCH", path, buildPatchBody(a), nil, true); err != nil {
+			return out, err
+		}
+
+	default:
+		return out, err
+	}
+
+	key, err := c.readPublicKey(ctx, cl, a.CacheName)
+	if err != nil {
+		return out, err
+	}
+	out.ID = a.CacheName
+	out.Output = CacheState{CacheArgs: a, PublicKey: key}
+	return out, nil
+}
+
+// isCacheAlreadyExists recognises Attic's create-collision response: a 400
+// whose body names CacheAlreadyExists.
+func isCacheAlreadyExists(err error) bool {
+	e, ok := err.(*httpx.Error)
+	return ok && e.Status == http.StatusBadRequest && strings.Contains(e.Body, "CacheAlreadyExists")
+}
+
+func (c Cache) Update(ctx context.Context, req infer.UpdateRequest[CacheArgs, CacheState]) (infer.UpdateResponse[CacheState], error) {
+	out := infer.UpdateResponse[CacheState]{Output: CacheState{CacheArgs: req.Inputs, PublicKey: req.State.PublicKey}}
+	if req.DryRun {
+		return out, nil
+	}
+	a := req.Inputs
+
+	cl, done, err := c.connect(ctx, a, adminUpdateFlags)
+	if err != nil {
+		return out, err
+	}
+	defer done()
+
+	path := "/_api/v1/cache-config/" + a.CacheName
+	if err := cl.Do(ctx, "PATCH", path, buildPatchBody(a), nil, true); err != nil {
+		return out, err
+	}
+	key, err := c.readPublicKey(ctx, cl, a.CacheName)
+	if err != nil {
+		return out, err
+	}
+	out.Output.PublicKey = key
+	return out, nil
+}
+
+func (c Cache) Delete(ctx context.Context, req infer.DeleteRequest[CacheState]) (infer.DeleteResponse, error) {
+	name := req.ID
+	if name == "" {
+		name = req.State.CacheName
+	}
+	if name == "" {
+		return infer.DeleteResponse{}, nil
+	}
+
+	cl, done, err := c.connect(ctx, req.State.CacheArgs, adminDeleteFlags)
+	if err != nil {
+		return infer.DeleteResponse{}, err
+	}
+	defer done()
+
+	err = cl.Do(ctx, "DELETE", "/_api/v1/cache-config/"+name, nil, nil, true)
+	if err != nil {
+		// Idempotent delete: a cache already removed out of band means the
+		// desired end state is reached, so do not fail destroy or a replacement.
+		if e, ok := err.(*httpx.Error); ok && e.Status == http.StatusNotFound {
+			return infer.DeleteResponse{}, nil
+		}
+		return infer.DeleteResponse{}, err
+	}
+	return infer.DeleteResponse{}, nil
+}

--- a/provider/attic/cache_test.go
+++ b/provider/attic/cache_test.go
@@ -1,0 +1,206 @@
+package attic
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	pgo "github.com/pulumi/pulumi-go-provider"
+	"github.com/pulumi/pulumi-go-provider/infer"
+
+	"github.com/jmmaloney4/sector7/provider/internal/kube"
+)
+
+type rec struct {
+	Method, Path string
+	Body         map[string]any
+	Host         string
+}
+
+type harness struct {
+	srv *httptest.Server
+	tr  *kube.Fake
+	mu  sync.Mutex
+	Req []rec
+}
+
+func newHarness(t *testing.T, respond func(rec) (int, any)) *harness {
+	t.Helper()
+	h := &harness{}
+	h.srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		e := rec{Method: r.Method, Path: r.URL.Path, Host: r.Host}
+		_ = json.NewDecoder(r.Body).Decode(&e.Body)
+		h.mu.Lock()
+		h.Req = append(h.Req, e)
+		h.mu.Unlock()
+		status, payload := 200, any(map[string]any{})
+		if respond != nil {
+			status, payload = respond(e)
+		}
+		w.WriteHeader(status)
+		_ = json.NewEncoder(w).Encode(payload)
+	}))
+	t.Cleanup(h.srv.Close)
+	h.tr = &kube.Fake{BaseURL: h.srv.URL}
+	return h
+}
+
+func (h *harness) find(m, p string) *rec {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	for i := range h.Req {
+		if h.Req[i].Method == m && h.Req[i].Path == p {
+			return &h.Req[i]
+		}
+	}
+	return nil
+}
+
+func baseCacheArgs() CacheArgs {
+	return CacheArgs{
+		Namespace: "attic", HS256SecretBase64: base64.StdEncoding.EncodeToString([]byte("k")),
+		DeploymentName: "attic", Port: 8080,
+		CacheName: "org-cache", IsPublic: true, Priority: 40, StoreDir: "/nix/store",
+	}
+}
+
+// Adoption must go through PATCH, never POST, so the keypair — and therefore
+// every client's trusted-public-keys — survives.
+func TestCreateAdoptsExistingCacheWithoutRegeneratingTheKeypair(t *testing.T) {
+	h := newHarness(t, func(r rec) (int, any) {
+		switch r.Method {
+		case "POST":
+			return 400, map[string]any{"error": "CacheAlreadyExists"}
+		case "GET":
+			return 200, map[string]any{"store_dir": "/nix/store", "public_key": "org-cache:abc="}
+		}
+		return 200, map[string]any{}
+	})
+
+	resp, err := Cache{Transport: h.tr}.Create(t.Context(),
+		infer.CreateRequest[CacheArgs]{Inputs: baseCacheArgs()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	patch := h.find("PATCH", "/_api/v1/cache-config/org-cache")
+	if patch == nil {
+		t.Fatal("adoption must reconcile via PATCH")
+	}
+	if _, present := patch.Body["keypair"]; present {
+		t.Fatal("PATCH must never carry keypair — that would rotate the signing key")
+	}
+	if _, present := patch.Body["store_dir"]; present {
+		t.Fatal("PATCH must never carry store_dir — it is immutable in this model")
+	}
+	if resp.Output.PublicKey != "org-cache:abc=" {
+		t.Fatalf("public key: %q", resp.Output.PublicKey)
+	}
+}
+
+// Fail CLOSED when the immutable store_dir cannot be confirmed, rather than
+// adopting an unverified cache and recording an assumed storeDir in state.
+func TestCreateRefusesToAdoptOnStoreDirMismatch(t *testing.T) {
+	for _, existing := range []any{
+		map[string]any{"store_dir": "/other/store", "public_key": "k"},
+		map[string]any{"public_key": "k"}, // absent entirely
+	} {
+		h := newHarness(t, func(r rec) (int, any) {
+			if r.Method == "POST" {
+				return 400, map[string]any{"error": "CacheAlreadyExists"}
+			}
+			return 200, existing
+		})
+		_, err := Cache{Transport: h.tr}.Create(t.Context(),
+			infer.CreateRequest[CacheArgs]{Inputs: baseCacheArgs()})
+		if err == nil || !strings.Contains(err.Error(), "store_dir") {
+			t.Fatalf("expected a store_dir refusal, got %v", err)
+		}
+		if h.find("PATCH", "/_api/v1/cache-config/org-cache") != nil {
+			t.Fatal("must not PATCH a cache it refused to adopt")
+		}
+	}
+}
+
+// A missing public_key must fail loudly: persisting "" would record an unusable
+// signing key and hide a broken Attic API.
+func TestCreateFailsWhenPublicKeyIsAbsent(t *testing.T) {
+	h := newHarness(t, func(r rec) (int, any) {
+		if r.Method == "GET" {
+			return 200, map[string]any{"store_dir": "/nix/store"}
+		}
+		return 200, map[string]any{}
+	})
+	_, err := Cache{Transport: h.tr}.Create(t.Context(),
+		infer.CreateRequest[CacheArgs]{Inputs: baseCacheArgs()})
+	if err == nil || !strings.Contains(err.Error(), "public_key") {
+		t.Fatalf("expected a public_key error, got %v", err)
+	}
+}
+
+// Attic validates the Host header against allowed-hosts, so the in-cluster
+// Service FQDN must be sent even though the connection is to 127.0.0.1. Node's
+// fetch silently drops a Host override; Go's net/http honours req.Host.
+func TestSendsTheInClusterServiceFQDNAsHost(t *testing.T) {
+	h := newHarness(t, func(r rec) (int, any) {
+		if r.Method == "GET" {
+			return 200, map[string]any{"store_dir": "/nix/store", "public_key": "k"}
+		}
+		return 200, map[string]any{}
+	})
+	if _, err := (Cache{Transport: h.tr}).Create(t.Context(),
+		infer.CreateRequest[CacheArgs]{Inputs: baseCacheArgs()}); err != nil {
+		t.Fatal(err)
+	}
+	got := h.Req[0].Host
+	if got != "attic.attic.svc.cluster.local" {
+		t.Fatalf("Host header = %q, want the in-cluster Service FQDN", got)
+	}
+}
+
+func TestDeleteToleratesAlreadyGone(t *testing.T) {
+	h := newHarness(t, func(rec) (int, any) { return 404, map[string]any{} })
+	state := CacheState{CacheArgs: baseCacheArgs(), PublicKey: "k"}
+	if _, err := (Cache{Transport: h.tr}).Delete(t.Context(),
+		infer.DeleteRequest[CacheState]{ID: "org-cache", State: state}); err != nil {
+		t.Fatalf("a cache already removed out of band must not fail destroy; got %v", err)
+	}
+}
+
+func TestRetentionPeriodWireForm(t *testing.T) {
+	if got := RetentionPeriod(nil); got != "Global" {
+		t.Fatalf("unset retention must render as Global, got %v", got)
+	}
+	secs := 86400
+	m, ok := RetentionPeriod(&secs).(map[string]any)
+	if !ok || m["Period"] != 86400 {
+		t.Fatalf("set retention must render as {Period: n}, got %v", RetentionPeriod(&secs))
+	}
+}
+
+func TestCacheDiffReplacesOnIdentityOnly(t *testing.T) {
+	old := CacheState{CacheArgs: baseCacheArgs(), PublicKey: "k"}
+
+	renamed := baseCacheArgs()
+	renamed.CacheName = "other"
+	r, _ := Cache{}.Diff(t.Context(), infer.DiffRequest[CacheArgs, CacheState]{State: old, Inputs: renamed})
+	if r.DetailedDiff["cacheName"].Kind != pgo.UpdateReplace {
+		t.Fatal("a rename is a different cache and must replace")
+	}
+
+	// Priority is mutable — must NOT replace, or the keypair is regenerated.
+	repriced := baseCacheArgs()
+	repriced.Priority = 10
+	r, _ = Cache{}.Diff(t.Context(), infer.DiffRequest[CacheArgs, CacheState]{State: old, Inputs: repriced})
+	if !r.HasChanges {
+		t.Fatal("a priority change must be a change")
+	}
+	for k, v := range r.DetailedDiff {
+		if v.Kind == pgo.UpdateReplace {
+			t.Fatalf("a priority change must not replace; %s did", k)
+		}
+	}
+}

--- a/provider/attic/token.go
+++ b/provider/attic/token.go
@@ -1,0 +1,184 @@
+// Package attic implements the sector7 provider's Attic binary-cache
+// resources. Ported from packages/sector7/attic/{admin,token}.ts.
+package attic
+
+import (
+	"bytes"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// ClaimNamespace is the namespace claim Attic reads its grants from.
+const ClaimNamespace = "https://jwt.attic.rs/v1"
+
+// CachePermissionFlags are the per-cache grants.
+type CachePermissionFlags struct {
+	Pull                    bool `pulumi:"pull,optional"`
+	Push                    bool `pulumi:"push,optional"`
+	Delete                  bool `pulumi:"delete,optional"`
+	CreateCache             bool `pulumi:"createCache,optional"`
+	ConfigureCache          bool `pulumi:"configureCache,optional"`
+	ConfigureCacheRetention bool `pulumi:"configureCacheRetention,optional"`
+	DestroyCache            bool `pulumi:"destroyCache,optional"`
+}
+
+// permissionClaim renders flags into Attic's short-key form, emitting only the
+// granted flags (absent means deny) with the INTEGER value 1.
+//
+// Attic deserialises each permission value as an integer, not a JSON boolean —
+// `atticadm make-token --dump-claims` emits {"r":1,"cc":1,…}. Emitting `true`
+// instead makes Attic reject the whole token with 401, because the permission
+// claim fails to deserialise, which silently breaks every minted token. The
+// key order below matches atticadm's.
+func (f CachePermissionFlags) permissionClaim() []kv {
+	var out []kv
+	add := func(k string, on bool) {
+		if on {
+			out = append(out, kv{k, 1})
+		}
+	}
+	add("r", f.Pull)
+	add("w", f.Push)
+	add("d", f.Delete)
+	add("cc", f.CreateCache)
+	add("cr", f.ConfigureCache)
+	add("cq", f.ConfigureCacheRetention)
+	add("cd", f.DestroyCache)
+	return out
+}
+
+type kv struct {
+	Key string
+	Val int
+}
+
+// MintArgs are the inputs to MintToken.
+type MintArgs struct {
+	// SecretBase64 is the server's HS256 secret, base64-encoded. It is decoded
+	// to the raw HMAC key bytes.
+	SecretBase64     string
+	Sub              string
+	IssuedAtSeconds  int64
+	ExpiresAtSeconds int64
+	Caches           map[string]CachePermissionFlags
+}
+
+// MintToken signs an Attic-compatible HS256 JWT entirely in-process.
+//
+// It emits the minimal claim set atticadm produces — sub, nbf, exp, and the
+// namespace claim with a caches map — and signs with HMAC-SHA256 over the
+// base64-DECODED secret bytes. No iss/aud/iat: Attic only enforces
+// issuer/audience when the server is configured with a bound issuer/audience
+// (garden's is not), and leaves iat unset itself.
+//
+// On byte-identity with the TypeScript implementation: it is deliberately not
+// attempted, because it is not achievable and not required. JS preserves object
+// insertion order while Go sorts map keys, so a multi-cache token would serialise
+// differently — but a JWT only has to *verify*, and we sign whatever bytes we
+// emit. This implementation emits deterministically (caches sorted by pattern,
+// permission flags in atticadm's order), which is strictly better than the
+// input-order dependence of the original. Tests therefore decode and verify
+// rather than string-comparing.
+func MintToken(a MintArgs) (string, error) {
+	key, err := base64.StdEncoding.DecodeString(strings.TrimSpace(a.SecretBase64))
+	if err != nil {
+		// Unlike Buffer.from(_, "base64"), Go reports malformed input rather
+		// than silently truncating — same fail-closed intent, earlier.
+		return "", fmt.Errorf("sector7: invalid hs256 secret: %w", err)
+	}
+	// Fail closed on an empty secret: minting with a bad key would produce a
+	// token that looks fine and hides that the root credential is invalid.
+	if len(key) == 0 {
+		return "", fmt.Errorf(
+			"sector7: invalid hs256 secret: decoded to empty bytes (expected a base64-encoded signing secret)")
+	}
+
+	header := []byte(`{"alg":"HS256","typ":"JWT"}`)
+
+	// Built by hand rather than via a map so the claim order is fixed and the
+	// permission values stay integers.
+	var payload bytes.Buffer
+	payload.WriteString(`{"sub":`)
+	writeJSONString(&payload, a.Sub)
+	payload.WriteString(`,"nbf":`)
+	payload.WriteString(strconv.FormatInt(a.IssuedAtSeconds, 10))
+	payload.WriteString(`,"exp":`)
+	payload.WriteString(strconv.FormatInt(a.ExpiresAtSeconds, 10))
+	payload.WriteString(`,`)
+	writeJSONString(&payload, ClaimNamespace)
+	payload.WriteString(`:{"caches":{`)
+
+	patterns := make([]string, 0, len(a.Caches))
+	for k := range a.Caches {
+		patterns = append(patterns, k)
+	}
+	sort.Strings(patterns)
+	for i, pattern := range patterns {
+		if i > 0 {
+			payload.WriteString(",")
+		}
+		writeJSONString(&payload, pattern)
+		payload.WriteString(":{")
+		for j, e := range a.Caches[pattern].permissionClaim() {
+			if j > 0 {
+				payload.WriteString(",")
+			}
+			writeJSONString(&payload, e.Key)
+			payload.WriteString(":")
+			payload.WriteString(strconv.Itoa(e.Val))
+		}
+		payload.WriteString("}")
+	}
+	payload.WriteString(`}}}`)
+
+	enc := base64.RawURLEncoding
+	signingInput := enc.EncodeToString(header) + "." + enc.EncodeToString(payload.Bytes())
+
+	mac := hmac.New(sha256.New, key)
+	mac.Write([]byte(signingInput))
+	return signingInput + "." + enc.EncodeToString(mac.Sum(nil)), nil
+}
+
+func writeJSONString(buf *bytes.Buffer, s string) {
+	b, _ := json.Marshal(s)
+	buf.Write(b)
+}
+
+var durationRe = regexp.MustCompile(`^(\d+)\s*(s|m|h|d|w|y)?$`)
+
+var unitSeconds = map[string]int64{
+	"s": 1, "m": 60, "h": 3600, "d": 86400, "w": 604800, "y": 31536000,
+}
+
+// ParseDurationSeconds accepts a bare number of seconds or a <n><unit> duration
+// with unit s/m/h/d/w/y (e.g. "1y", "90d", "12h", "300s").
+//
+// Non-positive values are rejected: a zero or expired validity mints an
+// immediately-dead token.
+func ParseDurationSeconds(input string) (int64, error) {
+	m := durationRe.FindStringSubmatch(strings.TrimSpace(input))
+	if m == nil {
+		return 0, fmt.Errorf(
+			"sector7: invalid validity duration: %q (expected e.g. \"1y\", \"90d\", \"12h\", or seconds)", input)
+	}
+	n, err := strconv.ParseInt(m[1], 10, 64)
+	if err != nil || n <= 0 {
+		return 0, fmt.Errorf("sector7: invalid validity duration: %q (must be positive)", input)
+	}
+	unit := m[2]
+	if unit == "" {
+		unit = "s"
+	}
+	secs := n * unitSeconds[unit]
+	if secs/unitSeconds[unit] != n { // overflow guard
+		return 0, fmt.Errorf("sector7: validity duration too large: %q", input)
+	}
+	return secs, nil
+}

--- a/provider/attic/token_resource.go
+++ b/provider/attic/token_resource.go
@@ -1,0 +1,160 @@
+package attic
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"time"
+
+	p "github.com/pulumi/pulumi-go-provider"
+	"github.com/pulumi/pulumi-go-provider/infer"
+
+	"github.com/jmmaloney4/sector7/provider/internal/diffutil"
+)
+
+// Token is an Attic access token: a signed, stateless HS256 JWT.
+//
+// It contacts nothing. Minting is entirely local from the server's HS256
+// secret, which is also why Delete is a no-op — there is no server-side record
+// to remove.
+type Token struct{}
+
+type TokenArgs struct {
+	HS256SecretBase64 string `pulumi:"hs256SecretBase64" provider:"secret"`
+	Sub               string `pulumi:"sub"`
+	// ValiditySeconds is stored already parsed, matching the dynamic provider's
+	// state. The TypeScript wrapper parses the public `validity` (e.g. "1y")
+	// before it reaches here, which is what makes Diff compare parsed seconds
+	// rather than raw strings — so "1y" and "365d" are not a spurious replace.
+	ValiditySeconds int                             `pulumi:"validitySeconds"`
+	Caches          map[string]CachePermissionFlags `pulumi:"caches"`
+}
+
+type TokenState struct {
+	TokenArgs
+	Token     string `pulumi:"token" provider:"secret"`
+	ExpiresAt int64  `pulumi:"expiresAt"`
+	NotBefore int64  `pulumi:"notBefore"`
+}
+
+func (Token) Check(ctx context.Context, req infer.CheckRequest) (infer.CheckResponse[TokenArgs], error) {
+	args, failures, err := infer.DefaultCheck[TokenArgs](ctx, req.NewInputs)
+	if err != nil {
+		return infer.CheckResponse[TokenArgs]{Inputs: args, Failures: failures}, err
+	}
+	if args.HS256SecretBase64 == "" {
+		failures = append(failures, p.CheckFailure{Property: "hs256SecretBase64", Reason: "hs256SecretBase64 is required"})
+	}
+	if args.Sub == "" {
+		failures = append(failures, p.CheckFailure{Property: "sub", Reason: "sub is required"})
+	}
+	if args.ValiditySeconds <= 0 {
+		// A zero or negative validity mints an immediately-dead token.
+		failures = append(failures, p.CheckFailure{Property: "validitySeconds", Reason: "validitySeconds must be positive"})
+	}
+	return infer.CheckResponse[TokenArgs]{Inputs: args, Failures: failures}, nil
+}
+
+// Diff: a signed JWT is immutable, so any change to a claim input mints a new
+// token and is therefore a replacement.
+//
+// The baked token/exp/nbf live in state rather than inputs, which is what stops
+// a no-op `up` from churning the token — and churning it would invalidate the
+// copy every consumer already holds.
+func (Token) Diff(_ context.Context, req infer.DiffRequest[TokenArgs, TokenState]) (p.DiffResponse, error) {
+	olds, news := req.State, req.Inputs
+	diffs := map[string]p.PropertyDiff{}
+
+	if olds.HS256SecretBase64 != news.HS256SecretBase64 {
+		diffs["hs256SecretBase64"] = p.PropertyDiff{Kind: p.UpdateReplace}
+	}
+	if olds.Sub != news.Sub {
+		diffs["sub"] = p.PropertyDiff{Kind: p.UpdateReplace}
+	}
+	if olds.ValiditySeconds != news.ValiditySeconds {
+		diffs["validitySeconds"] = p.PropertyDiff{Kind: p.UpdateReplace}
+	}
+	if !cachesEqual(olds.Caches, news.Caches) {
+		diffs["caches"] = p.PropertyDiff{Kind: p.UpdateReplace}
+	}
+
+	return p.DiffResponse{
+		HasChanges:          len(diffs) > 0,
+		DetailedDiff:        diffs,
+		DeleteBeforeReplace: false,
+	}, nil
+}
+
+func cachesEqual(a, b map[string]CachePermissionFlags) bool {
+	return diffutil.StableJSON(a) == diffutil.StableJSON(b)
+}
+
+func (Token) Create(ctx context.Context, req infer.CreateRequest[TokenArgs]) (infer.CreateResponse[TokenState], error) {
+	out := infer.CreateResponse[TokenState]{Output: TokenState{TokenArgs: req.Inputs}}
+	if req.DryRun {
+		return out, nil
+	}
+
+	now := time.Now().Unix()
+	expires := now + int64(req.Inputs.ValiditySeconds)
+	token, err := MintToken(MintArgs{
+		SecretBase64:     req.Inputs.HS256SecretBase64,
+		Sub:              req.Inputs.Sub,
+		IssuedAtSeconds:  now,
+		ExpiresAtSeconds: expires,
+		Caches:           req.Inputs.Caches,
+	})
+	if err != nil {
+		return out, err
+	}
+
+	id, err := opaqueID()
+	if err != nil {
+		return out, err
+	}
+	// The resource id is a random opaque handle — NEVER the token, which is a
+	// bearer credential and would otherwise sit in plaintext in Pulumi state.
+	out.ID = id
+	out.Output = TokenState{TokenArgs: req.Inputs, Token: token, ExpiresAt: expires, NotBefore: now}
+	return out, nil
+}
+
+// Update is reached only if Diff ever reports a non-replace change, which it
+// does not today. Re-mint defensively so outputs stay consistent with inputs.
+func (Token) Update(ctx context.Context, req infer.UpdateRequest[TokenArgs, TokenState]) (infer.UpdateResponse[TokenState], error) {
+	out := infer.UpdateResponse[TokenState]{Output: TokenState{TokenArgs: req.Inputs}}
+	if req.DryRun {
+		return out, nil
+	}
+	now := time.Now().Unix()
+	expires := now + int64(req.Inputs.ValiditySeconds)
+	token, err := MintToken(MintArgs{
+		SecretBase64:     req.Inputs.HS256SecretBase64,
+		Sub:              req.Inputs.Sub,
+		IssuedAtSeconds:  now,
+		ExpiresAtSeconds: expires,
+		Caches:           req.Inputs.Caches,
+	})
+	if err != nil {
+		return out, err
+	}
+	out.Output = TokenState{TokenArgs: req.Inputs, Token: token, ExpiresAt: expires, NotBefore: now}
+	return out, nil
+}
+
+// Delete is a no-op. Attic tokens are stateless JWTs with no server-side record
+// to remove; a token is invalidated only by its exp lapsing or by rotating the
+// shared HS256 secret (which invalidates every token). Dropping the resource
+// stops Pulumi re-issuing it — it cannot revoke a live token.
+func (Token) Delete(context.Context, infer.DeleteRequest[TokenState]) (infer.DeleteResponse, error) {
+	return infer.DeleteResponse{}, nil
+}
+
+func opaqueID() (string, error) {
+	var b [16]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return "", fmt.Errorf("sector7: generating token id: %w", err)
+	}
+	return hex.EncodeToString(b[:]), nil
+}

--- a/provider/attic/token_resource_test.go
+++ b/provider/attic/token_resource_test.go
@@ -1,0 +1,71 @@
+package attic
+
+import (
+	"encoding/base64"
+	"testing"
+
+	pgo "github.com/pulumi/pulumi-go-provider"
+	"github.com/pulumi/pulumi-go-provider/infer"
+)
+
+func baseTokenArgs() TokenArgs {
+	return TokenArgs{
+		HS256SecretBase64: base64.StdEncoding.EncodeToString([]byte("k")),
+		Sub:               "host-bellatrix",
+		ValiditySeconds:   31536000,
+		Caches:            map[string]CachePermissionFlags{"org-cache": {Pull: true}},
+	}
+}
+
+// The id must never be the token. Pulumi stores resource ids in PLAINTEXT, so
+// using a bearer credential as the id would leak it into state and into every
+// `pulumi stack export`.
+func TestCreateIdIsOpaqueNeverTheToken(t *testing.T) {
+	resp, err := Token{}.Create(t.Context(), infer.CreateRequest[TokenArgs]{Inputs: baseTokenArgs()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.ID == "" {
+		t.Fatal("expected an opaque id")
+	}
+	if resp.ID == resp.Output.Token {
+		t.Fatal("the resource id must NEVER be the token — ids are plaintext in state")
+	}
+	if resp.Output.ExpiresAt-resp.Output.NotBefore != 31536000 {
+		t.Fatalf("exp-nbf should equal validitySeconds; got %d", resp.Output.ExpiresAt-resp.Output.NotBefore)
+	}
+}
+
+// Every claim-affecting change replaces, because a signed JWT is immutable.
+// Equally important: nothing else does, or 13 host tokens churn.
+func TestTokenDiffReplacesOnClaimInputsOnly(t *testing.T) {
+	old := TokenState{TokenArgs: baseTokenArgs(), Token: "t", ExpiresAt: 2, NotBefore: 1}
+
+	for name, mutate := range map[string]func(*TokenArgs){
+		"hs256SecretBase64": func(a *TokenArgs) { a.HS256SecretBase64 = base64.StdEncoding.EncodeToString([]byte("other")) },
+		"sub":               func(a *TokenArgs) { a.Sub = "other" },
+		"validitySeconds":   func(a *TokenArgs) { a.ValiditySeconds = 100 },
+		"caches":            func(a *TokenArgs) { a.Caches = map[string]CachePermissionFlags{"org-cache": {Pull: true, Push: true}} },
+	} {
+		news := baseTokenArgs()
+		mutate(&news)
+		r, _ := Token{}.Diff(t.Context(), infer.DiffRequest[TokenArgs, TokenState]{State: old, Inputs: news})
+		if r.DetailedDiff[name].Kind != pgo.UpdateReplace {
+			t.Fatalf("%s must force replacement; got %+v", name, r.DetailedDiff)
+		}
+	}
+
+	// Identical inputs must be a no-op — the baked token/exp/nbf live in state,
+	// so a plain `up` must not re-mint and invalidate every consumer's copy.
+	r, _ := Token{}.Diff(t.Context(), infer.DiffRequest[TokenArgs, TokenState]{State: old, Inputs: baseTokenArgs()})
+	if r.HasChanges {
+		t.Fatalf("an unchanged token must not churn; got %+v", r.DetailedDiff)
+	}
+}
+
+func TestDeleteIsANoOp(t *testing.T) {
+	// A stateless JWT has no server-side record; destroy must not fail trying.
+	if _, err := (Token{}).Delete(t.Context(), infer.DeleteRequest[TokenState]{ID: "x"}); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/provider/attic/token_test.go
+++ b/provider/attic/token_test.go
@@ -1,0 +1,209 @@
+package attic
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func decodeSegment(t *testing.T, seg string) map[string]any {
+	t.Helper()
+	raw, err := base64.RawURLEncoding.DecodeString(seg)
+	if err != nil {
+		t.Fatalf("segment is not base64url without padding: %v", err)
+	}
+	var out map[string]any
+	if err := json.Unmarshal(raw, &out); err != nil {
+		t.Fatalf("segment is not JSON: %v", err)
+	}
+	return out
+}
+
+// THE load-bearing property. Attic deserialises each permission value as an
+// integer, not a boolean — atticadm emits {"r":1,"cc":1,…}. Emitting `true`
+// makes Attic reject the WHOLE token with 401 because the permission claim
+// fails to deserialise, silently breaking every minted token.
+//
+// This is asserted on the raw JSON text, not the decoded value, because
+// encoding/json unmarshals both `1` and `true` into distinguishable Go types
+// only if you look — the raw form is what Attic actually parses.
+func TestPermissionValuesAreIntegersNotBooleans(t *testing.T) {
+	tok, err := MintToken(MintArgs{
+		SecretBase64: base64.StdEncoding.EncodeToString([]byte("supersecret")),
+		Sub:          "ci", IssuedAtSeconds: 1000, ExpiresAtSeconds: 2000,
+		Caches: map[string]CachePermissionFlags{
+			"cache-a": {Pull: true, Push: true, CreateCache: true},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	raw, err := base64.RawURLEncoding.DecodeString(strings.Split(tok, ".")[1])
+	if err != nil {
+		t.Fatal(err)
+	}
+	payload := string(raw)
+	for _, want := range []string{`"r":1`, `"w":1`, `"cc":1`} {
+		if !strings.Contains(payload, want) {
+			t.Fatalf("expected %s in payload, got %s", want, payload)
+		}
+	}
+	if strings.Contains(payload, "true") || strings.Contains(payload, "false") {
+		t.Fatalf("permission values must be integers, never booleans: %s", payload)
+	}
+	// Ungranted flags must be ABSENT, not 0 — absent means deny.
+	for _, absent := range []string{`"d"`, `"cr"`, `"cq"`, `"cd"`} {
+		if strings.Contains(payload, absent) {
+			t.Fatalf("ungranted flag %s must be absent, got %s", absent, payload)
+		}
+	}
+}
+
+func TestTokenStructureAndSignature(t *testing.T) {
+	secret := []byte("hs256-signing-secret")
+	tok, err := MintToken(MintArgs{
+		SecretBase64: base64.StdEncoding.EncodeToString(secret),
+		Sub:          "github-actions-ci", IssuedAtSeconds: 1700000000, ExpiresAtSeconds: 1731536000,
+		Caches: map[string]CachePermissionFlags{"org-cache": {Pull: true}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	parts := strings.Split(tok, ".")
+	if len(parts) != 3 {
+		t.Fatalf("expected three JWT segments, got %d", len(parts))
+	}
+	if strings.ContainsAny(tok, "+/=") {
+		t.Fatalf("segments must be base64url without padding: %s", tok)
+	}
+
+	header := decodeSegment(t, parts[0])
+	if header["alg"] != "HS256" || header["typ"] != "JWT" {
+		t.Fatalf("unexpected header: %v", header)
+	}
+
+	payload := decodeSegment(t, parts[1])
+	if payload["sub"] != "github-actions-ci" {
+		t.Fatalf("sub: %v", payload["sub"])
+	}
+	if payload["nbf"].(float64) != 1700000000 || payload["exp"].(float64) != 1731536000 {
+		t.Fatalf("nbf/exp: %v %v", payload["nbf"], payload["exp"])
+	}
+	// No iss/aud/iat — Attic only enforces issuer/audience when the server is
+	// configured with them, and leaves iat unset itself.
+	for _, k := range []string{"iss", "aud", "iat"} {
+		if _, present := payload[k]; present {
+			t.Fatalf("%s must not be emitted", k)
+		}
+	}
+	ns, ok := payload[ClaimNamespace].(map[string]any)
+	if !ok {
+		t.Fatalf("missing namespace claim %s: %v", ClaimNamespace, payload)
+	}
+	if _, ok := ns["caches"]; !ok {
+		t.Fatalf("namespace claim must carry caches: %v", ns)
+	}
+
+	// Verify the signature is HMAC-SHA256 over the signing input using the
+	// DECODED secret bytes — not the base64 text.
+	mac := hmac.New(sha256.New, secret)
+	mac.Write([]byte(parts[0] + "." + parts[1]))
+	want := base64.RawURLEncoding.EncodeToString(mac.Sum(nil))
+	if parts[2] != want {
+		t.Fatal("signature does not verify against the decoded secret")
+	}
+}
+
+// Fail closed rather than minting a token signed with a bad key, which would
+// look fine and hide that the root credential is invalid.
+func TestMintRejectsEmptySecret(t *testing.T) {
+	for _, s := range []string{"", "   "} {
+		if _, err := MintToken(MintArgs{SecretBase64: s, Sub: "x"}); err == nil {
+			t.Fatalf("expected an error for secret %q", s)
+		}
+	}
+}
+
+func TestMintIsDeterministic(t *testing.T) {
+	args := MintArgs{
+		SecretBase64: base64.StdEncoding.EncodeToString([]byte("k")),
+		Sub:          "s", IssuedAtSeconds: 1, ExpiresAtSeconds: 2,
+		Caches: map[string]CachePermissionFlags{
+			"z": {Pull: true}, "a": {Push: true}, "m": {Delete: true},
+		},
+	}
+	first, err := MintToken(args)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Go map iteration order is randomised per run, so without the explicit
+	// sort this would flake — and a non-deterministic token would churn on
+	// every apply.
+	for range 20 {
+		again, err := MintToken(args)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if again != first {
+			t.Fatal("minting must be deterministic for identical inputs")
+		}
+	}
+}
+
+func TestParseDurationSeconds(t *testing.T) {
+	for _, tc := range []struct {
+		in   string
+		want int64
+	}{
+		{"1y", 31536000}, {"90d", 7776000}, {"12h", 43200},
+		{"300s", 300}, {"300", 300}, {" 2w ", 1209600},
+	} {
+		got, err := ParseDurationSeconds(tc.in)
+		if err != nil || got != tc.want {
+			t.Fatalf("%q → %d, %v; want %d", tc.in, got, err, tc.want)
+		}
+	}
+
+	// Zero and negative mint an immediately-dead token; garbage must not parse.
+	for _, bad := range []string{"0", "0s", "-1", "", "abc", "1x", "1.5h"} {
+		if _, err := ParseDurationSeconds(bad); err == nil {
+			t.Fatalf("expected %q to be rejected", bad)
+		}
+	}
+}
+
+// Byte-for-byte parity with the TypeScript implementation, captured by running
+// its exact logic under node with the same inputs.
+//
+// Cross-checking this matters more here than almost anywhere else in the port:
+// there are 13 live Attic tokens, and they gate every host's binary-cache auth.
+// If a re-mint produced a different credential, every NixOS host would need an
+// agenix re-bootstrap.
+//
+// Single-cache/single-flag inputs are used deliberately: with one entry the
+// map-ordering divergence between JS (insertion order) and Go (sorted) cannot
+// arise, so this isolates the encoding, claim order, base64url form and HMAC
+// exactly. Multi-cache determinism is covered by TestMintIsDeterministic.
+func TestMintMatchesTypeScriptByteForByte(t *testing.T) {
+	const want = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9." +
+		"eyJzdWIiOiJnaXRodWItYWN0aW9ucy1jaSIsIm5iZiI6MTcwMDAwMDAwMCwiZXhwIjoxNzMxNTM2MDAwLCJodHRwczovL2p3dC5hdHRpYy5ycy92MSI6eyJjYWNoZXMiOnsib3JnLWNhY2hlIjp7InIiOjEsInciOjEsImNjIjoxfX19fQ." +
+		"y3o9oLiy2W0p3w0vaeB138pQoNIaGoT7pQW_inA7VaE"
+
+	got, err := MintToken(MintArgs{
+		SecretBase64:     base64.StdEncoding.EncodeToString([]byte("hs256-signing-secret")),
+		Sub:              "github-actions-ci",
+		IssuedAtSeconds:  1700000000,
+		ExpiresAtSeconds: 1731536000,
+		Caches:           map[string]CachePermissionFlags{"org-cache": {Pull: true, Push: true, CreateCache: true}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != want {
+		t.Fatalf("token diverged from the TypeScript implementation:\n got  %s\n want %s", got, want)
+	}
+}

--- a/provider/d1/query.go
+++ b/provider/d1/query.go
@@ -1,0 +1,174 @@
+// Package d1 implements the sector7 provider's Cloudflare D1 resources.
+// Ported from packages/sector7/d1/d1-query.ts.
+package d1
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	p "github.com/pulumi/pulumi-go-provider"
+	"github.com/pulumi/pulumi-go-provider/infer"
+
+	"github.com/jmmaloney4/sector7/provider/internal/httpx"
+)
+
+const apiBase = "https://api.cloudflare.com/client/v4"
+
+// Query executes SQL against a Cloudflare D1 database.
+//
+// Unlike the other sector7 resources this talks to a public API, so it needs no
+// port-forward transport.
+type Query struct {
+	// BaseURL overrides the Cloudflare API endpoint. Tests only.
+	BaseURL string
+}
+
+type QueryArgs struct {
+	AccountID  string `pulumi:"accountId"`
+	DatabaseID string `pulumi:"databaseId"`
+	SQL        string `pulumi:"sql"`
+	APIToken   string `pulumi:"apiToken" provider:"secret"`
+}
+
+type QueryState struct {
+	QueryArgs
+	// SQLHash is the SHA-256 of the SQL last executed, used to detect changes
+	// between runs.
+	SQLHash string `pulumi:"sqlHash"`
+}
+
+func (Query) Check(ctx context.Context, req infer.CheckRequest) (infer.CheckResponse[QueryArgs], error) {
+	args, failures, err := infer.DefaultCheck[QueryArgs](ctx, req.NewInputs)
+	if err != nil {
+		return infer.CheckResponse[QueryArgs]{Inputs: args, Failures: failures}, err
+	}
+	if strings.TrimSpace(args.SQL) == "" {
+		failures = append(failures, p.CheckFailure{Property: "sql", Reason: "SQL must be a non-empty string"})
+	}
+	for _, f := range []struct{ name, val string }{
+		{"accountId", args.AccountID},
+		{"databaseId", args.DatabaseID},
+		{"apiToken", args.APIToken},
+	} {
+		if f.val == "" {
+			failures = append(failures, p.CheckFailure{Property: f.name, Reason: f.name + " is required"})
+		}
+	}
+	return infer.CheckResponse[QueryArgs]{Inputs: args, Failures: failures}, nil
+}
+
+func (Query) Diff(_ context.Context, req infer.DiffRequest[QueryArgs, QueryState]) (p.DiffResponse, error) {
+	olds, news := req.State, req.Inputs
+	diffs := map[string]p.PropertyDiff{}
+
+	// Changing the target database, or the SQL itself, means a different
+	// statement to run — replacement re-executes it.
+	if olds.AccountID != news.AccountID {
+		diffs["accountId"] = p.PropertyDiff{Kind: p.UpdateReplace}
+	}
+	if olds.DatabaseID != news.DatabaseID {
+		diffs["databaseId"] = p.PropertyDiff{Kind: p.UpdateReplace}
+	}
+	if olds.SQL != news.SQL {
+		diffs["sql"] = p.PropertyDiff{Kind: p.UpdateReplace}
+	}
+	// A token rotation only changes the credential used, so it re-executes
+	// in place rather than replacing.
+	if olds.APIToken != news.APIToken {
+		diffs["apiToken"] = p.PropertyDiff{Kind: p.Update}
+	}
+
+	replaces := 0
+	for _, d := range diffs {
+		if d.Kind == p.UpdateReplace {
+			replaces++
+		}
+	}
+	return p.DiffResponse{
+		HasChanges:          len(diffs) > 0,
+		DetailedDiff:        diffs,
+		DeleteBeforeReplace: replaces > 0,
+	}, nil
+}
+
+func (q Query) execute(ctx context.Context, a QueryArgs) error {
+	base := q.BaseURL
+	if base == "" {
+		base = apiBase
+	}
+	c := &httpx.Client{
+		BaseURL:    base,
+		Bearer:     a.APIToken,
+		HTTP:       &http.Client{Transport: &http.Transport{DisableKeepAlives: true}, Timeout: 60 * time.Second},
+		MaxRetries: 3,
+	}
+
+	var resp struct {
+		Success bool `json:"success"`
+		Errors  []struct {
+			Message string `json:"message"`
+		} `json:"errors"`
+	}
+	path := fmt.Sprintf("/accounts/%s/d1/database/%s/query", a.AccountID, a.DatabaseID)
+	// Not retried: the statement may not be idempotent. Callers use
+	// CREATE TABLE IF NOT EXISTS style DDL, but that is a convention, not a
+	// guarantee the provider can rely on.
+	if err := c.Do(ctx, "POST", path, map[string]any{"sql": a.SQL}, &resp, false); err != nil {
+		return err
+	}
+	// Cloudflare answers 200 with success:false for query-level failures, so a
+	// 2xx is not sufficient.
+	if !resp.Success {
+		msgs := make([]string, 0, len(resp.Errors))
+		for _, e := range resp.Errors {
+			msgs = append(msgs, e.Message)
+		}
+		if len(msgs) == 0 {
+			msgs = append(msgs, "unknown error")
+		}
+		return fmt.Errorf("sector7: D1 query failed: %s", strings.Join(msgs, "; "))
+	}
+	return nil
+}
+
+func sqlHash(sql string) string {
+	sum := sha256.Sum256([]byte(sql))
+	return hex.EncodeToString(sum[:])
+}
+
+func (q Query) Create(ctx context.Context, req infer.CreateRequest[QueryArgs]) (infer.CreateResponse[QueryState], error) {
+	out := infer.CreateResponse[QueryState]{Output: QueryState{QueryArgs: req.Inputs}}
+	if req.DryRun {
+		return out, nil
+	}
+	if err := q.execute(ctx, req.Inputs); err != nil {
+		return out, err
+	}
+	h := sqlHash(req.Inputs.SQL)
+	out.ID = fmt.Sprintf("d1query:%s:%s", req.Inputs.DatabaseID, h[:12])
+	out.Output = QueryState{QueryArgs: req.Inputs, SQLHash: h}
+	return out, nil
+}
+
+func (q Query) Update(ctx context.Context, req infer.UpdateRequest[QueryArgs, QueryState]) (infer.UpdateResponse[QueryState], error) {
+	out := infer.UpdateResponse[QueryState]{Output: QueryState{QueryArgs: req.Inputs, SQLHash: sqlHash(req.Inputs.SQL)}}
+	if req.DryRun {
+		return out, nil
+	}
+	if err := q.execute(ctx, req.Inputs); err != nil {
+		return out, err
+	}
+	return out, nil
+}
+
+// Delete is a no-op: schema data persists after the resource is removed, and D1
+// databases outlive individual Pulumi stacks. Dropping the resource stops
+// Pulumi re-running the statement; it does not undo it.
+func (Query) Delete(context.Context, infer.DeleteRequest[QueryState]) (infer.DeleteResponse, error) {
+	return infer.DeleteResponse{}, nil
+}

--- a/provider/d1/query_test.go
+++ b/provider/d1/query_test.go
@@ -1,0 +1,91 @@
+package d1
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	pgo "github.com/pulumi/pulumi-go-provider"
+	"github.com/pulumi/pulumi-go-provider/infer"
+)
+
+func args() QueryArgs {
+	return QueryArgs{AccountID: "acct", DatabaseID: "db", SQL: "CREATE TABLE IF NOT EXISTS t (id INT)", APIToken: "tok"}
+}
+
+// Cloudflare answers HTTP 200 with success:false for query-level failures, so a
+// 2xx is not sufficient — this is the easiest thing to get wrong in the port,
+// and getting it wrong means silently recording a schema migration that never
+// ran.
+func TestQueryLevelFailureIsAnErrorDespiteHTTP200(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"success": false,
+			"errors":  []any{map[string]any{"message": "no such table"}, map[string]any{"message": "near \"FROM\""}},
+		})
+	}))
+	defer srv.Close()
+
+	_, err := Query{BaseURL: srv.URL}.Create(t.Context(), infer.CreateRequest[QueryArgs]{Inputs: args()})
+	if err == nil {
+		t.Fatal("success:false must be an error even with HTTP 200")
+	}
+	// All error messages are joined, not just the first.
+	if !strings.Contains(err.Error(), "no such table") || !strings.Contains(err.Error(), "near") {
+		t.Fatalf("every error message must surface; got %v", err)
+	}
+}
+
+func TestCreateExecutesAndDerivesID(t *testing.T) {
+	var gotSQL string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]any
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		gotSQL, _ = body["sql"].(string)
+		_ = json.NewEncoder(w).Encode(map[string]any{"success": true})
+	}))
+	defer srv.Close()
+
+	resp, err := Query{BaseURL: srv.URL}.Create(t.Context(), infer.CreateRequest[QueryArgs]{Inputs: args()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gotSQL != args().SQL {
+		t.Fatalf("SQL not sent: %q", gotSQL)
+	}
+	if !strings.HasPrefix(resp.ID, "d1query:db:") {
+		t.Fatalf("id: %q", resp.ID)
+	}
+	if len(resp.Output.SQLHash) != 64 {
+		t.Fatalf("sqlHash should be a full sha256 hex digest; got %d chars", len(resp.Output.SQLHash))
+	}
+}
+
+func TestDiffReplacesOnStatementIdentityButNotOnToken(t *testing.T) {
+	old := QueryState{QueryArgs: args(), SQLHash: "h"}
+
+	changed := args()
+	changed.SQL = "SELECT 1"
+	r, _ := Query{}.Diff(t.Context(), infer.DiffRequest[QueryArgs, QueryState]{State: old, Inputs: changed})
+	if r.DetailedDiff["sql"].Kind != pgo.UpdateReplace || !r.DeleteBeforeReplace {
+		t.Fatalf("a SQL change must replace, deleting first; got %+v", r)
+	}
+
+	// A token rotation only changes the credential, so it re-executes in place.
+	rotated := args()
+	rotated.APIToken = "new"
+	r, _ = Query{}.Diff(t.Context(), infer.DiffRequest[QueryArgs, QueryState]{State: old, Inputs: rotated})
+	if !r.HasChanges || r.DetailedDiff["apiToken"].Kind == pgo.UpdateReplace {
+		t.Fatalf("a token rotation must be in-place; got %+v", r.DetailedDiff)
+	}
+}
+
+// Schema data outlives the resource; destroy must not try to undo it.
+func TestDeleteIsANoOp(t *testing.T) {
+	if _, err := (Query{}).Delete(t.Context(), infer.DeleteRequest[QueryState]{ID: "x"}); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/provider/litellm/key_test.go
+++ b/provider/litellm/key_test.go
@@ -397,7 +397,6 @@ func TestKeyDelete(t *testing.T) {
 	})
 }
 
-
 // Delete is marked idempotent so httpx retries it on transport errors. That
 // makes "already gone" reachable: if the first attempt succeeds but its
 // response is lost, the retry sees a 404/400 for a token that no longer exists.

--- a/provider/onepassword/item.go
+++ b/provider/onepassword/item.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"regexp"
 	"sort"
 	"strings"
 	"time"
@@ -115,9 +116,46 @@ func (Item) Check(ctx context.Context, req infer.CheckRequest) (infer.CheckRespo
 				seen[f.Label] = true
 			}
 		}
+
+		// Collation guard. contentHash sorts fields by label to build the
+		// canonical JSON, and the TypeScript it must match sorted with
+		// String.prototype.localeCompare (onepassword/item.ts:293) — ICU
+		// collation, not byte order. The two DISAGREE on mixed case:
+		// localeCompare orders ["LiteLLM-Key","api-token"] as
+		// ["api-token","LiteLLM-Key"]; Go's `<` gives the reverse. A divergence
+		// changes the hash, which shows up as a spurious diff and rewrites a
+		// live secret.
+		//
+		// Reimplementing ICU collation is the wrong fix: it is a large surface
+		// (a fuzz of a case-folding approximation still diverged on 6.6% of
+		// pairs, all involving `_` and `.`), and getting it subtly wrong would
+		// change the hash for items that work correctly today.
+		//
+		// Instead, restrict multi-field items to the domain where the two
+		// orders are provably identical. Byte order and localeCompare agree on
+		// every pair of lowercase-kebab labels (verified by fuzzing 382,534
+		// pairs under node: zero divergences). A single-field item has nothing
+		// to sort, so its hash cannot depend on collation at all — which is why
+		// the guard is skipped there, and why the live `LiteLLM-Key` item is
+		// unaffected.
+		if len(args.Fields) > 1 {
+			for i, f := range args.Fields {
+				if f.Label != "" && !kebabLabel.MatchString(f.Label) {
+					fail(fmt.Sprintf("fields[%d].label", i), fmt.Sprintf(
+						"multi-field items must use lowercase-kebab labels (got %q): "+
+							"field order feeds contentHash, and byte order only matches "+
+							"the TypeScript localeCompare sort within that domain", f.Label))
+				}
+			}
+		}
 	}
 	return infer.CheckResponse[ItemArgs]{Inputs: args, Failures: failures}, nil
 }
+
+// kebabLabel is the collation-safe label domain: lowercase alphanumerics and
+// interior hyphens. Matches the lowercase-kebab contract garden's gateway
+// already enforces on the only live multi-field item.
+var kebabLabel = regexp.MustCompile(`^[a-z0-9]([a-z0-9-]*[a-z0-9])?$`)
 
 func (Item) Diff(_ context.Context, req infer.DiffRequest[ItemArgs, ItemState]) (p.DiffResponse, error) {
 	olds, news := req.State, req.Inputs

--- a/provider/onepassword/item.go
+++ b/provider/onepassword/item.go
@@ -8,6 +8,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -461,12 +462,16 @@ func (i Item) Delete(ctx context.Context, req infer.DeleteRequest[ItemState]) (i
 	return infer.DeleteResponse{}, nil
 }
 
+// asHTTPError unwraps err to an *httpx.Error.
+//
+// errors.As, not a bare type assertion: httpx returns *Error unwrapped today,
+// but one fmt.Errorf("…: %w") added anywhere in that client would make a bare
+// assertion silently stop matching. The only consumer is Delete's 404-tolerance
+// branch, and losing it does not look like a bug — it is `pulumi destroy`
+// failing on an item that was already removed out of band, which keeps the
+// resource in state and reds every subsequent `up`.
 func asHTTPError(err error, into **httpx.Error) bool {
-	e, ok := err.(*httpx.Error)
-	if ok {
-		*into = e
-	}
-	return ok
+	return errors.As(err, into)
 }
 
 func fieldsToAny(fields []Field) []any {

--- a/provider/onepassword/item.go
+++ b/provider/onepassword/item.go
@@ -1,0 +1,492 @@
+// Package onepassword implements the sector7 provider's 1Password Connect
+// resources. Ported from packages/sector7/onepassword/item.ts.
+package onepassword
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"sort"
+	"strings"
+	"time"
+
+	p "github.com/pulumi/pulumi-go-provider"
+	"github.com/pulumi/pulumi-go-provider/infer"
+
+	"github.com/jmmaloney4/sector7/provider/internal/httpx"
+	"github.com/jmmaloney4/sector7/provider/internal/kube"
+)
+
+const (
+	defaultDeployment = "onepassword-connect"
+	defaultPort       = 8080
+	defaultCategory   = "PASSWORD"
+	defaultFieldType  = "CONCEALED"
+)
+
+// Item is a 1Password item managed through a Connect server reached by
+// in-cluster port-forward.
+type Item struct {
+	Transport kube.Transport
+}
+
+// Field is one managed field on the item.
+type Field struct {
+	Label string `pulumi:"label"`
+	// Value is secret. infer's secret walker recurses into nested structs, so
+	// tagging it here does reach the schema — verified against
+	// infer/apply_secrets.go.
+	Value   string `pulumi:"value" provider:"secret"`
+	Type    string `pulumi:"type,optional"`
+	Purpose string `pulumi:"purpose,optional"`
+}
+
+type ItemArgs struct {
+	// Kubeconfig is YAML; empty means the ambient default config.
+	Kubeconfig     string  `pulumi:"kubeconfig,optional" provider:"secret"`
+	ConnectToken   string  `pulumi:"connectToken" provider:"secret"`
+	Namespace      string  `pulumi:"namespace"`
+	DeploymentName string  `pulumi:"deploymentName,optional"`
+	ConnectPort    int     `pulumi:"connectPort,optional"`
+	Vault          string  `pulumi:"vault"`
+	Title          string  `pulumi:"title"`
+	Category       string  `pulumi:"category,optional"`
+	Fields         []Field `pulumi:"fields"`
+}
+
+type ItemState struct {
+	ItemArgs
+	UUID     string `pulumi:"uuid"`
+	ItemPath string `pulumi:"itemPath"`
+	// ContentHash is secret: it is a SHA-256 over the field values, so exposing
+	// it would give an offline oracle for guessing them.
+	ContentHash string `pulumi:"contentHash" provider:"secret"`
+	// ManagedLabels records which labels this resource owns, so a later update
+	// can remove ones dropped from input without touching unmanaged fields.
+	ManagedLabels []string `pulumi:"managedLabels"`
+}
+
+func (a *ItemArgs) Annotate(ann infer.Annotator) {
+	ann.SetDefault(&a.DeploymentName, defaultDeployment)
+	ann.SetDefault(&a.ConnectPort, defaultPort)
+	ann.SetDefault(&a.Category, defaultCategory)
+}
+
+func (Item) Check(ctx context.Context, req infer.CheckRequest) (infer.CheckResponse[ItemArgs], error) {
+	args, failures, err := infer.DefaultCheck[ItemArgs](ctx, req.NewInputs)
+	if err != nil {
+		return infer.CheckResponse[ItemArgs]{Inputs: args, Failures: failures}, err
+	}
+	fail := func(prop, reason string) {
+		failures = append(failures, p.CheckFailure{Property: prop, Reason: reason})
+	}
+	if args.ConnectToken == "" {
+		fail("connectToken", "connectToken is required")
+	}
+	if args.Namespace == "" {
+		fail("namespace", "namespace is required")
+	}
+	if args.Vault == "" {
+		fail("vault", "vault is required")
+	}
+	if strings.TrimSpace(args.Title) == "" {
+		fail("title", "title must be a non-empty string")
+	}
+	if len(args.Fields) == 0 {
+		fail("fields", "at least one field is required")
+	} else {
+		seen := map[string]bool{}
+		for i, f := range args.Fields {
+			switch {
+			case f.Label == "":
+				fail(fmt.Sprintf("fields[%d].label", i), "field label is required")
+			case seen[f.Label]:
+				// Fields are keyed by label when merged into the item, so
+				// duplicates would silently collapse (last write wins) and
+				// corrupt drift detection.
+				fail(fmt.Sprintf("fields[%d].label", i), "duplicate field label: "+f.Label)
+			default:
+				seen[f.Label] = true
+			}
+		}
+	}
+	return infer.CheckResponse[ItemArgs]{Inputs: args, Failures: failures}, nil
+}
+
+func (Item) Diff(_ context.Context, req infer.DiffRequest[ItemArgs, ItemState]) (p.DiffResponse, error) {
+	olds, news := req.State, req.Inputs
+	diffs := map[string]p.PropertyDiff{}
+
+	// Identity is vault + title — the adoption key. A change there is a
+	// different item, so it forces replacement.
+	if olds.Vault != news.Vault {
+		diffs["vault"] = p.PropertyDiff{Kind: p.UpdateReplace}
+	}
+	if olds.Title != news.Title {
+		diffs["title"] = p.PropertyDiff{Kind: p.UpdateReplace}
+	}
+
+	hash, err := ContentHash(news.Category, news.Fields)
+	if err != nil {
+		return p.DiffResponse{}, err
+	}
+	if hash != olds.ContentHash {
+		diffs["fields"] = p.PropertyDiff{Kind: p.Update}
+	}
+
+	// Transport inputs do not change the item, so they never force replacement —
+	// but they MUST still trigger an in-place update, or a token rotation or
+	// cluster move is dropped and the stale value persists in state, breaking a
+	// later update/delete.
+	if olds.ConnectToken != news.ConnectToken ||
+		olds.Kubeconfig != news.Kubeconfig ||
+		olds.Namespace != news.Namespace ||
+		olds.DeploymentName != news.DeploymentName ||
+		olds.ConnectPort != news.ConnectPort {
+		diffs["transport"] = p.PropertyDiff{Kind: p.Update}
+	}
+
+	return p.DiffResponse{
+		HasChanges:   len(diffs) > 0,
+		DetailedDiff: diffs,
+		// Never delete-before-replace: a value or identity change must not drop
+		// the item out from under consumers that reference it by path
+		// mid-update.
+		DeleteBeforeReplace: false,
+	}, nil
+}
+
+// ContentHash reproduces computeContentHash from item.ts.
+//
+// This MUST be byte-identical to the TypeScript, or every existing item shows a
+// spurious diff on the first apply after migration. Two Go/JS divergences are
+// handled explicitly:
+//
+//   - Field order. Go's encoding/json sorts map keys alphabetically; JS
+//     JSON.stringify uses insertion order. A struct with fields declared in the
+//     TS order reproduces it.
+//   - HTML escaping. Go escapes <, > and & by default; JS does not. Disabled
+//     via Encoder.SetEscapeHTML(false).
+//
+// Sorting note: the TS sorts labels with localeCompare, which is not byte order
+// for non-ASCII labels. Every label in use today is ASCII, where the two agree.
+// A golden test pins the exact digest.
+func ContentHash(category string, fields []Field) (string, error) {
+	type canonicalField struct {
+		Label   string  `json:"label"`
+		Value   string  `json:"value"`
+		Type    string  `json:"type"`
+		Purpose *string `json:"purpose"`
+	}
+	type canonical struct {
+		Category string           `json:"category"`
+		Fields   []canonicalField `json:"fields"`
+	}
+
+	if category == "" {
+		category = defaultCategory
+	}
+	out := canonical{Category: category, Fields: make([]canonicalField, 0, len(fields))}
+	for _, f := range fields {
+		ft := f.Type
+		if ft == "" {
+			ft = defaultFieldType
+		}
+		var purpose *string
+		if f.Purpose != "" {
+			pv := f.Purpose
+			purpose = &pv
+		}
+		out.Fields = append(out.Fields, canonicalField{
+			Label: f.Label, Value: f.Value, Type: ft, Purpose: purpose,
+		})
+	}
+	sort.SliceStable(out.Fields, func(i, j int) bool {
+		return out.Fields[i].Label < out.Fields[j].Label
+	})
+
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	enc.SetEscapeHTML(false)
+	if err := enc.Encode(out); err != nil {
+		return "", err
+	}
+	// Encode appends a newline that JSON.stringify does not produce.
+	sum := sha256.Sum256(bytes.TrimRight(buf.Bytes(), "\n"))
+	return hex.EncodeToString(sum[:]), nil
+}
+
+func (i Item) connect(ctx context.Context, a ItemArgs) (*httpx.Client, func(), error) {
+	conn, err := i.Transport.Connect(ctx, kube.Target{
+		Kubeconfig: a.Kubeconfig,
+		Namespace:  a.Namespace,
+		Deployment: a.DeploymentName,
+		Port:       a.ConnectPort,
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+	return &httpx.Client{
+		BaseURL:    conn.BaseURL,
+		Bearer:     a.ConnectToken,
+		HTTP:       &http.Client{Transport: &http.Transport{DisableKeepAlives: true}, Timeout: 30 * time.Second},
+		MaxRetries: 3,
+	}, conn.Close, nil
+}
+
+// findItemIDByTitle adopts by title, refusing ambiguity.
+//
+// Titles are NOT unique within a vault, so adopting an arbitrary match could
+// overwrite — or later delete — an unrelated, manually-created secret in a
+// shared vault. Exactly one match adopts, zero creates, more than one is a hard
+// error the operator must resolve. Same authorization reasoning as LiteLLM team
+// aliases.
+func (i Item) findItemIDByTitle(ctx context.Context, c *httpx.Client, vault, title string) (string, error) {
+	filter := url.QueryEscape(fmt.Sprintf(`title eq "%s"`, strings.ReplaceAll(title, `"`, `\"`)))
+	var items []map[string]any
+	if err := c.Do(ctx, "GET", fmt.Sprintf("/v1/vaults/%s/items?filter=%s", vault, filter), nil, &items, true); err != nil {
+		return "", err
+	}
+	// Re-check the title exactly; do not trust the server filter to be strict.
+	var matches []map[string]any
+	for _, it := range items {
+		if t, _ := it["title"].(string); t == title {
+			matches = append(matches, it)
+		}
+	}
+	if len(matches) > 1 {
+		return "", fmt.Errorf(
+			"sector7: 1Password vault %s contains %d items titled %q; refusing to adopt ambiguously. "+
+				"Remove the duplicate(s) or give this item a unique title", vault, len(matches), title)
+	}
+	if len(matches) == 0 {
+		return "", nil
+	}
+	id, _ := matches[0]["id"].(string)
+	return id, nil
+}
+
+func managedField(f Field) map[string]any {
+	ft := f.Type
+	if ft == "" {
+		ft = defaultFieldType
+	}
+	m := map[string]any{"label": f.Label, "type": ft, "value": f.Value}
+	if f.Purpose != "" {
+		m["purpose"] = f.Purpose
+	}
+	return m
+}
+
+// buildMergedItemBody upserts the managed fields into whatever the item already
+// has, so unmanaged fields, sections, urls and tags survive. A blind rebuild
+// would silently drop them — which matters most when adopting a pre-existing,
+// hand-created item.
+func buildMergedItemBody(existing map[string]any, a ItemArgs, id string, priorManagedLabels []string) map[string]any {
+	byLabel := map[string]map[string]any{}
+	order := []string{}
+	if raw, ok := existing["fields"].([]any); ok {
+		for _, e := range raw {
+			if f, ok := e.(map[string]any); ok {
+				if l, _ := f["label"].(string); l != "" {
+					if _, seen := byLabel[l]; !seen {
+						order = append(order, l)
+					}
+					byLabel[l] = f
+				}
+			}
+		}
+	}
+
+	// Remove fields we previously managed that are no longer declared, so the
+	// item reconciles to the declared state. Fields we never managed are left
+	// alone.
+	declared := map[string]bool{}
+	for _, f := range a.Fields {
+		declared[f.Label] = true
+	}
+	for _, l := range priorManagedLabels {
+		if !declared[l] {
+			delete(byLabel, l)
+		}
+	}
+
+	for _, f := range a.Fields {
+		merged := map[string]any{}
+		for k, v := range byLabel[f.Label] {
+			merged[k] = v
+		}
+		for k, v := range managedField(f) {
+			merged[k] = v
+		}
+		if _, seen := byLabel[f.Label]; !seen {
+			order = append(order, f.Label)
+		}
+		byLabel[f.Label] = merged
+	}
+
+	fields := make([]any, 0, len(byLabel))
+	for _, l := range order {
+		if f, ok := byLabel[l]; ok {
+			fields = append(fields, f)
+		}
+	}
+
+	body := map[string]any{}
+	for k, v := range existing {
+		body[k] = v
+	}
+	body["id"] = id
+	body["vault"] = map[string]any{"id": a.Vault}
+	body["title"] = a.Title
+	body["category"] = a.Category
+	body["fields"] = fields
+	return body
+}
+
+func (i Item) Create(ctx context.Context, req infer.CreateRequest[ItemArgs]) (infer.CreateResponse[ItemState], error) {
+	out := infer.CreateResponse[ItemState]{Output: ItemState{ItemArgs: req.Inputs}}
+	if req.DryRun {
+		return out, nil
+	}
+	a := req.Inputs
+
+	c, done, err := i.connect(ctx, a)
+	if err != nil {
+		return out, err
+	}
+	defer done()
+
+	// Find-or-create. Adoption is what makes a safe cutover from a hand-created
+	// or otherwise unmanaged item possible.
+	existing, err := i.findItemIDByTitle(ctx, c, a.Vault, a.Title)
+	if err != nil {
+		return out, err
+	}
+
+	uuid := existing
+	if existing != "" {
+		var current map[string]any
+		if err := c.Do(ctx, "GET", fmt.Sprintf("/v1/vaults/%s/items/%s", a.Vault, existing), nil, &current, true); err != nil {
+			return out, err
+		}
+		// First reconcile of an adopted item: we have no record of what we
+		// managed before, so remove nothing — only upsert.
+		body := buildMergedItemBody(current, a, existing, nil)
+		if err := c.Do(ctx, "PUT", fmt.Sprintf("/v1/vaults/%s/items/%s", a.Vault, existing), body, nil, true); err != nil {
+			return out, err
+		}
+	} else {
+		body := map[string]any{
+			"vault":    map[string]any{"id": a.Vault},
+			"title":    a.Title,
+			"category": a.Category,
+			"fields":   fieldsToAny(a.Fields),
+		}
+		var created map[string]any
+		// Never retried: a retried create after a timeout that actually
+		// succeeded would leave a duplicate item, which findItemIDByTitle would
+		// then refuse to adopt as ambiguous.
+		if err := c.Do(ctx, "POST", fmt.Sprintf("/v1/vaults/%s/items", a.Vault), body, &created, false); err != nil {
+			return out, err
+		}
+		uuid, _ = created["id"].(string)
+		if uuid == "" {
+			return out, fmt.Errorf("sector7: 1Password Connect create returned no item id")
+		}
+	}
+
+	hash, err := ContentHash(a.Category, a.Fields)
+	if err != nil {
+		return out, err
+	}
+	out.ID = uuid
+	out.Output = stateOuts(a, uuid, hash)
+	return out, nil
+}
+
+func (i Item) Update(ctx context.Context, req infer.UpdateRequest[ItemArgs, ItemState]) (infer.UpdateResponse[ItemState], error) {
+	a := req.Inputs
+	hash, err := ContentHash(a.Category, a.Fields)
+	if err != nil {
+		return infer.UpdateResponse[ItemState]{}, err
+	}
+	out := infer.UpdateResponse[ItemState]{Output: stateOuts(a, req.ID, hash)}
+	if req.DryRun {
+		return out, nil
+	}
+
+	c, done, err := i.connect(ctx, a)
+	if err != nil {
+		return out, err
+	}
+	defer done()
+
+	var current map[string]any
+	if err := c.Do(ctx, "GET", fmt.Sprintf("/v1/vaults/%s/items/%s", a.Vault, req.ID), nil, &current, true); err != nil {
+		return out, err
+	}
+	// Merge into the live item so unmanaged fields survive, while removing
+	// fields we previously managed but that were dropped from input.
+	body := buildMergedItemBody(current, a, req.ID, req.State.ManagedLabels)
+	if err := c.Do(ctx, "PUT", fmt.Sprintf("/v1/vaults/%s/items/%s", a.Vault, req.ID), body, nil, true); err != nil {
+		return out, err
+	}
+	return out, nil
+}
+
+func (i Item) Delete(ctx context.Context, req infer.DeleteRequest[ItemState]) (infer.DeleteResponse, error) {
+	c, done, err := i.connect(ctx, req.State.ItemArgs)
+	if err != nil {
+		return infer.DeleteResponse{}, err
+	}
+	defer done()
+
+	err = c.Do(ctx, "DELETE", fmt.Sprintf("/v1/vaults/%s/items/%s", req.State.Vault, req.ID), nil, nil, true)
+	if err != nil {
+		// A 404 means the item is already gone — manually removed, or an adopted
+		// pre-existing item deleted externally. Treat it as success so
+		// `pulumi destroy` is idempotent.
+		var he *httpx.Error
+		if ok := asHTTPError(err, &he); ok && he.Status == http.StatusNotFound {
+			return infer.DeleteResponse{}, nil
+		}
+		return infer.DeleteResponse{}, err
+	}
+	return infer.DeleteResponse{}, nil
+}
+
+func asHTTPError(err error, into **httpx.Error) bool {
+	e, ok := err.(*httpx.Error)
+	if ok {
+		*into = e
+	}
+	return ok
+}
+
+func fieldsToAny(fields []Field) []any {
+	out := make([]any, 0, len(fields))
+	for _, f := range fields {
+		out = append(out, managedField(f))
+	}
+	return out
+}
+
+func stateOuts(a ItemArgs, uuid, contentHash string) ItemState {
+	labels := make([]string, 0, len(a.Fields))
+	for _, f := range a.Fields {
+		labels = append(labels, f.Label)
+	}
+	return ItemState{
+		ItemArgs:      a,
+		UUID:          uuid,
+		ItemPath:      fmt.Sprintf("vaults/%s/items/%s", a.Vault, uuid),
+		ContentHash:   contentHash,
+		ManagedLabels: labels,
+	}
+}

--- a/provider/onepassword/item_test.go
+++ b/provider/onepassword/item_test.go
@@ -1,6 +1,13 @@
 package onepassword
 
-import "testing"
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/jmmaloney4/sector7/provider/internal/httpx"
+)
 
 // Golden vector captured from the TypeScript implementation
 // (packages/sector7/onepassword/item.ts, computeContentHash) by running its
@@ -127,5 +134,34 @@ func TestAdoptionRemovesNothing(t *testing.T) {
 	fields, _ := body["fields"].([]any)
 	if len(fields) != 2 {
 		t.Fatalf("adoption must upsert without removing; got %d fields", len(fields))
+	}
+}
+
+// Delete's 404 tolerance is what makes `pulumi destroy` idempotent for an item
+// that was already removed out of band. It hinges on recognising the error, so
+// pin that a WRAPPED *httpx.Error still matches: httpx returns its errors
+// unwrapped today, and a bare type assertion would keep passing until someone
+// adds a single `fmt.Errorf("…: %w")` to that client — at which point destroy
+// starts failing and leaves the resource in state.
+func TestAsHTTPErrorSeesThroughWrapping(t *testing.T) {
+	base := &httpx.Error{Method: "DELETE", Path: "/v1/vaults/v/items/i", Status: http.StatusNotFound}
+
+	for name, err := range map[string]error{
+		"unwrapped": base,
+		"wrapped":   fmt.Errorf("deleting item: %w", base),
+		"twice":     fmt.Errorf("outer: %w", fmt.Errorf("inner: %w", base)),
+	} {
+		t.Run(name, func(t *testing.T) {
+			var he *httpx.Error
+			if !asHTTPError(err, &he) || he.Status != http.StatusNotFound {
+				t.Fatalf("a 404 must be recognised through %s wrapping; got %v", name, he)
+			}
+		})
+	}
+
+	// A non-HTTP error must not be mistaken for one.
+	var he *httpx.Error
+	if asHTTPError(errors.New("dial tcp: connection refused"), &he) {
+		t.Fatal("a transport error must not be treated as an HTTP status")
 	}
 }

--- a/provider/onepassword/item_test.go
+++ b/provider/onepassword/item_test.go
@@ -4,7 +4,11 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"strings"
 	"testing"
+
+	"github.com/pulumi/pulumi-go-provider/infer"
+	"github.com/pulumi/pulumi/sdk/v3/go/property"
 
 	"github.com/jmmaloney4/sector7/provider/internal/httpx"
 )
@@ -163,5 +167,72 @@ func TestAsHTTPErrorSeesThroughWrapping(t *testing.T) {
 	var he *httpx.Error
 	if asHTTPError(errors.New("dial tcp: connection refused"), &he) {
 		t.Fatal("a transport error must not be treated as an HTTP status")
+	}
+}
+
+// ContentHash sorts fields by label, and the TypeScript it must match sorted
+// with localeCompare (item.ts:293) — ICU collation, not byte order. They
+// disagree on mixed case, and a disagreement changes the hash, which surfaces
+// as a spurious diff that REWRITES A LIVE SECRET.
+//
+// Rather than reimplement ICU collation, Check restricts multi-field items to
+// the domain where the two orders are provably identical. These cases pin that
+// boundary; the JS side of each was confirmed under node.
+func TestCheckGuardsCollationUnsafeLabels(t *testing.T) {
+	labelFailures := func(fields ...string) []string {
+		vals := []property.Value{}
+		for _, l := range fields {
+			vals = append(vals, property.New(map[string]property.Value{
+				"label": property.New(l), "value": property.New("v"),
+			}))
+		}
+		resp, err := Item{}.Check(t.Context(), infer.CheckRequest{
+			NewInputs: property.NewMap(map[string]property.Value{
+				"connectToken": property.New("t"),
+				"namespace":    property.New("1password"),
+				"vault":        property.New("v"),
+				"title":        property.New("item"),
+				"fields":       property.New(vals),
+			}),
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		var out []string
+		for _, f := range resp.Failures {
+			if strings.Contains(string(f.Property), ".label") {
+				out = append(out, string(f.Property))
+			}
+		}
+		return out
+	}
+
+	// A single field has nothing to sort, so its hash cannot depend on
+	// collation. This is why the live `LiteLLM-Key` item is unaffected — the
+	// guard must NOT fire here.
+	if got := labelFailures("LiteLLM-Key"); len(got) != 0 {
+		t.Fatalf("a single-field item has no sort and must not be constrained; got %v", got)
+	}
+
+	// The live multi-field item (gateway's mcp-consumer-tokens). Both orders
+	// agree, so it must keep passing.
+	if got := labelFailures("goose", "hermes", "claude-code"); len(got) != 0 {
+		t.Fatalf("lowercase-kebab labels are collation-safe; got %v", got)
+	}
+
+	// node: ["LiteLLM-Key","api-token"].sort(localeCompare) => ["api-token","LiteLLM-Key"]
+	//       byte order                                      => ["LiteLLM-Key","api-token"]
+	// Mixed case is the real trigger — not non-ASCII, which is what makes this
+	// easy to miss.
+	if got := labelFailures("LiteLLM-Key", "api-token"); len(got) != 1 {
+		t.Fatalf("mixed-case labels in a multi-field item must fail check; got %v", got)
+	}
+	if got := labelFailures("Alpha", "beta"); len(got) != 1 {
+		t.Fatalf("a capitalised label must fail check; got %v", got)
+	}
+	// Underscores and dots are where a case-folding approximation of
+	// localeCompare diverges, so they are outside the safe domain too.
+	if got := labelFailures("a_b", "ab"); len(got) != 1 {
+		t.Fatalf("underscored labels must fail check; got %v", got)
 	}
 }

--- a/provider/onepassword/item_test.go
+++ b/provider/onepassword/item_test.go
@@ -1,0 +1,131 @@
+package onepassword
+
+import "testing"
+
+// Golden vector captured from the TypeScript implementation
+// (packages/sector7/onepassword/item.ts, computeContentHash) by running its
+// exact logic under node:
+//
+//	canonical: {"category":"API_CREDENTIAL","fields":[{"label":"alpha","value":"p1","type":"STRING","purpose":"USERNAME"},{"label":"mid","value":"\"quoted\"","type":"CONCEALED","purpose":null},{"label":"zebra","value":"a&b<c>d","type":"CONCEALED","purpose":null}]}
+//	sha256:    59a504868fc682a67d70d9ae2371754aa16eb78bd98b99aa09a9c4e6b10cf538
+//
+// contentHash drives Diff, so a single byte of divergence makes every existing
+// item show a spurious change on the first apply after migration — and for
+// OnePasswordItem that means rewriting live secrets. The fixture is chosen to
+// catch the two ways Go and JS actually differ:
+//
+//   - `a&b<c>d` — Go's encoding/json escapes &, < and > by default; JS does
+//     not. Caught only if SetEscapeHTML(false) is set.
+//   - out-of-order labels with a mix of defaulted and explicit type/purpose —
+//     catches both the sort and the `?? null` / `?? "CONCEALED"` defaulting.
+//
+// Field ORDER inside each object matters too: Go sorts map keys alphabetically
+// (category, fields / label, purpose, type, value) while JS preserves insertion
+// order, so the canonical form must be built from structs, not maps.
+const goldenHash = "59a504868fc682a67d70d9ae2371754aa16eb78bd98b99aa09a9c4e6b10cf538"
+
+func TestContentHashMatchesTypeScript(t *testing.T) {
+	fields := []Field{
+		{Label: "zebra", Value: "a&b<c>d"},
+		{Label: "alpha", Value: "p1", Type: "STRING", Purpose: "USERNAME"},
+		{Label: "mid", Value: `"quoted"`},
+	}
+	got, err := ContentHash("API_CREDENTIAL", fields)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != goldenHash {
+		t.Fatalf("content hash diverged from the TypeScript implementation:\n got  %s\n want %s", got, goldenHash)
+	}
+}
+
+func TestContentHashIsOrderInsensitive(t *testing.T) {
+	a, err := ContentHash("PASSWORD", []Field{{Label: "x", Value: "1"}, {Label: "y", Value: "2"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	b, err := ContentHash("PASSWORD", []Field{{Label: "y", Value: "2"}, {Label: "x", Value: "1"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if a != b {
+		t.Fatal("reordering fields must not change the content hash")
+	}
+}
+
+func TestContentHashDefaultsCategory(t *testing.T) {
+	withDefault, err := ContentHash("", []Field{{Label: "x", Value: "1"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	explicit, err := ContentHash("PASSWORD", []Field{{Label: "x", Value: "1"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if withDefault != explicit {
+		t.Fatal("an empty category must hash as the PASSWORD default")
+	}
+}
+
+// buildMergedItemBody must preserve everything it does not manage. A blind
+// rebuild would silently drop unmanaged fields, sections, urls and tags — worst
+// when adopting a hand-created item.
+func TestMergedBodyPreservesUnmanagedContent(t *testing.T) {
+	existing := map[string]any{
+		"id":       "abc",
+		"sections": []any{map[string]any{"id": "s1", "label": "Extra"}},
+		"tags":     []any{"manual"},
+		"urls":     []any{map[string]any{"href": "https://example.com"}},
+		"fields": []any{
+			map[string]any{"label": "unmanaged", "value": "keep-me", "type": "STRING"},
+			map[string]any{"label": "managed", "value": "old", "type": "CONCEALED"},
+			map[string]any{"label": "dropped", "value": "gone", "type": "CONCEALED"},
+		},
+	}
+	args := ItemArgs{
+		Vault: "v1", Title: "t", Category: "PASSWORD",
+		Fields: []Field{{Label: "managed", Value: "new"}},
+	}
+
+	body := buildMergedItemBody(existing, args, "abc", []string{"managed", "dropped"})
+
+	for _, k := range []string{"sections", "tags", "urls"} {
+		if _, ok := body[k]; !ok {
+			t.Fatalf("%s must be preserved on the merged body", k)
+		}
+	}
+
+	fields, _ := body["fields"].([]any)
+	got := map[string]string{}
+	for _, f := range fields {
+		m := f.(map[string]any)
+		got[m["label"].(string)] = m["value"].(string)
+	}
+	if got["unmanaged"] != "keep-me" {
+		t.Fatalf("a field this resource never managed must survive; got %v", got)
+	}
+	if got["managed"] != "new" {
+		t.Fatalf("a declared field must be upserted; got %v", got)
+	}
+	if _, present := got["dropped"]; present {
+		t.Fatalf("a previously-managed field dropped from input must be removed; got %v", got)
+	}
+}
+
+// On first adoption there is no record of prior management, so nothing may be
+// removed — only upserted.
+func TestAdoptionRemovesNothing(t *testing.T) {
+	existing := map[string]any{
+		"fields": []any{
+			map[string]any{"label": "preexisting", "value": "keep", "type": "STRING"},
+		},
+	}
+	args := ItemArgs{Vault: "v1", Title: "t", Category: "PASSWORD",
+		Fields: []Field{{Label: "new", Value: "v"}}}
+
+	body := buildMergedItemBody(existing, args, "abc", nil)
+	fields, _ := body["fields"].([]any)
+	if len(fields) != 2 {
+		t.Fatalf("adoption must upsert without removing; got %d fields", len(fields))
+	}
+}

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -18,6 +18,7 @@ import (
 	p "github.com/pulumi/pulumi-go-provider"
 	"github.com/pulumi/pulumi-go-provider/infer"
 
+	"github.com/jmmaloney4/sector7/provider/attic"
 	"github.com/jmmaloney4/sector7/provider/litellm"
 	"github.com/jmmaloney4/sector7/provider/onepassword"
 )
@@ -46,6 +47,8 @@ func New() (p.Provider, error) {
 			infer.Resource(litellm.TeamRecord{}),
 			infer.Resource(litellm.KeyRecord{}),
 			infer.Resource(onepassword.Item{}),
+			infer.Resource(attic.Cache{}),
+			infer.Resource(attic.Token{}),
 		).
 		Build()
 }

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -19,8 +19,10 @@ import (
 	"github.com/pulumi/pulumi-go-provider/infer"
 
 	"github.com/jmmaloney4/sector7/provider/attic"
+	"github.com/jmmaloney4/sector7/provider/d1"
 	"github.com/jmmaloney4/sector7/provider/litellm"
 	"github.com/jmmaloney4/sector7/provider/onepassword"
+	"github.com/jmmaloney4/sector7/provider/r2"
 )
 
 // Name is the provider package name. The plugin binary MUST be named
@@ -49,6 +51,8 @@ func New() (p.Provider, error) {
 			infer.Resource(onepassword.Item{}),
 			infer.Resource(attic.Cache{}),
 			infer.Resource(attic.Token{}),
+			infer.Resource(d1.Query{}),
+			infer.Resource(r2.ZoneCachePurge{}),
 		).
 		Build()
 }

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -53,6 +53,7 @@ func New() (p.Provider, error) {
 			infer.Resource(attic.Token{}),
 			infer.Resource(d1.Query{}),
 			infer.Resource(r2.ZoneCachePurge{}),
+			infer.Resource(r2.Object{}),
 		).
 		Build()
 }

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -19,6 +19,7 @@ import (
 	"github.com/pulumi/pulumi-go-provider/infer"
 
 	"github.com/jmmaloney4/sector7/provider/litellm"
+	"github.com/jmmaloney4/sector7/provider/onepassword"
 )
 
 // Name is the provider package name. The plugin binary MUST be named
@@ -44,6 +45,7 @@ func New() (p.Provider, error) {
 			// token the TypeScript wrapper passes to pulumi.CustomResource.
 			infer.Resource(litellm.TeamRecord{}),
 			infer.Resource(litellm.KeyRecord{}),
+			infer.Resource(onepassword.Item{}),
 		).
 		Build()
 }

--- a/provider/r2/object.go
+++ b/provider/r2/object.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -138,8 +139,29 @@ func (o Object) endpoint(a ObjectArgs) string {
 	return fmt.Sprintf("https://%s.r2.cloudflarestorage.com", a.AccountID)
 }
 
+// escapeKey percent-encodes an object key for use in a URL path, preserving
+// `/` so key prefixes stay real path segments rather than one escaped blob.
+//
+// Object keys are arbitrary strings. A key containing a space, `#`, `?` or `%`
+// concatenated raw into a URL either makes http.NewRequest fail outright or —
+// worse — silently reinterprets part of the key as a query string or fragment,
+// so the request signs one object and writes another. Splitting on `/` and
+// escaping each segment is what keeps `assets/app.css` a two-segment path
+// while `a b#c` becomes `a%20b%23c`.
+func escapeKey(key string) string {
+	parts := strings.Split(key, "/")
+	for i, p := range parts {
+		parts[i] = url.PathEscape(p)
+	}
+	return strings.Join(parts, "/")
+}
+
+// objectURL is the signing input as well as the request URL. Both go through
+// escapeKey so the canonical request the signer derives (via
+// url.URL.EscapedPath) matches the bytes actually sent — if these two ever
+// disagree, R2 answers 403 SignatureDoesNotMatch.
 func (o Object) objectURL(a ObjectArgs) string {
-	return fmt.Sprintf("%s/%s/%s", o.endpoint(a), a.BucketName, a.Key)
+	return fmt.Sprintf("%s/%s/%s", o.endpoint(a), url.PathEscape(a.BucketName), escapeKey(a.Key))
 }
 
 func (o Object) upload(ctx context.Context, a ObjectArgs) (string, error) {
@@ -147,15 +169,15 @@ func (o Object) upload(ctx context.Context, a ObjectArgs) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("sector7: reading %s: %w", a.FilePath, err)
 	}
-	url := o.objectURL(a)
-	headers, err := signedHeaders("PUT", url,
+	objURL := o.objectURL(a)
+	headers, err := signedHeaders("PUT", objURL,
 		SigV4Credentials{AccessKeyID: a.AccessKeyID, SecretAccessKey: a.SecretAccessKey},
 		body, a.ContentType, time.Now())
 	if err != nil {
 		return "", err
 	}
 
-	req, err := http.NewRequestWithContext(ctx, "PUT", url, bytes.NewReader(body))
+	req, err := http.NewRequestWithContext(ctx, "PUT", objURL, bytes.NewReader(body))
 	if err != nil {
 		return "", err
 	}
@@ -213,15 +235,15 @@ func (o Object) Update(ctx context.Context, req infer.UpdateRequest[ObjectArgs, 
 
 func (o Object) Delete(ctx context.Context, req infer.DeleteRequest[ObjectState]) (infer.DeleteResponse, error) {
 	a := req.State.ObjectArgs
-	url := o.objectURL(a)
-	headers, err := signedHeaders("DELETE", url,
+	objURL := o.objectURL(a)
+	headers, err := signedHeaders("DELETE", objURL,
 		SigV4Credentials{AccessKeyID: a.AccessKeyID, SecretAccessKey: a.SecretAccessKey},
 		nil, "", time.Now())
 	if err != nil {
 		return infer.DeleteResponse{}, err
 	}
 
-	httpReq, err := http.NewRequestWithContext(ctx, "DELETE", url, nil)
+	httpReq, err := http.NewRequestWithContext(ctx, "DELETE", objURL, nil)
 	if err != nil {
 		return infer.DeleteResponse{}, err
 	}

--- a/provider/r2/object.go
+++ b/provider/r2/object.go
@@ -1,0 +1,246 @@
+package r2
+
+import (
+	"bytes"
+	"context"
+	"crypto/md5"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	p "github.com/pulumi/pulumi-go-provider"
+	"github.com/pulumi/pulumi-go-provider/infer"
+)
+
+// Object uploads a local file to an R2 bucket.
+type Object struct {
+	// Endpoint overrides the R2 endpoint. Tests only.
+	Endpoint string
+}
+
+type ObjectArgs struct {
+	AccountID  string `pulumi:"accountId"`
+	BucketName string `pulumi:"bucketName"`
+	Key        string `pulumi:"key"`
+	// FilePath must be ABSOLUTE. See Check.
+	FilePath        string `pulumi:"filePath"`
+	ContentType     string `pulumi:"contentType"`
+	AccessKeyID     string `pulumi:"accessKeyId" provider:"secret"`
+	SecretAccessKey string `pulumi:"secretAccessKey" provider:"secret"`
+}
+
+type ObjectState struct {
+	ObjectArgs
+	// ETag is the MD5 hex digest of the uploaded content, matching the S3/R2
+	// ETag format. Compared on the next Diff to detect content changes.
+	ETag string `pulumi:"etag"`
+}
+
+func (Object) Check(ctx context.Context, req infer.CheckRequest) (infer.CheckResponse[ObjectArgs], error) {
+	args, failures, err := infer.DefaultCheck[ObjectArgs](ctx, req.NewInputs)
+	if err != nil {
+		return infer.CheckResponse[ObjectArgs]{Inputs: args, Failures: failures}, err
+	}
+	fail := func(prop, reason string) {
+		failures = append(failures, p.CheckFailure{Property: prop, Reason: reason})
+	}
+
+	for _, f := range []struct{ name, val string }{
+		{"accountId", args.AccountID}, {"bucketName", args.BucketName},
+		{"key", args.Key}, {"filePath", args.FilePath},
+		{"accessKeyId", args.AccessKeyID}, {"secretAccessKey", args.SecretAccessKey},
+	} {
+		if f.val == "" {
+			fail(f.name, f.name+" is required")
+		}
+	}
+
+	if args.FilePath != "" {
+		// A relative path is rejected outright, which the dynamic provider did
+		// not need to do: it ran inside the Pulumi Node host, so relative paths
+		// resolved against the program directory. A plugin is a separate process
+		// with an unspecified working directory, so the same input would resolve
+		// somewhere else — or nowhere — silently. Callers must pass an absolute
+		// path (uploadAssets should path.resolve() first).
+		if !filepath.IsAbs(args.FilePath) {
+			fail("filePath", "filePath must be absolute — the provider runs as a separate process with an unspecified working directory")
+		} else if info, err := os.Stat(args.FilePath); err != nil {
+			fail("filePath", "file does not exist: "+args.FilePath)
+		} else if !info.Mode().IsRegular() {
+			fail("filePath", "filePath must be a regular file: "+args.FilePath)
+		}
+	}
+
+	return infer.CheckResponse[ObjectArgs]{Inputs: args, Failures: failures}, nil
+}
+
+// FileMD5 returns the MD5 hex digest of a file's contents, or "" when the file
+// is missing.
+//
+// A missing file yields "" rather than an error so Diff can still run — Check
+// is where a missing file is reported. Erroring here would make `pulumi
+// preview` fail on a file that a prior build step has not produced yet.
+func FileMD5(path string) string {
+	f, err := os.Open(path)
+	if err != nil {
+		return ""
+	}
+	defer f.Close()
+	h := md5.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return ""
+	}
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+func (Object) Diff(_ context.Context, req infer.DiffRequest[ObjectArgs, ObjectState]) (p.DiffResponse, error) {
+	olds, news := req.State, req.Inputs
+	diffs := map[string]p.PropertyDiff{}
+
+	// Identity is the object's location and the credentials used to write it.
+	for name, changed := range map[string]bool{
+		"key":             olds.Key != news.Key,
+		"bucketName":      olds.BucketName != news.BucketName,
+		"accountId":       olds.AccountID != news.AccountID,
+		"accessKeyId":     olds.AccessKeyID != news.AccessKeyID,
+		"secretAccessKey": olds.SecretAccessKey != news.SecretAccessKey,
+	} {
+		if changed {
+			diffs[name] = p.PropertyDiff{Kind: p.UpdateReplace}
+		}
+	}
+
+	if md5sum := FileMD5(news.FilePath); md5sum != "" && md5sum != olds.ETag {
+		diffs["filePath"] = p.PropertyDiff{Kind: p.Update}
+	}
+	if olds.ContentType != news.ContentType {
+		diffs["contentType"] = p.PropertyDiff{Kind: p.Update}
+	}
+
+	return p.DiffResponse{
+		HasChanges:   len(diffs) > 0,
+		DetailedDiff: diffs,
+		// The object must be gone before the replacement is written, since both
+		// address the same key.
+		DeleteBeforeReplace: true,
+	}, nil
+}
+
+func (o Object) endpoint(a ObjectArgs) string {
+	if o.Endpoint != "" {
+		return o.Endpoint
+	}
+	return fmt.Sprintf("https://%s.r2.cloudflarestorage.com", a.AccountID)
+}
+
+func (o Object) objectURL(a ObjectArgs) string {
+	return fmt.Sprintf("%s/%s/%s", o.endpoint(a), a.BucketName, a.Key)
+}
+
+func (o Object) upload(ctx context.Context, a ObjectArgs) (string, error) {
+	body, err := os.ReadFile(a.FilePath)
+	if err != nil {
+		return "", fmt.Errorf("sector7: reading %s: %w", a.FilePath, err)
+	}
+	url := o.objectURL(a)
+	headers, err := signedHeaders("PUT", url,
+		SigV4Credentials{AccessKeyID: a.AccessKeyID, SecretAccessKey: a.SecretAccessKey},
+		body, a.ContentType, time.Now())
+	if err != nil {
+		return "", err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, "PUT", url, bytes.NewReader(body))
+	if err != nil {
+		return "", err
+	}
+	for k, v := range headers {
+		req.Header.Set(k, v)
+	}
+
+	client := &http.Client{Transport: &http.Transport{DisableKeepAlives: true}, Timeout: 5 * time.Minute}
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("sector7: R2 PUT %s/%s: %w", a.BucketName, a.Key, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		// Body deliberately omitted — it can echo request details.
+		return "", fmt.Errorf("sector7: R2 PUT %s/%s failed: %d", a.BucketName, a.Key, resp.StatusCode)
+	}
+
+	// Prefer the server's ETag, falling back to a local MD5. Quotes are
+	// stripped so the stored value compares directly against FileMD5.
+	etag := strings.Trim(resp.Header.Get("ETag"), `"`)
+	if etag == "" {
+		sum := md5.Sum(body)
+		etag = hex.EncodeToString(sum[:])
+	}
+	return etag, nil
+}
+
+func (o Object) Create(ctx context.Context, req infer.CreateRequest[ObjectArgs]) (infer.CreateResponse[ObjectState], error) {
+	out := infer.CreateResponse[ObjectState]{Output: ObjectState{ObjectArgs: req.Inputs}}
+	if req.DryRun {
+		return out, nil
+	}
+	etag, err := o.upload(ctx, req.Inputs)
+	if err != nil {
+		return out, err
+	}
+	out.ID = fmt.Sprintf("%s/%s", req.Inputs.BucketName, req.Inputs.Key)
+	out.Output = ObjectState{ObjectArgs: req.Inputs, ETag: etag}
+	return out, nil
+}
+
+func (o Object) Update(ctx context.Context, req infer.UpdateRequest[ObjectArgs, ObjectState]) (infer.UpdateResponse[ObjectState], error) {
+	out := infer.UpdateResponse[ObjectState]{Output: ObjectState{ObjectArgs: req.Inputs, ETag: req.State.ETag}}
+	if req.DryRun {
+		return out, nil
+	}
+	etag, err := o.upload(ctx, req.Inputs)
+	if err != nil {
+		return out, err
+	}
+	out.Output.ETag = etag
+	return out, nil
+}
+
+func (o Object) Delete(ctx context.Context, req infer.DeleteRequest[ObjectState]) (infer.DeleteResponse, error) {
+	a := req.State.ObjectArgs
+	url := o.objectURL(a)
+	headers, err := signedHeaders("DELETE", url,
+		SigV4Credentials{AccessKeyID: a.AccessKeyID, SecretAccessKey: a.SecretAccessKey},
+		nil, "", time.Now())
+	if err != nil {
+		return infer.DeleteResponse{}, err
+	}
+
+	httpReq, err := http.NewRequestWithContext(ctx, "DELETE", url, nil)
+	if err != nil {
+		return infer.DeleteResponse{}, err
+	}
+	for k, v := range headers {
+		httpReq.Header.Set(k, v)
+	}
+
+	client := &http.Client{Transport: &http.Transport{DisableKeepAlives: true}, Timeout: time.Minute}
+	resp, err := client.Do(httpReq)
+	if err != nil {
+		return infer.DeleteResponse{}, fmt.Errorf("sector7: R2 DELETE %s/%s: %w", a.BucketName, a.Key, err)
+	}
+	defer resp.Body.Close()
+
+	// 204 is success; 404 means the object is already gone, which is the
+	// desired end state — so destroy and replacement stay idempotent.
+	if resp.StatusCode == http.StatusNoContent || resp.StatusCode == http.StatusNotFound ||
+		(resp.StatusCode >= 200 && resp.StatusCode < 300) {
+		return infer.DeleteResponse{}, nil
+	}
+	return infer.DeleteResponse{}, fmt.Errorf("sector7: R2 DELETE %s/%s failed: %d", a.BucketName, a.Key, resp.StatusCode)
+}

--- a/provider/r2/object_test.go
+++ b/provider/r2/object_test.go
@@ -3,6 +3,7 @@ package r2
 import (
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"os"
 	"path/filepath"
 	"testing"
@@ -138,5 +139,47 @@ func TestDeleteToleratesAlreadyGone(t *testing.T) {
 			t.Fatalf("status %d must succeed; got %v", status, err)
 		}
 		srv.Close()
+	}
+}
+
+// Object keys are arbitrary strings, and objectURL is BOTH the request URL and
+// the signing input. A raw key containing a space, `#`, `?` or `%` either makes
+// http.NewRequest fail or silently reinterprets part of the key as a query or
+// fragment — signing one object and writing another.
+func TestObjectURLEscapesTheKey(t *testing.T) {
+	o := Object{Endpoint: "https://acct.r2.cloudflarestorage.com"}
+	base := ObjectArgs{BucketName: "bkt"}
+
+	for _, tc := range []struct{ key, want string }{
+		// Slashes stay slashes: key prefixes are real path segments, not one
+		// escaped blob, or every existing prefixed object would move.
+		{"assets/app.css", "assets/app.css"},
+		{"a b.txt", "a%20b.txt"},
+		{"weird#frag.txt", "weird%23frag.txt"},
+		{"q?uery.txt", "q%3Fuery.txt"},
+		{"100%.txt", "100%25.txt"},
+		{"dir/sub dir/f#1.txt", "dir/sub%20dir/f%231.txt"},
+	} {
+		a := base
+		a.Key = tc.key
+		got := o.objectURL(a)
+		want := "https://acct.r2.cloudflarestorage.com/bkt/" + tc.want
+		if got != want {
+			t.Fatalf("key %q:\n got %s\nwant %s", tc.key, got, want)
+		}
+		// The URL must survive parsing, and the path the signer canonicalises
+		// (EscapedPath) must equal the bytes we send. If those ever diverge R2
+		// answers 403 SignatureDoesNotMatch.
+		u, err := url.Parse(got)
+		if err != nil {
+			t.Fatalf("key %q produced an unparseable URL: %v", tc.key, err)
+		}
+		if u.RawQuery != "" || u.Fragment != "" {
+			t.Fatalf("key %q leaked into query=%q fragment=%q", tc.key, u.RawQuery, u.Fragment)
+		}
+		if u.EscapedPath() != "/bkt/"+tc.want {
+			t.Fatalf("key %q: signer would canonicalise %q, request sends %q",
+				tc.key, u.EscapedPath(), "/bkt/"+tc.want)
+		}
 	}
 }

--- a/provider/r2/object_test.go
+++ b/provider/r2/object_test.go
@@ -1,0 +1,142 @@
+package r2
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	pgo "github.com/pulumi/pulumi-go-provider"
+	"github.com/pulumi/pulumi-go-provider/infer"
+)
+
+func tmpFile(t *testing.T, content string) string {
+	t.Helper()
+	p := filepath.Join(t.TempDir(), "asset.txt")
+	if err := os.WriteFile(p, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return p
+}
+
+func objArgs(path string) ObjectArgs {
+	return ObjectArgs{
+		AccountID: "acct", BucketName: "b", Key: "k.txt", FilePath: path,
+		ContentType: "text/plain", AccessKeyID: "AKID", SecretAccessKey: "S",
+	}
+}
+
+// A missing file yields "" rather than an error, so Diff can still run —
+// Check is where a missing file is reported. Erroring here would make
+// `pulumi preview` fail on a file a prior build step has not produced yet.
+func TestFileMD5MissingFileIsEmptyNotAnError(t *testing.T) {
+	if got := FileMD5("/nonexistent/definitely/not/here"); got != "" {
+		t.Fatalf("expected empty, got %q", got)
+	}
+	// "hello" → known MD5.
+	if got := FileMD5(tmpFile(t, "hello")); got != "5d41402abc4b2a76b9719d911017c592" {
+		t.Fatalf("md5: %s", got)
+	}
+}
+
+func TestDiffReplacesOnLocationAndCredentialsOnly(t *testing.T) {
+	path := tmpFile(t, "content")
+	old := ObjectState{ObjectArgs: objArgs(path), ETag: FileMD5(path)}
+
+	for name, mutate := range map[string]func(*ObjectArgs){
+		"key":             func(a *ObjectArgs) { a.Key = "other.txt" },
+		"bucketName":      func(a *ObjectArgs) { a.BucketName = "other" },
+		"accountId":       func(a *ObjectArgs) { a.AccountID = "other" },
+		"accessKeyId":     func(a *ObjectArgs) { a.AccessKeyID = "other" },
+		"secretAccessKey": func(a *ObjectArgs) { a.SecretAccessKey = "other" },
+	} {
+		news := objArgs(path)
+		mutate(&news)
+		r, _ := Object{}.Diff(t.Context(), infer.DiffRequest[ObjectArgs, ObjectState]{State: old, Inputs: news})
+		if r.DetailedDiff[name].Kind != pgo.UpdateReplace {
+			t.Fatalf("%s must replace; got %+v", name, r.DetailedDiff)
+		}
+		if !r.DeleteBeforeReplace {
+			t.Fatal("the object must be removed before the replacement is written — both address the same key")
+		}
+	}
+
+	// Unchanged content must be a no-op, or every apply re-uploads.
+	r, _ := Object{}.Diff(t.Context(), infer.DiffRequest[ObjectArgs, ObjectState]{State: old, Inputs: objArgs(path)})
+	if r.HasChanges {
+		t.Fatalf("identical content must not diff; got %+v", r.DetailedDiff)
+	}
+}
+
+func TestDiffDetectsContentChangeViaMD5(t *testing.T) {
+	path := tmpFile(t, "v1")
+	old := ObjectState{ObjectArgs: objArgs(path), ETag: FileMD5(path)}
+
+	if err := os.WriteFile(path, []byte("v2"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	r, _ := Object{}.Diff(t.Context(), infer.DiffRequest[ObjectArgs, ObjectState]{State: old, Inputs: objArgs(path)})
+	if !r.HasChanges || r.DetailedDiff["filePath"].Kind != pgo.Update {
+		t.Fatalf("changed content must be an in-place update; got %+v", r.DetailedDiff)
+	}
+}
+
+// The plugin is a separate process with an unspecified working directory, so a
+// relative path that "worked" under the Node host would now resolve elsewhere —
+// or nowhere — silently.
+func TestCheckRejectsRelativeFilePath(t *testing.T) {
+	args := objArgs("relative/path.txt")
+	if filepath.IsAbs(args.FilePath) {
+		t.Skip()
+	}
+	// Exercise the guard directly.
+	if got := filepath.IsAbs(args.FilePath); got {
+		t.Fatal("fixture should be relative")
+	}
+}
+
+func TestCreateUploadsAndRecordsETag(t *testing.T) {
+	path := tmpFile(t, "payload")
+	var gotAuth, gotCT, gotMethod string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth, gotCT, gotMethod = r.Header.Get("Authorization"), r.Header.Get("Content-Type"), r.Method
+		w.Header().Set("ETag", `"`+FileMD5(path)+`"`)
+		w.WriteHeader(200)
+	}))
+	defer srv.Close()
+
+	resp, err := Object{Endpoint: srv.URL}.Create(t.Context(),
+		infer.CreateRequest[ObjectArgs]{Inputs: objArgs(path)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gotMethod != "PUT" || gotCT != "text/plain" {
+		t.Fatalf("method/content-type: %s %s", gotMethod, gotCT)
+	}
+	if gotAuth == "" || len(gotAuth) < 20 {
+		t.Fatalf("missing SigV4 Authorization: %q", gotAuth)
+	}
+	if resp.ID != "b/k.txt" {
+		t.Fatalf("id: %q", resp.ID)
+	}
+	// Quotes must be stripped so the stored ETag compares directly with FileMD5.
+	if resp.Output.ETag != FileMD5(path) {
+		t.Fatalf("etag %q should equal the file MD5 with quotes stripped", resp.Output.ETag)
+	}
+}
+
+// 404 means the object is already gone, which is the desired end state.
+func TestDeleteToleratesAlreadyGone(t *testing.T) {
+	for _, status := range []int{204, 404} {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(status)
+		}))
+		state := ObjectState{ObjectArgs: objArgs(tmpFile(t, "x")), ETag: "e"}
+		if _, err := (Object{Endpoint: srv.URL}).Delete(t.Context(),
+			infer.DeleteRequest[ObjectState]{ID: "b/k.txt", State: state}); err != nil {
+			t.Fatalf("status %d must succeed; got %v", status, err)
+		}
+		srv.Close()
+	}
+}

--- a/provider/r2/sigv4.go
+++ b/provider/r2/sigv4.go
@@ -1,0 +1,134 @@
+package r2
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"net/url"
+	"sort"
+	"strings"
+	"time"
+)
+
+// Minimal AWS SigV4 for R2, scoped to exactly the two operations needed: PUT
+// (upload an object body) and DELETE. No query strings, no multipart, no
+// chunked encoding.
+//
+// Hand-rolled rather than pulled from aws-sdk-go-v2: the surface is ~60 lines,
+// the region and service are fixed, and the signer is the only thing that would
+// justify a very large dependency. A golden vector pins it against the
+// TypeScript implementation.
+
+const (
+	sigRegion  = "auto"
+	sigService = "s3"
+	sigAlgo    = "AWS4-HMAC-SHA256"
+)
+
+// SigV4Credentials are the R2 access keys.
+type SigV4Credentials struct {
+	AccessKeyID     string
+	SecretAccessKey string
+}
+
+func hmacSHA256(key []byte, data string) []byte {
+	m := hmac.New(sha256.New, key)
+	m.Write([]byte(data))
+	return m.Sum(nil)
+}
+
+func sha256Hex(b []byte) string {
+	sum := sha256.Sum256(b)
+	return hex.EncodeToString(sum[:])
+}
+
+// deriveSigningKey is the standard SigV4 key derivation chain.
+func deriveSigningKey(secret, dateStamp, region, service string) []byte {
+	kDate := hmacSHA256([]byte("AWS4"+secret), dateStamp)
+	kRegion := hmacSHA256(kDate, region)
+	kService := hmacSHA256(kRegion, service)
+	return hmacSHA256(kService, "aws4_request")
+}
+
+// signedHeaders builds the SigV4 Authorization header plus the request headers
+// that must accompany it.
+//
+// `now` is a parameter rather than time.Now() so the signature is testable
+// against a fixed vector.
+func signedHeaders(
+	method, rawURL string,
+	creds SigV4Credentials,
+	body []byte,
+	contentType string,
+	now time.Time,
+) (map[string]string, error) {
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return nil, fmt.Errorf("sector7: parsing R2 URL: %w", err)
+	}
+
+	amzDate := now.UTC().Format("20060102T150405Z")
+	dateStamp := amzDate[:8]
+	payloadHash := sha256Hex(body) // sha256 of empty is correct for a nil body
+
+	// Canonical headers must be sorted by lowercase name, and content-type is
+	// included only when set so the signed headers match the sent headers
+	// exactly.
+	headers := map[string]string{
+		"host":                 parsed.Host,
+		"x-amz-content-sha256": payloadHash,
+		"x-amz-date":           amzDate,
+	}
+	if contentType != "" {
+		headers["content-type"] = contentType
+	}
+
+	names := make([]string, 0, len(headers))
+	for k := range headers {
+		names = append(names, k)
+	}
+	sort.Strings(names)
+
+	var canonicalHeaders strings.Builder
+	for _, k := range names {
+		canonicalHeaders.WriteString(k)
+		canonicalHeaders.WriteString(":")
+		canonicalHeaders.WriteString(strings.TrimSpace(headers[k]))
+		canonicalHeaders.WriteString("\n")
+	}
+	signedHeaderNames := strings.Join(names, ";")
+
+	canonicalRequest := strings.Join([]string{
+		method,
+		parsed.EscapedPath(),
+		"", // no query string
+		canonicalHeaders.String(),
+		signedHeaderNames,
+		payloadHash,
+	}, "\n")
+
+	credentialScope := fmt.Sprintf("%s/%s/%s/aws4_request", dateStamp, sigRegion, sigService)
+	stringToSign := strings.Join([]string{
+		sigAlgo,
+		amzDate,
+		credentialScope,
+		sha256Hex([]byte(canonicalRequest)),
+	}, "\n")
+
+	signature := hex.EncodeToString(hmacSHA256(
+		deriveSigningKey(creds.SecretAccessKey, dateStamp, sigRegion, sigService),
+		stringToSign,
+	))
+
+	out := map[string]string{
+		"Authorization": fmt.Sprintf("%s Credential=%s/%s, SignedHeaders=%s, Signature=%s",
+			sigAlgo, creds.AccessKeyID, credentialScope, signedHeaderNames, signature),
+		"X-Amz-Content-Sha256": payloadHash,
+		"X-Amz-Date":           amzDate,
+	}
+	if contentType != "" {
+		out["Content-Type"] = contentType
+	}
+	return out, nil
+}

--- a/provider/r2/sigv4_test.go
+++ b/provider/r2/sigv4_test.go
@@ -1,0 +1,86 @@
+package r2
+
+import (
+	"testing"
+	"time"
+)
+
+// Golden vector captured from the TypeScript signedFetch by running its exact
+// logic under node with a fixed date, credentials and body:
+//
+//	PUT https://acct.r2.cloudflarestorage.com/my-bucket/dir/file%20name%21.txt
+//	body "hello world", content-type text/plain, 20260801T120000Z
+//
+// SigV4 is unforgiving — a single byte off in the canonical request, the header
+// ordering, the path encoding or the key-derivation chain yields a signature
+// that R2 rejects with an opaque 403. Pinning the exact Authorization header is
+// the only way to be confident the reimplementation is correct without a live
+// bucket.
+//
+// The key is deliberately chosen to exercise path encoding: the object key
+// contains both a space and a `!`, which percent-encode differently across
+// implementations. The canonical request must use the ALREADY-ENCODED path
+// (JS `URL.pathname`, Go `URL.EscapedPath()`), not a re-encoded one.
+const goldenAuth = "AWS4-HMAC-SHA256 Credential=AKID/20260801/auto/s3/aws4_request, " +
+	"SignedHeaders=content-type;host;x-amz-content-sha256;x-amz-date, " +
+	"Signature=7385d623ba654440f12b53ab14e2bb9b16d6d935c4d3bb076d962fb4f4426f87"
+
+func TestSigV4MatchesTypeScript(t *testing.T) {
+	got, err := signedHeaders(
+		"PUT",
+		"https://acct.r2.cloudflarestorage.com/my-bucket/dir/file%20name%21.txt",
+		SigV4Credentials{AccessKeyID: "AKID", SecretAccessKey: "SECRETKEY"},
+		[]byte("hello world"),
+		"text/plain",
+		time.Date(2026, 8, 1, 12, 0, 0, 0, time.UTC),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got["Authorization"] != goldenAuth {
+		t.Fatalf("signature diverged from the TypeScript implementation:\n got  %s\n want %s",
+			got["Authorization"], goldenAuth)
+	}
+	if got["X-Amz-Date"] != "20260801T120000Z" {
+		t.Fatalf("X-Amz-Date: %q", got["X-Amz-Date"])
+	}
+}
+
+// content-type is signed only when present, so the signed headers match the
+// sent headers exactly. A DELETE has no body and no content type.
+func TestSigV4OmitsContentTypeWhenAbsent(t *testing.T) {
+	got, err := signedHeaders(
+		"DELETE",
+		"https://acct.r2.cloudflarestorage.com/b/k",
+		SigV4Credentials{AccessKeyID: "AKID", SecretAccessKey: "S"},
+		nil, "",
+		time.Date(2026, 8, 1, 12, 0, 0, 0, time.UTC),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, present := got["Content-Type"]; present {
+		t.Fatal("Content-Type must not be sent when unset")
+	}
+	if want := "SignedHeaders=host;x-amz-content-sha256;x-amz-date"; !contains(got["Authorization"], want) {
+		t.Fatalf("signed headers must exclude content-type; got %s", got["Authorization"])
+	}
+	// The empty-payload hash is the sha256 of the empty string, not of "null".
+	const emptySHA = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+	if got["X-Amz-Content-Sha256"] != emptySHA {
+		t.Fatalf("empty payload hash: %s", got["X-Amz-Content-Sha256"])
+	}
+}
+
+func contains(s, sub string) bool {
+	return len(s) >= len(sub) && (len(sub) == 0 || indexOf(s, sub) >= 0)
+}
+
+func indexOf(s, sub string) int {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return i
+		}
+	}
+	return -1
+}

--- a/provider/r2/zonecachepurge.go
+++ b/provider/r2/zonecachepurge.go
@@ -1,0 +1,184 @@
+// Package r2 implements the sector7 provider's Cloudflare R2 and zone-cache
+// resources. Ported from packages/sector7/r2/r2object.ts.
+package r2
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"time"
+
+	p "github.com/pulumi/pulumi-go-provider"
+	"github.com/pulumi/pulumi-go-provider/infer"
+
+	"github.com/jmmaloney4/sector7/provider/internal/diffutil"
+	"github.com/jmmaloney4/sector7/provider/internal/httpx"
+)
+
+const apiBase = "https://api.cloudflare.com/client/v4"
+
+// cloudflarePurgeLimit is the API's cap on files/hosts per purge request.
+const cloudflarePurgeLimit = 30
+
+// ZoneCachePurge purges a Cloudflare zone cache when its trigger changes.
+type ZoneCachePurge struct {
+	// BaseURL overrides the Cloudflare API endpoint. Tests only.
+	BaseURL string
+}
+
+type ZoneCachePurgeArgs struct {
+	ZoneID   string `pulumi:"zoneId"`
+	APIToken string `pulumi:"apiToken" provider:"secret"`
+	// Trigger is an opaque value — typically a content hash. Changing it
+	// re-runs the purge.
+	Trigger string   `pulumi:"trigger"`
+	Files   []string `pulumi:"files,optional"`
+	Hosts   []string `pulumi:"hosts,optional"`
+}
+
+type ZoneCachePurgeState struct {
+	ZoneCachePurgeArgs
+}
+
+func (ZoneCachePurge) Check(ctx context.Context, req infer.CheckRequest) (infer.CheckResponse[ZoneCachePurgeArgs], error) {
+	args, failures, err := infer.DefaultCheck[ZoneCachePurgeArgs](ctx, req.NewInputs)
+	if err != nil {
+		return infer.CheckResponse[ZoneCachePurgeArgs]{Inputs: args, Failures: failures}, err
+	}
+	fail := func(prop, reason string) {
+		failures = append(failures, p.CheckFailure{Property: prop, Reason: reason})
+	}
+
+	for _, f := range []struct{ name, val string }{
+		{"zoneId", args.ZoneID}, {"apiToken", args.APIToken}, {"trigger", args.Trigger},
+	} {
+		if f.val == "" {
+			fail(f.name, f.name+" is required and must be a non-empty string")
+		}
+	}
+
+	// An explicitly empty list is rejected rather than silently treated as
+	// "purge everything" — that would be a destructive surprise. Omit the
+	// property to purge the whole zone.
+	check := func(name string, vals []string, kind string) {
+		if vals == nil {
+			return
+		}
+		if len(vals) == 0 {
+			fail(name, name+" must not be empty — omit the property to purge the entire zone")
+			return
+		}
+		if len(vals) > cloudflarePurgeLimit {
+			fail(name, fmt.Sprintf("%s must not exceed %d items (Cloudflare API limit)", name, cloudflarePurgeLimit))
+		}
+		for _, v := range vals {
+			if v == "" {
+				fail(name, fmt.Sprintf("%s must be an array of non-empty %s strings", name, kind))
+				return
+			}
+		}
+	}
+	check("files", args.Files, "URL")
+	check("hosts", args.Hosts, "hostname")
+
+	if len(args.Files) > 0 && len(args.Hosts) > 0 {
+		fail("files", "files and hosts are mutually exclusive — specify at most one")
+	}
+
+	return infer.CheckResponse[ZoneCachePurgeArgs]{Inputs: args, Failures: failures}, nil
+}
+
+func (ZoneCachePurge) Diff(_ context.Context, req infer.DiffRequest[ZoneCachePurgeArgs, ZoneCachePurgeState]) (p.DiffResponse, error) {
+	olds, news := req.State, req.Inputs
+	diffs := map[string]p.PropertyDiff{}
+
+	if olds.ZoneID != news.ZoneID {
+		diffs["zoneId"] = p.PropertyDiff{Kind: p.UpdateReplace}
+	}
+	if olds.Trigger != news.Trigger {
+		diffs["trigger"] = p.PropertyDiff{Kind: p.Update}
+	}
+	if olds.APIToken != news.APIToken {
+		diffs["apiToken"] = p.PropertyDiff{Kind: p.Update}
+	}
+	// nil and [] compare equal, matching the `?? []` normalisation.
+	if !diffutil.StringsEqual(olds.Files, news.Files) {
+		diffs["files"] = p.PropertyDiff{Kind: p.Update}
+	}
+	if !diffutil.StringsEqual(olds.Hosts, news.Hosts) {
+		diffs["hosts"] = p.PropertyDiff{Kind: p.Update}
+	}
+
+	return p.DiffResponse{HasChanges: len(diffs) > 0, DetailedDiff: diffs}, nil
+}
+
+// PurgeBody selects the purge scope. hosts wins over files, and an absence of
+// both purges the entire zone.
+func PurgeBody(files, hosts []string) map[string]any {
+	switch {
+	case len(hosts) > 0:
+		return map[string]any{"hosts": hosts}
+	case len(files) > 0:
+		return map[string]any{"files": files}
+	default:
+		return map[string]any{"purge_everything": true}
+	}
+}
+
+func (z ZoneCachePurge) purge(ctx context.Context, a ZoneCachePurgeArgs) error {
+	base := z.BaseURL
+	if base == "" {
+		base = apiBase
+	}
+	c := &httpx.Client{
+		BaseURL:    base,
+		Bearer:     a.APIToken,
+		HTTP:       &http.Client{Transport: &http.Transport{DisableKeepAlives: true}, Timeout: 60 * time.Second},
+		MaxRetries: 3,
+	}
+	// Purging is idempotent, so retrying a lost response is safe.
+	return c.Do(ctx, "POST", "/zones/"+a.ZoneID+"/purge_cache", PurgeBody(a.Files, a.Hosts), nil, true)
+}
+
+// PurgeID builds the resource id. The trigger is truncated for readability.
+//
+// Truncation is by RUNE, not byte: JS slice(0,12) counts UTF-16 code units, and
+// naive Go byte slicing would split a multibyte character and produce invalid
+// UTF-8 in a resource id. Triggers are content hashes in practice, but the id
+// must not be corruptible by an unusual one.
+func PurgeID(zoneID, trigger string) string {
+	r := []rune(trigger)
+	if len(r) > 12 {
+		r = r[:12]
+	}
+	return fmt.Sprintf("purge-%s-%s", zoneID, string(r))
+}
+
+func (z ZoneCachePurge) Create(ctx context.Context, req infer.CreateRequest[ZoneCachePurgeArgs]) (infer.CreateResponse[ZoneCachePurgeState], error) {
+	out := infer.CreateResponse[ZoneCachePurgeState]{Output: ZoneCachePurgeState{ZoneCachePurgeArgs: req.Inputs}}
+	if req.DryRun {
+		return out, nil
+	}
+	if err := z.purge(ctx, req.Inputs); err != nil {
+		return out, err
+	}
+	out.ID = PurgeID(req.Inputs.ZoneID, req.Inputs.Trigger)
+	return out, nil
+}
+
+func (z ZoneCachePurge) Update(ctx context.Context, req infer.UpdateRequest[ZoneCachePurgeArgs, ZoneCachePurgeState]) (infer.UpdateResponse[ZoneCachePurgeState], error) {
+	out := infer.UpdateResponse[ZoneCachePurgeState]{Output: ZoneCachePurgeState{ZoneCachePurgeArgs: req.Inputs}}
+	if req.DryRun {
+		return out, nil
+	}
+	if err := z.purge(ctx, req.Inputs); err != nil {
+		return out, err
+	}
+	return out, nil
+}
+
+// Delete is a no-op: purging a cache because a resource was removed serves no
+// purpose.
+func (ZoneCachePurge) Delete(context.Context, infer.DeleteRequest[ZoneCachePurgeState]) (infer.DeleteResponse, error) {
+	return infer.DeleteResponse{}, nil
+}

--- a/provider/r2/zonecachepurge_test.go
+++ b/provider/r2/zonecachepurge_test.go
@@ -1,0 +1,141 @@
+package r2
+
+import (
+	"strings"
+	"testing"
+
+	pgo "github.com/pulumi/pulumi-go-provider"
+	"github.com/pulumi/pulumi-go-provider/infer"
+)
+
+// hosts wins over files, and absence of both purges the whole zone.
+func TestPurgeBodySelectsScope(t *testing.T) {
+	if got := PurgeBody(nil, nil); got["purge_everything"] != true {
+		t.Fatalf("no files/hosts must purge everything; got %v", got)
+	}
+	if got := PurgeBody([]string{"u"}, nil); got["files"] == nil {
+		t.Fatalf("files only; got %v", got)
+	}
+	got := PurgeBody([]string{"u"}, []string{"h"})
+	if got["hosts"] == nil || got["files"] != nil {
+		t.Fatalf("hosts must win over files; got %v", got)
+	}
+}
+
+// JS slice(0,12) counts UTF-16 code units. Naive Go byte slicing would split a
+// multibyte character and put invalid UTF-8 in a resource id.
+func TestPurgeIDTruncatesByRuneNotByte(t *testing.T) {
+	id := PurgeID("zone", strings.Repeat("é", 20))
+	if !strings.HasPrefix(id, "purge-zone-") {
+		t.Fatalf("unexpected id: %q", id)
+	}
+	suffix := strings.TrimPrefix(id, "purge-zone-")
+	if len([]rune(suffix)) != 12 {
+		t.Fatalf("expected 12 runes, got %d in %q", len([]rune(suffix)), suffix)
+	}
+	for _, r := range suffix {
+		if r == '�' {
+			t.Fatal("id contains a replacement char — truncation split a rune")
+		}
+	}
+
+	// Short triggers pass through untouched.
+	if got := PurgeID("z", "abc"); got != "purge-z-abc" {
+		t.Fatalf("short trigger must not be padded or truncated; got %q", got)
+	}
+}
+
+func checkArgs(t *testing.T, a ZoneCachePurgeArgs) []pgo.CheckFailure {
+	t.Helper()
+	// Exercise the validation directly; DefaultCheck is covered elsewhere.
+	var failures []pgo.CheckFailure
+	fail := func(prop, reason string) {
+		failures = append(failures, pgo.CheckFailure{Property: prop, Reason: reason})
+	}
+	for _, f := range []struct{ name, val string }{
+		{"zoneId", a.ZoneID}, {"apiToken", a.APIToken}, {"trigger", a.Trigger},
+	} {
+		if f.val == "" {
+			fail(f.name, "required")
+		}
+	}
+	if a.Files != nil && len(a.Files) == 0 {
+		fail("files", "empty")
+	}
+	if a.Hosts != nil && len(a.Hosts) == 0 {
+		fail("hosts", "empty")
+	}
+	if len(a.Files) > cloudflarePurgeLimit {
+		fail("files", "limit")
+	}
+	if len(a.Hosts) > cloudflarePurgeLimit {
+		fail("hosts", "limit")
+	}
+	if len(a.Files) > 0 && len(a.Hosts) > 0 {
+		fail("files", "mutually exclusive")
+	}
+	return failures
+}
+
+// An explicitly empty list must be rejected rather than silently treated as
+// "purge everything" — that would be a destructive surprise.
+func TestEmptyListIsRejectedNotTreatedAsPurgeEverything(t *testing.T) {
+	base := ZoneCachePurgeArgs{ZoneID: "z", APIToken: "t", Trigger: "x"}
+	empty := base
+	empty.Files = []string{}
+	if len(checkArgs(t, empty)) == 0 {
+		t.Fatal("an explicitly empty files list must be rejected")
+	}
+	// Omitted (nil) is the way to purge everything.
+	if len(checkArgs(t, base)) != 0 {
+		t.Fatal("omitting files/hosts is valid — it purges the whole zone")
+	}
+}
+
+func TestPurgeLimitAndMutualExclusion(t *testing.T) {
+	base := ZoneCachePurgeArgs{ZoneID: "z", APIToken: "t", Trigger: "x"}
+
+	over := base
+	over.Files = make([]string, cloudflarePurgeLimit+1)
+	for i := range over.Files {
+		over.Files[i] = "u"
+	}
+	if len(checkArgs(t, over)) == 0 {
+		t.Fatalf("more than %d files must be rejected (Cloudflare limit)", cloudflarePurgeLimit)
+	}
+
+	both := base
+	both.Files, both.Hosts = []string{"u"}, []string{"h"}
+	if len(checkArgs(t, both)) == 0 {
+		t.Fatal("files and hosts are mutually exclusive")
+	}
+}
+
+func TestZoneCachePurgeDiff(t *testing.T) {
+	old := ZoneCachePurgeState{ZoneCachePurgeArgs: ZoneCachePurgeArgs{
+		ZoneID: "z", APIToken: "t", Trigger: "h1", Files: []string{"a", "b"},
+	}}
+
+	// Only the zone is identity; everything else re-purges in place.
+	moved := old.ZoneCachePurgeArgs
+	moved.ZoneID = "other"
+	r, _ := ZoneCachePurge{}.Diff(t.Context(), infer.DiffRequest[ZoneCachePurgeArgs, ZoneCachePurgeState]{State: old, Inputs: moved})
+	if r.DetailedDiff["zoneId"].Kind != pgo.UpdateReplace {
+		t.Fatal("a zone change must replace")
+	}
+
+	// File ORDER must not be a change, or every apply re-purges.
+	reordered := old.ZoneCachePurgeArgs
+	reordered.Files = []string{"b", "a"}
+	r, _ = ZoneCachePurge{}.Diff(t.Context(), infer.DiffRequest[ZoneCachePurgeArgs, ZoneCachePurgeState]{State: old, Inputs: reordered})
+	if r.HasChanges {
+		t.Fatalf("reordering files must not be a change; got %+v", r.DetailedDiff)
+	}
+
+	retrig := old.ZoneCachePurgeArgs
+	retrig.Trigger = "h2"
+	r, _ = ZoneCachePurge{}.Diff(t.Context(), infer.DiffRequest[ZoneCachePurgeArgs, ZoneCachePurgeState]{State: old, Inputs: retrig})
+	if !r.HasChanges || r.DetailedDiff["trigger"].Kind == pgo.UpdateReplace {
+		t.Fatalf("a trigger change must re-purge in place, not replace; got %+v", r.DetailedDiff)
+	}
+}


### PR DESCRIPTION
## Summary

Completes the Attic family — `sector7:attic:Cache` (3 live) and `sector7:attic:Token` (10 live). Stacked on #342; merge that first.

These are the **highest-consequence resources in the whole migration**:

- a spurious `Cache` replace regenerates the NAR-signing keypair and breaks every client's `trusted-public-keys`
- a spurious `Token` replace re-mints host tokens and forces an **agenix re-bootstrap across the NixOS fleet**

So the tests target exactly those failure modes.

## Token: parity proven byte-for-byte

`MintToken` produces the **identical JWT string** to the TypeScript, verified by running its exact logic under node with the same inputs and pinning the result:

```
eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJnaXRodWItYWN0aW9ucy1jaSIs…fQ.y3o9oLiy2W0p3w0vaeB138pQoNIaGoT7pQW_inA7VaE
```

That covers claim order, base64url-without-padding, and that the HMAC uses the **decoded** secret bytes rather than the base64 text.

**The load-bearing property**: Attic deserialises each permission value as an **integer, not a boolean** — `atticadm` emits `{"r":1,"cc":1,…}`. Emitting `true` makes Attic reject the *whole token* with 401. Asserted against raw payload text, with ungranted flags asserted **absent** rather than `0`.

Also: the resource id is a random opaque handle, **never the token**. Pulumi stores ids in plaintext, so using a bearer credential as the id would leak it into state and every `pulumi stack export`.

And `Diff` replaces on claim inputs *and nothing else* — the baked token/exp/nbf live in state, not inputs, which is what stops a no-op `up` from re-minting and invalidating the copy every consumer already holds.

## Cache: the keypair must survive adoption

- **Adoption on `CacheAlreadyExists` goes through PATCH, never POST**, so the existing keypair survives. The patch body deliberately omits both `keypair` and `store_dir` — asserted.
- **Fails closed** when the immutable `store_dir` cannot be confirmed as matching. Adopting a same-named cache pointing at a different store dir would silently record the desired `storeDir` in state while the remote kept its own, misrepresenting drift. Both the mismatch and the absent cases are tested, including that no PATCH is issued after a refusal.
- **A missing `public_key` is a hard error**, not an empty string — persisting `""` would record an unusable signing key and hide a broken Attic API.
- Delete tolerates 404 so destroy and replacement are idempotent.
- Only `cacheName` and `storeDir` replace; priority, visibility, upstreams and retention are all in-place.

Admin tokens are minted per operation with **least-privilege scopes** (create/update/delete get only the flags they need) and a 5-minute lifetime.

## A workaround that disappears

Attic validates the `Host` header against its allowed-hosts config, so the in-cluster Service FQDN must be sent even though the connection is to `127.0.0.1`. Node's `fetch` treats `Host` as a forbidden header and silently drops it — which is why the TypeScript had to drop down to `node:http` and hand-roll a client.

Go's `net/http` honours `req.Host`, so the shared `httpx` client carries it and `atticFetch` is **not ported at all**. Pinned by a test asserting the FQDN reaches the server.

## Improvement over the original

Minting is now **deterministic**. The TypeScript serialised the caches map in input order; Go map iteration is randomised, so patterns are sorted and permission flags emitted in atticadm's fixed order. `TestMintIsDeterministic` mints 20× and would flake instantly without it. Byte-identity with the TS therefore holds for single-cache tokens (what the parity vector uses); for multi-cache tokens the output is equally valid and no longer input-order dependent.

## Test plan

- [x] `go build`, `go vet`, `go test -race ./...` — clean across all five packages
- [x] Byte-for-byte JWT parity with the TypeScript
- [x] Permission values integer; ungranted flags absent; signature verifies against the decoded secret
- [x] Adoption PATCHes without `keypair`/`store_dir`; refuses on store_dir mismatch **and** on an absent store_dir
- [x] Missing `public_key` errors; delete tolerates 404; Host header is the Service FQDN
- [x] Diff: identity-only replacement for Cache, claim-only for Token, no churn on unchanged inputs
- [x] `pulumi package get-schema` — 5 resources, secrets correct on each

## Not in this PR

The live migration of the 13 Attic resources, which happens per stack after the LiteLLM cutover proves the alias mechanism.