### PR TITLE
fix(litellm): never replace a live key on an unknown upstream input

### DIFF
--- a/provider/litellm/key.go
+++ b/provider/litellm/key.go
@@ -90,10 +90,31 @@ func (KeyRecord) Diff(_ context.Context, req infer.DiffRequest[KeyArgs, KeyState
 	olds, news := req.State, req.Inputs
 	diffs := map[string]p.PropertyDiff{}
 
-	if olds.KeyValue != news.KeyValue {
+	// Both replace triggers are guarded on a NON-EMPTY new value.
+	//
+	// An input that is unknown at preview time — because the resource
+	// producing it is itself being updated — decodes to the Go zero value
+	// here, not to an unknown sentinel. Without the guard, a key whose teamId
+	// comes from a LiteLLMTeam output sees "personal" != "" and reports
+	// UpdateReplace, so ANY update to a team threatens to replace every one of
+	// its keys:
+	//
+	//	~ teamId : "personal" => [unknown]
+	//	+-sector7:litellm:KeyRecord: (replace)
+	//
+	// That is six live production credentials in litellm/prod, triggered by
+	// something as ordinary as changing a team's model list. TeamRecord.Diff
+	// has always carried this guard (`news.DesiredTeamID != "" && …`); the key
+	// side never did, and nothing exercised it until a team actually changed.
+	//
+	// The tradeoff is deliberate: deliberately clearing teamId or keyValue back
+	// to empty no longer replaces. Neither is a real operation — a LiteLLM key
+	// always belongs to a team, and Check rejects an empty keyValue — whereas
+	// an unknown upstream is routine.
+	if news.KeyValue != "" && olds.KeyValue != news.KeyValue {
 		diffs["keyValue"] = p.PropertyDiff{Kind: p.UpdateReplace}
 	}
-	if olds.TeamID != news.TeamID {
+	if news.TeamID != "" && olds.TeamID != news.TeamID {
 		diffs["teamId"] = p.PropertyDiff{Kind: p.UpdateReplace}
 	}
 

--- a/provider/litellm/key_test.go
+++ b/provider/litellm/key_test.go
@@ -498,3 +498,61 @@ func TestKubeconfigChangeIsAnAdminTargetDiff(t *testing.T) {
 		t.Fatalf("unchanged inputs must not diff; got %+v", r.DetailedDiff)
 	}
 }
+
+// An unknown upstream input must never replace a live key.
+//
+// This is the exact shape that stopped the litellm/prod kubeconfig rollout:
+// garden's keys take `teamId: personalTeam.teamId`, an OUTPUT of the team. When
+// the team itself updates — for any reason — its outputs are unknown during
+// preview, and an unknown decodes here as the zero value rather than as an
+// unknown sentinel. Before the non-empty guard, all six live production keys
+// planned as replaces:
+//
+//	~ teamId : "personal" => [unknown]
+//	+-sector7:litellm:KeyRecord: (replace)
+//
+// A key is only ever replaced for a REAL, KNOWN change of identity.
+func TestUnknownUpstreamInputNeverReplacesALiveKey(t *testing.T) {
+	old := KeyState{KeyArgs: baseKeyArgs()}
+
+	for _, tc := range []struct {
+		name   string
+		mutate func(*KeyArgs)
+	}{
+		// "" is how infer surfaces an input that is unknown at preview time.
+		{"unknown teamId (team is updating)", func(a *KeyArgs) { a.TeamID = "" }},
+		{"unknown keyValue (RandomPassword is updating)", func(a *KeyArgs) { a.KeyValue = "" }},
+		{"both unknown", func(a *KeyArgs) { a.TeamID = ""; a.KeyValue = "" }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			news := baseKeyArgs()
+			tc.mutate(&news)
+
+			r, err := KeyRecord{}.Diff(t.Context(),
+				infer.DiffRequest[KeyArgs, KeyState]{State: old, Inputs: news})
+			if err != nil {
+				t.Fatal(err)
+			}
+			for name, d := range r.DetailedDiff {
+				if d.Kind == p.UpdateReplace {
+					t.Fatalf("an unknown upstream input must never replace a live key "+
+						"(%s planned a replace); this is six production credentials", name)
+				}
+			}
+		})
+	}
+
+	// The guard must not blunt a REAL identity change — those still replace.
+	for name, mutate := range map[string]func(*KeyArgs){
+		"teamId":   func(a *KeyArgs) { a.TeamID = "cavinsresearch" },
+		"keyValue": func(a *KeyArgs) { a.KeyValue = "sk-rotated" },
+	} {
+		news := baseKeyArgs()
+		mutate(&news)
+		r, _ := KeyRecord{}.Diff(t.Context(),
+			infer.DiffRequest[KeyArgs, KeyState]{State: old, Inputs: news})
+		if r.DetailedDiff[name].Kind != p.UpdateReplace {
+			t.Fatalf("a real %s change must still replace; got %+v", name, r.DetailedDiff)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

`KeyRecord.Diff` replaced on **any** `teamId` or `keyValue` difference — including a difference against the Go zero value. An input that is unknown at preview time (because the resource producing it is itself updating) decodes as `""` here, not as an unknown sentinel. So a key whose `teamId` comes from a `LiteLLMTeam` **output** compared `"personal"` against `""` and planned a replacement:

```
~ teamId : "personal" => [unknown]
+-sector7:litellm:KeyRecord: (replace)
```

That means **any** update to a team threatens to replace every one of its keys — six live production credentials in `litellm/prod` — on something as ordinary as changing a team's model list.

## How it was found

While previewing an unrelated change (wiring an explicit kubeconfig, #350), the migration runbook's gate fired. It names a `KeyRecord` replace as an explicit *stop and fall back to state surgery* condition, so the rollout halted there rather than proceeding on the assumption that the replace would evaporate once the team's real `teamId` resolved.

Pre-existing, not introduced by that change: no team had been updated since the plugin migration, so nothing had exercised this path.

## The asymmetry

`TeamRecord.Diff` has **always** carried this guard:

```go
if news.DesiredTeamID != "" && news.DesiredTeamID != managed {
```

The key side never did. Both replace triggers are now guarded on a non-empty new value.

## Deliberate tradeoff

Clearing `teamId` or `keyValue` back to empty no longer replaces. Neither is a real operation — a LiteLLM key always belongs to a team, and `Check` rejects an empty `keyValue` — whereas an unknown upstream is routine. Documented inline.

## Tests

`TestUnknownUpstreamInputNeverReplacesALiveKey` covers unknown `teamId`, unknown `keyValue`, and both at once. It separately asserts a **real** change to either still replaces, so the guard cannot silently blunt a genuine identity change.

Verified both directions:
- passes on this tree
- removing the `teamId` guard fails it with `an unknown upstream input must never replace a live key (teamId planned a replace); this is six production credentials`

## Test plan

- [x] `nix build .#checks.x86_64-linux.provider-go-test` — pass (gofmt + `go test -race ./...`)
- [x] Negative control — fails correctly

Known-inherited failures, unchanged and not chased: #345 (stale `pnpmDepsHash` breaks the `tsc`/`vitest` nix checks), #347 (treefmt red on 7 files, none in this diff).

## Follow-up

Once released, garden can finally wire `kubeconfig: getPlatformKubeconfig({ environment })` into the LiteLLM resources with a clean preview — the change that surfaced this.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

https://claude.ai/code/session_014fxmGtPEGqWumJw8yyHfHb