### PR TITLE
feat(litellm): accept an explicit kubeconfig for the admin port-forward

### DIFF
--- a/packages/sector7/litellm/admin.ts
+++ b/packages/sector7/litellm/admin.ts
@@ -61,6 +61,11 @@ function pluginOpts(
  */
 function teamProviderInputs(args: LiteLLMTeamArgs) {
 	return {
+		// Passed through rather than defaulted to "": undefined is omitted from
+		// the inputs entirely, so a resource that never set a kubeconfig keeps
+		// decoding to the Go zero value and diffs to nothing. Same reasoning as
+		// `maxBudget` below.
+		kubeconfig: args.kubeconfig,
 		proxyNamespace: args.proxyNamespace,
 		masterKey: args.masterKey,
 		proxyDeploymentName: pulumi.output(args.proxyDeploymentName ?? "litellm"),
@@ -130,6 +135,11 @@ function keyProviderInputs(
 	keyValue: pulumi.Output<string>,
 ) {
 	return {
+		// Passed through rather than defaulted to "": undefined is omitted from
+		// the inputs entirely, so a resource that never set a kubeconfig keeps
+		// decoding to the Go zero value and diffs to nothing. Same reasoning as
+		// `maxBudget` below.
+		kubeconfig: args.kubeconfig,
 		proxyNamespace: args.proxyNamespace,
 		masterKey: args.masterKey,
 		proxyDeploymentName: pulumi.output(args.proxyDeploymentName ?? "litellm"),

--- a/packages/sector7/litellm/config-types.ts
+++ b/packages/sector7/litellm/config-types.ts
@@ -237,6 +237,24 @@ export interface LiteLLMGeneratedConfig {
 }
 
 export interface LiteLLMAdminTargetArgs {
+	/**
+	 * Kubeconfig YAML used to open the admin port-forward. Omit to use the
+	 * ambient default config.
+	 *
+	 * Pass this. The ambient config is whatever `kubectl` happens to point at,
+	 * which is usually NOT the identity the rest of the stack deploys with:
+	 * garden binds its `k8s.Provider` to the platform kubeconfig via
+	 * `getK8sProvider`, and `OnePasswordItem` already takes this same input for
+	 * exactly this reason. Leaving it unset is why a narrower ambient identity
+	 * gets refused:
+	 *
+	 *   deployments.apps "litellm" is forbidden: User "pulumi-zeus" cannot get
+	 *   resource "deployments" in API group "apps" in the namespace "litellm"
+	 *
+	 * Optional rather than required so resources retyped by the plugin
+	 * migration keep decoding — no existing state carries it.
+	 */
+	kubeconfig?: pulumi.Input<string>;
 	proxyNamespace: pulumi.Input<string>;
 	masterKey: pulumi.Input<string>;
 	proxyDeploymentName?: pulumi.Input<string>;

--- a/provider/internal/kube/kube.go
+++ b/provider/internal/kube/kube.go
@@ -56,10 +56,19 @@ type Fake struct {
 	// Connects counts calls, so tests can assert the per-operation forward
 	// behaviour (each CRUD method opens its own).
 	Connects int
+	// LastTarget is the most recent Target received.
+	//
+	// Without it a resource can silently drop part of its connection inputs —
+	// Kubeconfig especially — and every test still passes, because the Fake
+	// ignores the Target and hands back the same BaseURL regardless. The only
+	// visible symptom is in production, as a port-forward opened against the
+	// wrong cluster identity.
+	LastTarget Target
 }
 
 func (f *Fake) Connect(_ context.Context, t Target) (*Conn, error) {
 	f.Connects++
+	f.LastTarget = t
 	host := f.HostVal
 	if host == "" {
 		host = t.Deployment + "." + t.Namespace + ".svc.cluster.local"

--- a/provider/litellm/client.go
+++ b/provider/litellm/client.go
@@ -24,6 +24,25 @@ import (
 // `aliases: [{ type: "pulumi-nodejs:dynamic:Resource" }]` diffs to nothing.
 // Do not "improve" these names in the retype release.
 type AdminTarget struct {
+	// Kubeconfig is YAML; empty means the ambient default config.
+	//
+	// Added after the retype, so it is genuinely new rather than
+	// state-compatible — no live resource carries it. Without it these
+	// resources fall back to whatever kubeconfig happens to be ambient, which
+	// is NOT the identity the rest of the stack deploys with: garden's litellm
+	// stack binds its k8s.Provider to the platform kubeconfig
+	// (deploy/lib/index.ts getK8sProvider), and OnePasswordItem in that same
+	// file already passes it explicitly for exactly this reason. Only the
+	// LiteLLM resources were left reading the ambient config, so on a machine
+	// whose kubeconfig is the narrower `pulumi-zeus` deploy identity every
+	// port-forward is refused:
+	//
+	//	deployments.apps "litellm" is forbidden: User "pulumi-zeus" cannot get
+	//	resource "deployments" in API group "apps" in the namespace "litellm"
+	//
+	// Secret because a kubeconfig carries client certificates and keys —
+	// matching onepassword.ItemArgs.Kubeconfig.
+	Kubeconfig     string `pulumi:"kubeconfig,optional" provider:"secret"`
 	ProxyNamespace string `pulumi:"proxyNamespace"`
 	// MasterKey is secret here even though the dynamic provider did NOT mark it
 	// so — it currently sits in plaintext in litellm/prod state on eight
@@ -34,6 +53,15 @@ type AdminTarget struct {
 	ProxyPort           int    `pulumi:"proxyPort,optional"`
 }
 
+// Changed reports whether the connection half of the inputs differs.
+//
+// Shared by KeyRecord.Diff and TeamRecord.Diff so the two can never disagree
+// about what an admin-target change is — adding Kubeconfig to one and not the
+// other would leave a rotated kubeconfig stranded in one resource's state.
+func (t AdminTarget) Changed(other AdminTarget) bool {
+	return t != other
+}
+
 // connect opens a port-forward and returns a client bound to it, plus the
 // teardown. Every CRUD method opens its own forward rather than sharing one:
 // keys `dependsOn` the proxy, so a rollout immediately precedes these calls and
@@ -41,6 +69,7 @@ type AdminTarget struct {
 // check exists to avoid.
 func connect(ctx context.Context, tr kube.Transport, t AdminTarget) (*httpx.Client, func(), error) {
 	conn, err := tr.Connect(ctx, kube.Target{
+		Kubeconfig: t.Kubeconfig,
 		Namespace:  t.ProxyNamespace,
 		Deployment: t.ProxyDeploymentName,
 		Port:       t.ProxyPort,

--- a/provider/litellm/key.go
+++ b/provider/litellm/key.go
@@ -97,10 +97,7 @@ func (KeyRecord) Diff(_ context.Context, req infer.DiffRequest[KeyArgs, KeyState
 		diffs["teamId"] = p.PropertyDiff{Kind: p.UpdateReplace}
 	}
 
-	if olds.ProxyNamespace != news.ProxyNamespace ||
-		olds.ProxyDeploymentName != news.ProxyDeploymentName ||
-		olds.ProxyPort != news.ProxyPort ||
-		olds.MasterKey != news.MasterKey {
+	if olds.AdminTarget.Changed(news.AdminTarget) {
 		diffs["adminTarget"] = p.PropertyDiff{Kind: p.Update}
 	}
 	if olds.KeyAlias != news.KeyAlias {

--- a/provider/litellm/key_test.go
+++ b/provider/litellm/key_test.go
@@ -425,3 +425,76 @@ func TestKeyDeleteToleratesAlreadyGone(t *testing.T) {
 		}
 	})
 }
+
+// The kubeconfig must actually reach the transport.
+//
+// The ambient default config is whatever kubectl happens to point at, which is
+// usually NOT the identity the rest of the stack deploys with. Dropping this
+// input anywhere between the resource and kube.Target is invisible to every
+// other test — the Fake ignores the Target and returns the same BaseURL — and
+// shows up only in production, as a port-forward refused for the wrong user:
+//
+//	deployments.apps "litellm" is forbidden: User "pulumi-zeus" cannot get
+//	resource "deployments" in API group "apps" in the namespace "litellm"
+func TestAdminTargetKubeconfigReachesTheTransport(t *testing.T) {
+	const kubeconfig = "apiVersion: v1\nkind: Config\n# platform identity\n"
+
+	t.Run("forwarded when set", func(t *testing.T) {
+		h := newHarness(t, nil)
+		args := baseKeyArgs()
+		args.Kubeconfig = kubeconfig
+
+		if _, _, err := connect(t.Context(), h.tr, args.AdminTarget); err != nil {
+			t.Fatal(err)
+		}
+		if got := h.tr.LastTarget.Kubeconfig; got != kubeconfig {
+			t.Fatalf("kubeconfig did not reach kube.Target: got %q", got)
+		}
+		// The rest of the target must still be carried, or a correct
+		// kubeconfig would just point at the wrong deployment.
+		if h.tr.LastTarget.Namespace != "litellm" ||
+			h.tr.LastTarget.Deployment != "litellm" ||
+			h.tr.LastTarget.Port != 4000 {
+			t.Fatalf("rest of the target was dropped: %+v", h.tr.LastTarget)
+		}
+	})
+
+	t.Run("empty when unset, meaning ambient", func(t *testing.T) {
+		h := newHarness(t, nil)
+		if _, _, err := connect(t.Context(), h.tr, baseKeyArgs().AdminTarget); err != nil {
+			t.Fatal(err)
+		}
+		if got := h.tr.LastTarget.Kubeconfig; got != "" {
+			t.Fatalf("unset kubeconfig must stay empty (ambient), got %q", got)
+		}
+	})
+}
+
+// A rotated kubeconfig has to land in state, or every later operation keeps
+// using the stale one. Both resources share AdminTarget.Changed so they cannot
+// disagree about what counts as an admin-target change.
+func TestKubeconfigChangeIsAnAdminTargetDiff(t *testing.T) {
+	old := KeyState{KeyArgs: baseKeyArgs()}
+	news := baseKeyArgs()
+	news.Kubeconfig = "apiVersion: v1\nkind: Config\n# rotated\n"
+
+	r, err := KeyRecord{}.Diff(t.Context(), infer.DiffRequest[KeyArgs, KeyState]{State: old, Inputs: news})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r.DetailedDiff["adminTarget"].Kind != p.Update {
+		t.Fatalf("a rotated kubeconfig must be an in-place adminTarget update; got %+v", r.DetailedDiff)
+	}
+	for name, d := range r.DetailedDiff {
+		if d.Kind == p.UpdateReplace {
+			t.Fatalf("a kubeconfig change must never replace a live key (%s did)", name)
+		}
+	}
+
+	// Unchanged inputs must stay a no-op — this is what keeps the six live
+	// credentials from churning on every apply.
+	r, _ = KeyRecord{}.Diff(t.Context(), infer.DiffRequest[KeyArgs, KeyState]{State: old, Inputs: baseKeyArgs()})
+	if r.HasChanges {
+		t.Fatalf("unchanged inputs must not diff; got %+v", r.DetailedDiff)
+	}
+}

--- a/provider/litellm/team.go
+++ b/provider/litellm/team.go
@@ -102,10 +102,7 @@ func (TeamRecord) Diff(_ context.Context, req infer.DiffRequest[TeamArgs, TeamSt
 	// An admin-target change does not alter the remote team, but it must still
 	// flow into stored state so a later update/delete targets the new
 	// deployment and uses the new master key rather than the stale ones.
-	if olds.ProxyNamespace != news.ProxyNamespace ||
-		olds.ProxyDeploymentName != news.ProxyDeploymentName ||
-		olds.ProxyPort != news.ProxyPort ||
-		olds.MasterKey != news.MasterKey {
+	if olds.AdminTarget.Changed(news.AdminTarget) {
 		diffs["adminTarget"] = p.PropertyDiff{Kind: p.Update}
 	}
 	if olds.TeamAlias != news.TeamAlias {


### PR DESCRIPTION
## Summary

`LiteLLMApiKey` and `LiteLLMTeam` open their admin port-forward using the **ambient** kubeconfig, while everything else in garden's litellm stack uses the **platform** kubeconfig — its `k8s.Provider` is bound to it via `getK8sProvider`, and `OnePasswordItem` *in that same file* already passes it explicitly. The LiteLLM resources were the only ones left reading whatever `kubectl` happens to point at.

On a machine whose kubeconfig is the narrower `pulumi-zeus` deploy identity, every operation is refused:

```
deployments.apps "litellm" is forbidden: User "pulumi-zeus" cannot get
resource "deployments" in API group "apps" in the namespace "litellm"
```

`deploy/lib/index.ts` already documents explicit kubeconfig as the intended pattern for *"dynamic resources that open their own in-process Kubernetes port-forward and therefore need the raw kubeconfig rather than a bound `k8s.Provider`"*. This closes the gap, rather than widening a deploy identity's RBAC to match an identity the stack already has.

## Design notes

**Optional, not required** — resources retyped by the plugin migration keep decoding; no live state carries this field.

**Secret** — a kubeconfig holds client certificates and keys. Matches `onepassword.ItemArgs.Kubeconfig`.

**Passed through raw in TypeScript, not defaulted to `""`** — `undefined` is omitted from the inputs entirely, so a caller that sets no kubeconfig keeps decoding to the Go zero value and diffs to nothing. Same reasoning as the `maxBudget` sentinel fix.

**Both `Diff`s now route through `AdminTarget.Changed`** instead of hand-listing fields, so `KeyRecord` and `TeamRecord` cannot disagree about what an admin-target change is. Adding a field to one and forgetting the other would strand a rotated kubeconfig in one resource's state — the same class of bug as the four resources that shipped with a nil transport.

**`kube.Fake` gains `LastTarget`.** Without it a resource can silently drop part of its connection inputs and every test still passes, because the Fake ignores the `Target` and returns the same `BaseURL` regardless. The failure is visible only in production, as a port-forward opened against the wrong identity. This is the same reason the nil-transport bug (#349) survived five releases.

## Verification

Both directions, as usual:

- `TestAdminTargetKubeconfigReachesTheTransport` passes — and removing the single line that forwards `Kubeconfig` fails it with `kubeconfig did not reach kube.Target: got ""`
- `TestKubeconfigChangeIsAnAdminTargetDiff` pins that a rotation is an **in-place update, never a replace** of a live key, and that unchanged inputs still diff to nothing (what keeps the six live credentials from churning)

## Test plan

- [x] `nix build .#checks.x86_64-linux.provider-go-test` — pass (gofmt + `go test -race ./...`, all packages)
- [x] Negative control on the new propagation test — fails correctly
- [x] `tsc -p tsconfig.build.json --noEmit` — clean (run directly; see below)
- [x] `vitest run` — 304 tests pass
- [x] `alejandra --check flake.nix` — clean

Two checks fail for reasons **proven pre-existing**, both filed earlier:

| check | cause | proof |
|---|---|---|
| `tsc`, `vitest` (nix) | stale `pnpmDepsHash` (#345) | byte-identical hash mismatch (`wC91t…` vs `QkhFw…`) |
| `treefmt` | 7 unformatted files (#347) | none of them mine — flagged list is `docs/renovate/*`, `pulumi-config/*`, two tests, one renovate json |
| `vitest` suite `renovate-pulumi.test.ts` | "expected exactly one Pulumi customManager, found 2" | reproduced identically on a clean `origin/main` worktree: `1 failed, 24 passed, 304 tests` |

Because #345 blocks the nix `tsc`/`vitest` checks entirely, I compiled and tested the TypeScript directly inside `.#ci-pnpm` instead.

## Scope

`attic.Cache` has the **identical** gap — no `Kubeconfig` field, `connect` never passes one — and is deliberately untouched. `attic/prod` is a separate stack with 13 live resources including host tokens, and nothing is blocked on it today. Worth doing when attic's TypeScript is retyped.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

https://claude.ai/code/session_014fxmGtPEGqWumJw8yyHfHb