### PR TITLE
feat(d1): migrate __provider out of dynamic-provider state

### DIFF
--- a/provider/d1/migrations.go
+++ b/provider/d1/migrations.go
@@ -37,7 +37,13 @@ type queryStateV0 struct {
 	// Provider is the serialized dynamic-provider closure. Declared only so it
 	// can be dropped — nothing reads it, and this is how __provider finally
 	// leaves state.
-	Provider string `pulumi:"__provider,optional"`
+	//
+	// Deliberately NOT optional, and that tag is load-bearing. infer tries this
+	// migrator before the normal decode, so `optional` would make the shape
+	// match plugin-native state too and route every future read through the
+	// migration — the opposite of the additive-safety described above. Required
+	// is what makes native state miss this shape and fall through.
+	Provider string `pulumi:"__provider"`
 }
 
 // StateMigrations satisfies infer.CustomStateMigrations[QueryState].

--- a/provider/d1/migrations.go
+++ b/provider/d1/migrations.go
@@ -1,0 +1,55 @@
+package d1
+
+import (
+	"context"
+
+	"github.com/pulumi/pulumi-go-provider/infer"
+)
+
+// State migration off the dynamic provider.
+//
+// Live state written by the dynamic provider carries `__provider`, the
+// serialized JavaScript closure — the very thing this plugin exists to stop
+// storing. No struct here declares it, and infer treats an unrecognized
+// property as a decode FAILURE rather than something quietly ignored:
+//
+//	Unrecognized field '__provider' on 'd1.QueryState'
+//
+// So without this migration the alias retype does not diff to nothing; it
+// fails outright at the first preview. Verified against the real gRPC path in
+// migrations_test.go using the shape read off uptime/prod.
+//
+// This is simpler than the litellm equivalent, and deliberately so. litellm
+// needed two shapes per resource to discriminate a sentinel-encoded optional
+// (`maxBudget: number | ""`), because a single shape would have made state
+// carrying a real budget fail both the migrator and the normal decode. d1 has
+// no such hazard: accountId, databaseId, sql and apiToken are all strings, so
+// an empty value is a valid value of its own type and decodes fine either way.
+// __provider is the only obstacle, so one shape suffices.
+//
+// The migration is additive-safe: state that never passed through the dynamic
+// provider has no __provider, fails this migrator's decode ("doesn't fit into
+// the migrator", per infer's own docs), and falls through to the normal path
+// unchanged.
+type queryStateV0 struct {
+	QueryArgs
+	SQLHash string `pulumi:"sqlHash,optional"`
+	// Provider is the serialized dynamic-provider closure. Declared only so it
+	// can be dropped — nothing reads it, and this is how __provider finally
+	// leaves state.
+	Provider string `pulumi:"__provider,optional"`
+}
+
+// StateMigrations satisfies infer.CustomStateMigrations[QueryState].
+func (Query) StateMigrations(context.Context) []infer.StateMigrationFunc[QueryState] {
+	return []infer.StateMigrationFunc[QueryState]{
+		infer.StateMigration(func(_ context.Context, old queryStateV0) (infer.MigrationResult[QueryState], error) {
+			return infer.MigrationResult[QueryState]{
+				Result: &QueryState{
+					QueryArgs: old.QueryArgs,
+					SQLHash:   old.SQLHash,
+				},
+			}, nil
+		}),
+	}
+}

--- a/provider/d1/migrations_test.go
+++ b/provider/d1/migrations_test.go
@@ -1,0 +1,132 @@
+package d1
+
+import (
+	"context"
+	"testing"
+
+	"github.com/blang/semver"
+	p "github.com/pulumi/pulumi-go-provider"
+	"github.com/pulumi/pulumi-go-provider/infer"
+	"github.com/pulumi/pulumi-go-provider/integration"
+	"github.com/pulumi/pulumi/sdk/v3/go/property"
+)
+
+// liveQueryState mirrors what uptime/prod actually holds today, read off the
+// stack rather than imagined:
+//
+//	pulumi stack export -C deploy/services/uptime -s prod
+//	  urn: …:UptimeMonitor$pulumi-nodejs:dynamic:Resource::uptime-prod-schema
+//	  outputs: __provider, accountId, apiToken, databaseId, sql, sqlHash
+//
+// Every property maps onto QueryArgs/QueryState except __provider — the
+// serialized dynamic-provider closure. Unlike litellm there is no sentinel
+// hazard here: all four inputs are strings, so an empty value is a valid value
+// of its own type and decodes fine. __provider is the only obstacle.
+func liveQueryState() property.Map {
+	return property.NewMap(map[string]property.Value{
+		"accountId":  property.New("acct-123"),
+		"databaseId": property.New("db-456"),
+		"sql":        property.New("CREATE TABLE IF NOT EXISTS checks (id TEXT PRIMARY KEY);"),
+		"apiToken":   property.New("cf-token"),
+		"sqlHash":    property.New("abc123"),
+		"__provider": property.New("4;/deleted/worktree/node_modules/...;closure"),
+	})
+}
+
+// newInputs is what the retyped TypeScript wrapper sends: the same values,
+// minus __provider (which belonged to the dynamic provider) and minus sqlHash
+// (an output, not an input).
+func newInputs() property.Map {
+	return liveQueryState().Delete("__provider", "sqlHash")
+}
+
+func testServer(t *testing.T) integration.Server {
+	t.Helper()
+	prov, err := infer.NewProviderBuilder().
+		WithNamespace("jmmaloney4").
+		WithResources(infer.Resource(Query{})).
+		Build()
+	if err != nil {
+		t.Fatal(err)
+	}
+	srv, err := integration.NewServer(context.Background(), "sector7",
+		semver.MustParse("0.21.0"), integration.WithProvider(prov))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return srv
+}
+
+// THE migration gate: the exact call the engine makes during the alias retype.
+// Old state from the dynamic provider, new inputs from the retyped wrapper. It
+// must succeed AND report no changes — anything else means the cutover fails at
+// preview rather than diffing to nothing.
+//
+// Without a state migration this fails outright, because an unrecognized
+// property is a decode FAILURE rather than something quietly ignored:
+//
+//	Unrecognized field '__provider' on 'd1.QueryState'
+//
+// That is why every dynamic-provider family needs this before it can be
+// retyped, not just the ones with awkward sentinel encodings.
+func TestDiffAcceptsLiveDynamicProviderState(t *testing.T) {
+	srv := testServer(t)
+
+	resp, err := srv.Diff(p.DiffRequest{
+		ID:     "uptime-prod-schema",
+		Urn:    "urn:pulumi:prod::uptime::sector7:cloudflare:UptimeMonitor$sector7:d1:Query::uptime-prod-schema",
+		State:  liveQueryState(),
+		Inputs: newInputs(),
+	})
+	if err != nil {
+		t.Fatalf("Diff must accept live dynamic-provider state: %v", err)
+	}
+	if resp.HasChanges {
+		t.Fatalf("retype must diff to nothing; got %+v", resp.DetailedDiff)
+	}
+}
+
+// The migration must not swallow a real change. Dropping __provider is the only
+// thing it is allowed to do — a genuinely edited schema still has to plan an
+// update, or a schema change would silently never be applied.
+func TestRealSqlChangeSurvivesTheMigration(t *testing.T) {
+	srv := testServer(t)
+
+	inputs := newInputs().Set("sql",
+		property.New("CREATE TABLE IF NOT EXISTS checks (id TEXT PRIMARY KEY, added_at INTEGER);"))
+
+	resp, err := srv.Diff(p.DiffRequest{
+		ID:     "uptime-prod-schema",
+		Urn:    "urn:pulumi:prod::uptime::sector7:cloudflare:UptimeMonitor$sector7:d1:Query::uptime-prod-schema",
+		State:  liveQueryState(),
+		Inputs: inputs,
+	})
+	if err != nil {
+		t.Fatalf("edited SQL must decode: %v", err)
+	}
+	if !resp.HasChanges {
+		t.Fatal("an edited schema must plan a change, not be swallowed by the migration")
+	}
+	if _, ok := resp.DetailedDiff["sql"]; !ok {
+		t.Fatalf("expected a sql diff; got %+v", resp.DetailedDiff)
+	}
+}
+
+// State that never passed through the dynamic provider — anything created by
+// the plugin itself — has no __provider and must decode by the normal path.
+func TestPluginNativeStateStillDecodes(t *testing.T) {
+	srv := testServer(t)
+
+	resp, err := srv.Diff(p.DiffRequest{
+		ID:     "uptime-prod-schema",
+		Urn:    "urn:pulumi:prod::uptime::sector7:cloudflare:UptimeMonitor$sector7:d1:Query::uptime-prod-schema",
+		State:  liveQueryState().Delete("__provider"),
+		Inputs: newInputs(),
+	})
+	if err != nil {
+		t.Fatalf("plugin-native state must decode without a migration: %v", err)
+	}
+	if resp.HasChanges {
+		t.Fatalf("unchanged plugin-native state must diff to nothing; got %+v", resp.DetailedDiff)
+	}
+}


### PR DESCRIPTION
## Summary

First slice of the next migration family: **uptime/prod's `D1Query`**, chosen as the lowest-blast-radius live dynamic resource remaining.

Live state written by the dynamic provider carries `__provider` — the serialized JavaScript closure this whole plugin exists to stop storing. No struct declares it, and `infer` treats an unrecognized property as a decode **failure**, not something quietly ignored:

```
Unrecognized field '__provider' on 'd1.QueryState'
```

Without a state migration the alias retype does not diff to nothing; it fails outright at the first preview.

## Confirmed, not assumed

The gate test was written **first** and run **before** the migration existed. It failed with exactly that message against the real gRPC path (`integration.NewServer` → `srv.Diff`) — so the gap is demonstrated, not inferred from the migration plan.

The state shape is read off the live stack rather than imagined:

```
$ pulumi stack export -C deploy/services/uptime -s prod
urn:     …UptimeMonitor$pulumi-nodejs:dynamic:Resource::uptime-prod-schema
outputs: __provider, accountId, apiToken, databaseId, sql, sqlHash
```

## Why this is simpler than litellm's

litellm needed **two** shapes per resource to discriminate a sentinel-encoded optional (`maxBudget: number | ""`) — one shape alone would make state carrying a real budget fail both the migrator *and* the normal decode.

d1 has no such hazard: `accountId`, `databaseId`, `sql` and `apiToken` are all strings, so an empty value is a valid value of its own type and decodes fine either way. `__provider` is the only obstacle, so one shape suffices.

## Tests

| test | what it pins |
|---|---|
| `TestDiffAcceptsLiveDynamicProviderState` | **the gate** — live state in, retyped inputs out, must diff to nothing |
| `TestRealSqlChangeSurvivesTheMigration` | dropping `__provider` is the ONLY permitted effect; an edited schema must still plan an update, not be silently swallowed |
| `TestPluginNativeStateStillDecodes` | state with no `__provider` decodes by the normal path — the migration is additive-safe |

Schema verified unchanged via `pulumi package get-schema`: `__provider` stays migration-only and never enters the public surface.

## This gap is systemic

Only **litellm** had `__provider` handling. `attic`, `onepassword`, `matrix` and `r2` all still need the same treatment before their families can be retyped — every one would hit an identical fatal decode on its first preview.

Doing d1 first because uptime/prod is the smallest live blast radius; the pattern here is what the others follow.

## Not in this PR

The TypeScript retype of `D1Query` and the alias cutover on uptime. This is the provider-side prerequisite only.

## Test plan

- [x] `nix build .#checks.x86_64-linux.provider-go-test` — pass (gofmt + `go test -race ./...`)
- [x] Gate test verified failing **before** the migration, passing after
- [x] `pulumi package get-schema` — d1 surface unchanged

Known-inherited, unchanged: #345 (stale `pnpmDepsHash`), #347 (treefmt). This PR touches no TypeScript.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

https://claude.ai/code/session_014fxmGtPEGqWumJw8yyHfHb