### PR TITLE
fix(pulumi): stamp the plugin binary's real version via ldflags

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -61,6 +61,14 @@
         ];
 
         renovateConfigPaths = map (path: "${self.outPath}/${path}") renovateConfigFiles;
+
+        # Single source of truth for packages.pulumi-resource-sector7 AND
+        # checks.provider-version-stamped, so the two can never desync — the
+        # exact failure mode (a build path deriving the version one way, a
+        # check asserting it a different way) that let v0.20.2 ship reporting
+        # itself as "dev".
+        providerVersion =
+          (builtins.fromJSON (builtins.readFile ./packages/sector7/package.json)).version;
       in {
         jackpkgs.just.cut = {
           enable = true;
@@ -92,35 +100,31 @@
         # downstream consumers; exposing it here means sector7's own CI builds
         # it on every PR (compute-flake-build-matrix selects packages.*), so Go
         # breakage surfaces in this repo rather than in jackpkgs.
-        packages.pulumi-resource-sector7 = let
-          providerVersion =
-            (builtins.fromJSON (builtins.readFile ./packages/sector7/package.json)).version;
-        in
-          pkgs.buildGoModule {
-            pname = "pulumi-resource-sector7";
-            version = providerVersion;
-            src = ./.;
-            modRoot = "provider";
-            # Maintained hash rather than a committed provider/vendor/: vendoring
-            # this tree is 83 MB / 6518 files (client-go + the Pulumi SDK), which
-            # would roughly triple the repo. A stale hash reds this repo's CI,
-            # never a consumer's.
-            vendorHash = "sha256-sGg1c8lDx94MqpEPIlVB1YHp/ZouJnphyz0+BWhnffI=";
-            subPackages = ["cmd/pulumi-resource-sector7"];
-            meta.mainProgram = "pulumi-resource-sector7";
-            # provider/version/version.go defaults Version to "dev" precisely so
-            # a build that forgets this line fails LOUDLY rather than silently
-            # shipping a plugin that reports itself as "dev" to the Pulumi
-            # engine. It does exactly that: "dev" is not valid semver, so
-            # EVERY operation against EVERY resource this provider owns fails
-            # at the provider-handshake step, before any real diffing even
-            # starts — found in production via `pulumi preview` on litellm/prod
-            # after v0.20.2 was already released and consumed downstream.
-            #
-            # checks.provider-version-stamped below asserts the built binary
-            # actually reports providerVersion, not just that this line exists.
-            ldflags = ["-X" "github.com/jmmaloney4/sector7/provider/version.Version=${providerVersion}"];
-          };
+        packages.pulumi-resource-sector7 = pkgs.buildGoModule {
+          pname = "pulumi-resource-sector7";
+          version = providerVersion;
+          src = ./.;
+          modRoot = "provider";
+          # Maintained hash rather than a committed provider/vendor/: vendoring
+          # this tree is 83 MB / 6518 files (client-go + the Pulumi SDK), which
+          # would roughly triple the repo. A stale hash reds this repo's CI,
+          # never a consumer's.
+          vendorHash = "sha256-sGg1c8lDx94MqpEPIlVB1YHp/ZouJnphyz0+BWhnffI=";
+          subPackages = ["cmd/pulumi-resource-sector7"];
+          meta.mainProgram = "pulumi-resource-sector7";
+          # provider/version/version.go defaults Version to "dev" precisely so
+          # a build that forgets this line fails LOUDLY rather than silently
+          # shipping a plugin that reports itself as "dev" to the Pulumi
+          # engine. It does exactly that: "dev" is not valid semver, so
+          # EVERY operation against EVERY resource this provider owns fails
+          # at the provider-handshake step, before any real diffing even
+          # starts — found in production via `pulumi preview` on litellm/prod
+          # after v0.20.2 was already released and consumed downstream.
+          #
+          # checks.provider-version-stamped below asserts the built binary
+          # actually reports providerVersion, not just that this line exists.
+          ldflags = ["-X" "github.com/jmmaloney4/sector7/provider/version.Version=${providerVersion}"];
+        };
 
         # Asserts the plugin binary's SELF-REPORTED version — not just that an
         # ldflags line exists in this file, which regressing to `dev` would
@@ -145,10 +149,13 @@
         checks.provider-version-stamped =
           pkgs.runCommand "provider-version-stamped" {
             nativeBuildInputs = [pkgs.pulumi-bin pkgs.jq];
+            # Passed through the environment, not string-interpolated into the
+            # script, so nothing about the value's content — however it is
+            # ever derived in the future — is interpreted by the shell.
+            want = providerVersion;
           } ''
             set -euo pipefail
             bin=${config.packages.pulumi-resource-sector7}/bin/pulumi-resource-sector7
-            want="${(builtins.fromJSON (builtins.readFile ./packages/sector7/package.json)).version}"
             got=$(pulumi package get-schema "$bin" | jq -r .version)
             if [ "$got" != "$want" ]; then
               echo "plugin reports version '$got' via get-schema, expected '$want' —" \

--- a/flake.nix
+++ b/flake.nix
@@ -92,20 +92,72 @@
         # downstream consumers; exposing it here means sector7's own CI builds
         # it on every PR (compute-flake-build-matrix selects packages.*), so Go
         # breakage surfaces in this repo rather than in jackpkgs.
-        packages.pulumi-resource-sector7 = pkgs.buildGoModule {
-          pname = "pulumi-resource-sector7";
-          version =
+        packages.pulumi-resource-sector7 = let
+          providerVersion =
             (builtins.fromJSON (builtins.readFile ./packages/sector7/package.json)).version;
-          src = ./.;
-          modRoot = "provider";
-          # Maintained hash rather than a committed provider/vendor/: vendoring
-          # this tree is 83 MB / 6518 files (client-go + the Pulumi SDK), which
-          # would roughly triple the repo. A stale hash reds this repo's CI,
-          # never a consumer's.
-          vendorHash = "sha256-sGg1c8lDx94MqpEPIlVB1YHp/ZouJnphyz0+BWhnffI=";
-          subPackages = ["cmd/pulumi-resource-sector7"];
-          meta.mainProgram = "pulumi-resource-sector7";
-        };
+        in
+          pkgs.buildGoModule {
+            pname = "pulumi-resource-sector7";
+            version = providerVersion;
+            src = ./.;
+            modRoot = "provider";
+            # Maintained hash rather than a committed provider/vendor/: vendoring
+            # this tree is 83 MB / 6518 files (client-go + the Pulumi SDK), which
+            # would roughly triple the repo. A stale hash reds this repo's CI,
+            # never a consumer's.
+            vendorHash = "sha256-sGg1c8lDx94MqpEPIlVB1YHp/ZouJnphyz0+BWhnffI=";
+            subPackages = ["cmd/pulumi-resource-sector7"];
+            meta.mainProgram = "pulumi-resource-sector7";
+            # provider/version/version.go defaults Version to "dev" precisely so
+            # a build that forgets this line fails LOUDLY rather than silently
+            # shipping a plugin that reports itself as "dev" to the Pulumi
+            # engine. It does exactly that: "dev" is not valid semver, so
+            # EVERY operation against EVERY resource this provider owns fails
+            # at the provider-handshake step, before any real diffing even
+            # starts — found in production via `pulumi preview` on litellm/prod
+            # after v0.20.2 was already released and consumed downstream.
+            #
+            # checks.provider-version-stamped below asserts the built binary
+            # actually reports providerVersion, not just that this line exists.
+            ldflags = ["-X" "github.com/jmmaloney4/sector7/provider/version.Version=${providerVersion}"];
+          };
+
+        # Asserts the plugin binary's SELF-REPORTED version — not just that an
+        # ldflags line exists in this file, which regressing to `dev` would
+        # leave syntactically present but silently wrong (e.g. a typo'd
+        # package path that Go accepts silently without ever linking against
+        # the real `version.Version` symbol).
+        #
+        # `pulumi package get-schema <bin>` is the right tool for this, not a
+        # `strings`/grep scan of the binary: Go's `-ldflags -X` stores the
+        # string with no guaranteed null-byte boundary before it, so a raw
+        # byte-run scanner can merge it with adjacent binary data (observed:
+        # the actually-correct value showed up as "L0.20.2", an unrelated
+        # preceding byte glued onto the front — this exact version number ALSO
+        # coincidentally collides with an unrelated vendored dependency's own
+        # pinned version string elsewhere in the binary, `go-openapi/jsonref-
+        # erence@v0.20.2`, so even a substring match would have given a false
+        # pass). `get-schema` sidesteps all of that: it drives the binary
+        # through its real plugin-info path and hands back a JSON `version`
+        # field with no ambiguity about string boundaries — confirmed this
+        # reports literally `"version": "dev"` against the broken binary that
+        # failed on litellm/prod, before this fix.
+        checks.provider-version-stamped =
+          pkgs.runCommand "provider-version-stamped" {
+            nativeBuildInputs = [pkgs.pulumi-bin pkgs.jq];
+          } ''
+            set -euo pipefail
+            bin=${config.packages.pulumi-resource-sector7}/bin/pulumi-resource-sector7
+            want="${(builtins.fromJSON (builtins.readFile ./packages/sector7/package.json)).version}"
+            got=$(pulumi package get-schema "$bin" | jq -r .version)
+            if [ "$got" != "$want" ]; then
+              echo "plugin reports version '$got' via get-schema, expected '$want' —" \
+                   "ldflags did not stamp the binary. This is exactly the bug that made" \
+                   "every operation on every sector7 resource fail on litellm/prod." >&2
+              exit 1
+            fi
+            touch $out
+          '';
 
         # `go test ./...` across every resource package.
         #

--- a/provider/version/version.go
+++ b/provider/version/version.go
@@ -6,13 +6,20 @@ package version
 //
 //	-ldflags "-X github.com/jmmaloney4/sector7/provider/version.Version=<v>"
 //
-// by the Nix derivation (pkgs/pulumi-resource-sector7 in jackpkgs), which
-// derives <v> from the nvfetcher-pinned release tag with the leading "v"
-// stripped.
+// by packages.pulumi-resource-sector7 in THIS repo's own flake.nix (not
+// jackpkgs — packaging moved here so this repo's own CI builds the plugin on
+// every PR; see the comment on that derivation), which reads <v> straight
+// off packages/sector7/package.json. checks.provider-version-stamped in the
+// same flake.nix asserts the built binary actually reports that version via
+// `pulumi package get-schema`, not just that this ldflags line is present —
+// a build that silently drops the -X flag (e.g. a bad module path) leaves
+// this var at its "dev" default with no other visible signal, which is
+// exactly what shipped in v0.20.2 and made every operation on every sector7
+// resource fail on litellm/prod.
 //
-// This MUST match the version the TypeScript wrappers pass in
-// CustomResourceOptions.version, or the engine reports
-// "no resource plugin 'sector7' found in the workspace at version vX.Y.Z".
-// garden's checks.sector7-plugin-lockstep asserts that invariant at
-// `nix flake check` time rather than at deploy time.
+// The reported version MUST match the version the TypeScript wrappers pass
+// in CustomResourceOptions.version, or the engine reports "no resource
+// plugin 'sector7' found in the workspace at version vX.Y.Z". garden's
+// checks.sector7-plugin-lockstep asserts THAT invariant, at `nix flake
+// check` time rather than at deploy time.
 var Version = "dev"


### PR DESCRIPTION
## Summary

The released `v0.20.2` plugin reports its own version to the Pulumi engine as the literal string `"dev"` instead of `"0.20.2"`. Found in production, not in testing: `pulumi preview -C deploy/services/litellm -s prod` (garden#1582, the just-merged plugin-wiring PR) failed outright with

```
error: Invalid character(s) found in major number "dev"
```

attributed to `pulumi:providers:sector7::default_0_20_2`, before any resource-level diffing could even start. This is **not litellm-specific** — every operation against every resource this provider owns fails the same way, since `"dev"` is not valid semver and the engine rejects it at the provider handshake, before `Check`/`Diff`/anything resource-specific ever runs.

## Root cause

`packages.pulumi-resource-sector7` in this repo's own `flake.nix` never passed `ldflags` to `buildGoModule`, so `provider/version/version.go`'s `var Version = "dev"` default was never overwritten — in every build, including the one already released.

`version.go`'s own comment explains why this slipped through: it said the injection happened "by the Nix derivation (`pkgs/pulumi-resource-sector7` in jackpkgs)" — the *original* plan, before packaging moved into this repo's own flake (a documented deviation, see the migration plan's STATUS section). The ldflags line never got carried over to the new location, and the stale comment pointed at the wrong place, so nothing flagged the gap during review.

## Fix

Adds `ldflags = ["-X" "…/version.Version=${providerVersion}"]` to the `buildGoModule` derivation, and corrects the stale comment in `version.go`.

## Regression guard: `checks.provider-version-stamped`

Deliberately **not** a `strings`/`grep` scan of the binary. I tried that first and it produced a false negative I had to chase down: Go's `-ldflags -X` stores the string with no guaranteed null-byte boundary before it, so a raw byte-run scanner can merge it with adjacent binary data — the correctly-injected value showed up as `"L0.20.2"`, an unrelated preceding byte glued onto the front. Worse, this *exact* version number coincidentally collides with an unrelated vendored dependency's own pinned version elsewhere in the binary (`go-openapi/jsonreference@v0.20.2`), so even a plain substring match would have given a **false pass** with ldflags completely broken.

Instead the check runs `pulumi package get-schema <bin>` and asserts the JSON `version` field — the same code path the Pulumi engine itself exercises, with no string-boundary ambiguity. Verified:
- reports literally `"dev"` against the pre-fix binary (reproduced the exact bug)
- reports the correct version after the fix
- **fails loudly** when the ldflags line is removed (negative control) — actually fails even earlier than my own assertion, at `get-schema`'s own schema-binding step, which refuses to parse a non-semver version

## Functional verification against the actual bug

With this fix applied via a local flake override (`--override-input sector7 path:…`, nothing merged yet), ran the real acceptance test: `pulumi preview -C deploy/services/litellm -s prod --show-sames`.

Every `sector7:litellm:ApiKey`/`Team`/`KeyRecord`/`TeamRecord` resource and every `RandomPassword` child (the 6 live API key secrets) shows `(same)` under its retyped URN — the alias absorbed the dynamic-provider-to-plugin retype with **zero** diff, exactly as designed:

```
sector7:litellm:ApiKey$sector7:litellm:KeyRecord::adr-compliance-bot-key-key: (same)
  [provider: …pulumi-nodejs::default::93dfeeb9… => …sector7::default_0_20_2::[unknown]]
```

The only pending changes in that preview (8 update, 6 replace) are unrelated pre-existing drift in `codex-proxy`/quota-exporter Nix images — confirmed by URN, not by absence, that none of them touch `sector7:litellm:` or `randomPassword`.

## Test plan

- [x] `gofmt -l provider/` clean
- [x] `go build`, `go vet`, `go test -race ./...` — all 7 packages pass
- [x] `nix build .#checks.x86_64-linux.provider-go-test` — pass
- [x] `nix build .#checks.x86_64-linux.provider-version-stamped` — pass, and fails correctly on a negative control
- [x] `nix build .#checks.x86_64-linux.treefmt` — fails only on 7 pre-existing files unrelated to this diff (sector7#347)
- [x] End-to-end functional verification against real litellm/prod state, as above

## Not in this PR

Cutting the release and re-wiring garden — that's the next step once this merges.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

https://claude.ai/code/session_014fxmGtPEGqWumJw8yyHfHb