### PR TITLE
fix(provider): wire a real kube.Transport into port-forwarded resources

### DIFF
--- a/provider/provider.go
+++ b/provider/provider.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/jmmaloney4/sector7/provider/attic"
 	"github.com/jmmaloney4/sector7/provider/d1"
+	"github.com/jmmaloney4/sector7/provider/internal/kube"
 	"github.com/jmmaloney4/sector7/provider/litellm"
 	"github.com/jmmaloney4/sector7/provider/matrix"
 	"github.com/jmmaloney4/sector7/provider/onepassword"
@@ -36,6 +37,20 @@ const Name = "sector7"
 // with the dynamic provider it replaces, so that retyping a live resource via
 // `aliases: [{ type: "pulumi-nodejs:dynamic:Resource" }]` diffs to nothing.
 func New() (p.Provider, error) {
+	// ONE transport shared by every port-forwarded resource.
+	//
+	// Sharing is deliberate: SPDYTransport caches *rest.Config per kubeconfig
+	// payload, so a single instance parses each kubeconfig once for the whole
+	// process, and its mutex makes that cache safe under Pulumi's concurrent
+	// gRPC serving. It caches configs, never forwards — each CRUD call still
+	// opens its own port-forward.
+	//
+	// Passing it is NOT optional. kube.Transport is an interface, so a resource
+	// registered as a bare `litellm.KeyRecord{}` carries a nil transport and
+	// SEGFAULTS the whole provider process the moment it reaches connect() —
+	// see resources() below.
+	transport := &kube.SPDYTransport{}
+
 	return infer.NewProviderBuilder().
 		WithNamespace("jmmaloney4").
 		WithDisplayName("sector7").
@@ -43,24 +58,51 @@ func New() (p.Provider, error) {
 		WithHomepage("https://github.com/jmmaloney4/sector7").
 		WithRepository("https://github.com/jmmaloney4/sector7").
 		WithLicense("MIT").
-		WithResources(
-			// The token's module segment is derived from the Go package name,
-			// so this registers as `sector7:litellm:TeamRecord` — matching the
-			// token the TypeScript wrapper passes to pulumi.CustomResource.
-			infer.Resource(litellm.TeamRecord{}),
-			infer.Resource(litellm.KeyRecord{}),
-			infer.Resource(onepassword.Item{}),
-			infer.Resource(attic.Cache{}),
-			infer.Resource(attic.Token{}),
-			infer.Resource(d1.Query{}),
-			infer.Resource(r2.ZoneCachePurge{}),
-			infer.Resource(r2.Object{}),
-			// Matrix resources were garden-LOCAL dynamic providers, not
-			// sector7 ones. They live here because they carry the identical
-			// serialised-closure fragility and a second plugin binary would
-			// duplicate all the packaging, discovery and release machinery.
-			infer.Resource(matrix.BotAccount{}),
-			infer.Resource(matrix.Room{}),
-		).
+		WithResources(resources(transport)...).
 		Build()
+}
+
+// resources is every resource this provider serves, wired to tr.
+//
+// Split out of New so TestEveryKubeBackedResourceHasATransport can reflect over
+// the exact values New registers. That test exists because the first four
+// entries below shipped with a nil Transport from the very first release and
+// nothing caught it for five releases: unit tests always construct these types
+// with an explicit kube.Fake, and Check/Diff never touch the transport, so
+// `preview` and `up` stayed green while the state was byte-identical. The first
+// real Read — `pulumi refresh` against litellm/prod, after the migration had
+// already landed — took the provider down with
+//
+//	panic: runtime error: invalid memory address or nil pointer dereference
+//	  ...litellm.connect(...) client.go:43
+//	  ...litellm.KeyRecord.Read(...) key.go:315
+//
+// A nil interface field is invisible to the compiler and to every test that
+// bothers to populate it, which is exactly the shape of bug that needs a
+// structural check rather than another unit test.
+func resources(tr kube.Transport) []infer.InferredResource {
+	return []infer.InferredResource{
+		// The token's module segment is derived from the Go package name,
+		// so this registers as `sector7:litellm:TeamRecord` — matching the
+		// token the TypeScript wrapper passes to pulumi.CustomResource.
+		infer.Resource(litellm.TeamRecord{Transport: tr}),
+		infer.Resource(litellm.KeyRecord{Transport: tr}),
+		infer.Resource(onepassword.Item{Transport: tr}),
+		infer.Resource(attic.Cache{Transport: tr}),
+		// attic.Token mints a JWT locally and never calls a server, so it
+		// needs no transport — the reason it has no Transport field at all.
+		infer.Resource(attic.Token{}),
+		// d1 and r2 talk to the Cloudflare API directly over the public
+		// internet; only ClusterIP-only Services need a port-forward.
+		infer.Resource(d1.Query{}),
+		infer.Resource(r2.ZoneCachePurge{}),
+		infer.Resource(r2.Object{}),
+		// Matrix resources were garden-LOCAL dynamic providers, not
+		// sector7 ones. They live here because they carry the identical
+		// serialised-closure fragility and a second plugin binary would
+		// duplicate all the packaging, discovery and release machinery.
+		// homeserverUrl is a public URL, so no transport either.
+		infer.Resource(matrix.BotAccount{}),
+		infer.Resource(matrix.Room{}),
+	}
 }

--- a/provider/provider_test.go
+++ b/provider/provider_test.go
@@ -1,0 +1,102 @@
+package provider
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/jmmaloney4/sector7/provider/internal/kube"
+)
+
+// kubeBackedResourceCount is how many registered resources reach a
+// ClusterIP-only Service through a port-forward: litellm's TeamRecord and
+// KeyRecord, onepassword's Item, and attic's Cache.
+//
+// Deliberately hardcoded. If you add a resource with a kube.Transport field
+// this test fails until you bump it, which is the point: the bump is the
+// moment you confirm the new resource is actually wired in resources() rather
+// than registered as a bare struct literal.
+const kubeBackedResourceCount = 4
+
+// Every resource carrying a kube.Transport field must be registered WITH a
+// transport, not as a bare struct literal.
+//
+// This is a structural check rather than a behavioural one because the bug it
+// guards is structural, and nothing behavioural caught it. `litellm.KeyRecord{}`
+// and three siblings shipped with a nil Transport from the provider's first
+// release and survived five of them:
+//
+//   - every unit test constructs these types with an explicit kube.Fake, so
+//     the zero-value path is never exercised;
+//   - Check and Diff never touch the transport, so `pulumi preview` and
+//     `pulumi up` stayed green as long as state was byte-identical — which is
+//     exactly what the alias migration was engineered to produce.
+//
+// The first operation to actually open a port-forward was a `pulumi refresh`
+// against litellm/prod, after the migration had already landed, and it took
+// the whole provider process down:
+//
+//	panic: runtime error: invalid memory address or nil pointer dereference
+//	  [signal SIGSEGV: segmentation violation]
+//	  ...provider/litellm.connect(...)      client.go:43
+//	  ...provider/litellm.KeyRecord.Read(...) key.go:315
+//
+// A nil interface field is invisible to the compiler, and invisible to any
+// test that dutifully populates it. Hence reflection over the real
+// registration list.
+func TestEveryKubeBackedResourceHasATransport(t *testing.T) {
+	transportType := reflect.TypeOf((*kube.Transport)(nil)).Elem()
+
+	checked := 0
+	for i, res := range resources(&kube.SPDYTransport{}) {
+		rsc := registeredValue(t, i, res)
+
+		for j := range rsc.NumField() {
+			if rsc.Type().Field(j).Type != transportType {
+				continue
+			}
+			checked++
+			if rsc.Field(j).IsNil() {
+				t.Errorf("%s.%s is nil: this segfaults the entire provider process "+
+					"on the first operation that opens a port-forward",
+					rsc.Type(), rsc.Type().Field(j).Name)
+			}
+		}
+	}
+
+	// Guard the guard. If the reflection below ever stops finding the
+	// registered values — a pulumi-go-provider refactor, a resource switched to
+	// a pointer receiver — every assertion above silently stops running and
+	// this test passes while asserting nothing.
+	if checked != kubeBackedResourceCount {
+		t.Fatalf("inspected %d kube.Transport fields, expected %d: either a "+
+			"port-forwarded resource was added without updating "+
+			"kubeBackedResourceCount, or this test can no longer see what "+
+			"resources() registers", checked, kubeBackedResourceCount)
+	}
+}
+
+// registeredValue digs the resource value back out of an infer.InferredResource.
+//
+// infer.Resource stores it as derivedResourceController.receiver (*R), with no
+// exported accessor. Reading it through reflection is the price of asserting
+// against what New() ACTUALLY registers instead of against a reconstruction —
+// and a reconstruction is worthless here, since the bug was that the real list
+// and a correct-looking one had diverged.
+func registeredValue(t *testing.T, i int, res any) reflect.Value {
+	t.Helper()
+
+	v := reflect.ValueOf(res)
+	if v.Kind() == reflect.Pointer {
+		v = v.Elem()
+	}
+	receiver := v.FieldByName("receiver")
+	if !receiver.IsValid() || receiver.Kind() != reflect.Pointer {
+		t.Fatalf("resource %d (%T): cannot reach derivedResourceController.receiver; "+
+			"pulumi-go-provider's internals changed and this test is now blind", i, res)
+	}
+	rsc := receiver.Elem()
+	if rsc.Kind() != reflect.Struct {
+		t.Fatalf("resource %d (%T): receiver points at %s, not a struct", i, res, rsc.Kind())
+	}
+	return rsc
+}


### PR DESCRIPTION
## Summary

Four resources — `litellm.TeamRecord`, `litellm.KeyRecord`, `onepassword.Item`, `attic.Cache` — were registered as bare struct literals, leaving their `kube.Transport` **interface field nil**. The first operation to actually open a port-forward segfaulted the whole provider process:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18]
  ...provider/litellm.connect(...)        client.go:43
  ...provider/litellm.KeyRecord.Read(...) key.go:315
```

Found by running `pulumi refresh` against `litellm/prod` right after the migration landed — the acceptance test this entire migration exists to make possible.

`internal/kube/kube.go`'s own package comment already said *"production wires SPDYTransport"*. It simply never did.

## Why this survived five releases

Nothing in the test or deploy path ever exercised the zero value:

- **Every unit test** constructs these types with an explicit `kube.Fake`, so the nil path is unreachable in `go test`.
- **`Check` and `Diff` never touch the transport**, so `pulumi preview` and `pulumi up` stayed green for as long as state was byte-identical — which is *exactly* what the alias migration was engineered to produce. The migration succeeding is what kept the bug hidden.

A nil interface field is invisible to the compiler and to any test that dutifully populates it.

## Fix

One shared `*kube.SPDYTransport` passed to the four resources that need it. Sharing is deliberate: it caches `*rest.Config` per kubeconfig payload behind a mutex, so a single instance parses each kubeconfig once per process, while still opening a fresh forward per CRUD call.

`attic.Token` (mints a JWT locally), `d1`, `r2` and `matrix` (public APIs) correctly have no transport field at all — I verified this by scanning every resource struct rather than assuming.

## Regression guard

`TestEveryKubeBackedResourceHasATransport` is a **structural** check, because the bug is structural and nothing behavioural caught it.

The resource list moves into `resources(tr)` so the test can reflect over *exactly what `New()` registers* rather than a reconstruction — a reconstruction would be worthless here, since the defect was precisely that the real list and a correct-looking one had diverged. It digs out `derivedResourceController.receiver` by reflection, and guards itself with an expected-count assertion so a `pulumi-go-provider` refactor makes it fail loudly instead of passing vacuously.

Verified in both directions:
- passes on this tree
- reverting one resource to a bare literal fails it with `litellm.KeyRecord.Transport is nil: this segfaults the entire provider process...`

## Verified against the real bug

With this build linked, `pulumi refresh -C deploy/services/litellm -s prod`:

- **zero** `panic` / `SIGSEGV` occurrences (was: process death)
- the provider now loads the kubeconfig, authenticates, and issues a real Kubernetes API call
- it surfaces a clean, actionable error instead of a segfault

## Separate pre-existing issue this now makes visible

With the crash gone, `refresh` reveals what was underneath:

```
sector7: reading deployment litellm/litellm: deployments.apps "litellm" is forbidden:
User "pulumi-zeus" cannot get resource "deployments" in API group "apps" in the namespace "litellm"
```

`kubectl auth can-i` under the only available context confirms `pulumi-zeus` has **none** of the three permissions a port-forward requires:

| permission | result |
|---|---|
| `get deployments -n litellm` | no |
| `create pods/portforward -n litellm` | no |
| `list pods -n litellm` | no |

This is **not** caused by this PR or by the migration — the TypeScript dynamic provider needed the exact same permissions and used the same ambient kubeconfig. It was masked by two successive earlier failures: first `ERR_MODULE_NOT_FOUND` (the serialised-closure bug that motivated this whole migration), then this segfault. It is an RBAC/infrastructure matter, tracked separately — deliberately not addressed here.

Practical impact: `preview`/`up` on unchanged resources are unaffected (confirmed — litellm/prod's migration `up` succeeded earlier). `refresh`, and any real change to a LiteLLM key/team, Attic cache, or 1Password item, needs the RBAC granted.

## Test plan

- [x] `gofmt -l`, `go build`, `go vet` clean
- [x] `go test -race ./...` — all 8 packages pass
- [x] `nix build .#checks.x86_64-linux.provider-go-test` — pass
- [x] Negative control on the new test — fails correctly
- [x] Real `pulumi refresh` against `litellm/prod` — panic gone

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

https://claude.ai/code/session_014fxmGtPEGqWumJw8yyHfHb