### PR TITLE
fix(onepassword): keep secret field values out of state, and migrate __provider

### DIFF
--- a/provider/onepassword/item.go
+++ b/provider/onepassword/item.go
@@ -106,9 +106,15 @@ type ItemState struct {
 }
 
 // target rebuilds the connection half of the inputs from stored state, for the
-// paths that must reach Connect using what was persisted rather than what the
-// program currently declares (Delete, and Update's removal reconciliation).
-// Fields is intentionally absent — nothing on those paths needs it.
+// one path that must reach Connect using what was persisted rather than what
+// the program currently declares: Delete, which is handed no inputs at all.
+// Fields is intentionally absent — nothing on that path needs it.
+//
+// Update is deliberately NOT a caller. It connects with the CURRENT inputs, so
+// that a token rotation or cluster move takes effect on the same apply that
+// declares it; the only thing it draws from prior state is ManagedLabels, for
+// removal reconciliation. Delete is the sole caller — keep it that way, or the
+// "what was persisted" framing above stops being true.
 func (s ItemState) target() ItemArgs {
 	return ItemArgs{
 		Kubeconfig:     s.Kubeconfig,

--- a/provider/onepassword/item.go
+++ b/provider/onepassword/item.go
@@ -61,8 +61,40 @@ type ItemArgs struct {
 	Fields         []Field `pulumi:"fields"`
 }
 
+// ItemState deliberately does NOT embed ItemArgs, and so deliberately does not
+// carry Fields.
+//
+// The dynamic provider this replaces never persisted field values. Its
+// stateOuts (packages/sector7/onepassword/item.ts) listed the connection and
+// identity inputs explicitly and stopped there, keeping only `managedLabels`
+// (labels, not values) and `contentHash` (a digest over the values) — secret
+// values never entered state at all. Embedding ItemArgs here silently reversed
+// that: Create and Update both write ItemState{ItemArgs: a, …}, so every
+// managed secret would be persisted. Encrypted, since Field.Value is tagged
+// secret — but present, which is a weaker property than absent, and the reason
+// contentHash is itself marked secret is precisely to avoid handing out an
+// offline oracle over those values.
+//
+// It also matches what live state actually looks like. The five dynamic
+// OnePasswordItems in gateway/ergon/matrix/litellm have no `fields` key in
+// their outputs, so an ItemState requiring one cannot decode them and the alias
+// retype would fail before it began.
+//
+// Nothing reads persisted Fields: Diff hashes the INCOMING fields and compares
+// against the stored contentHash, and Update reconciles removals from
+// ManagedLabels. Both match the TypeScript.
 type ItemState struct {
-	ItemArgs
+	// Connection and identity inputs are echoed back, mirroring stateOuts in
+	// the TypeScript. Fields is the deliberate omission.
+	Kubeconfig     string `pulumi:"kubeconfig,optional" provider:"secret"`
+	ConnectToken   string `pulumi:"connectToken" provider:"secret"`
+	Namespace      string `pulumi:"namespace"`
+	DeploymentName string `pulumi:"deploymentName,optional"`
+	ConnectPort    int    `pulumi:"connectPort,optional"`
+	Vault          string `pulumi:"vault"`
+	Title          string `pulumi:"title"`
+	Category       string `pulumi:"category,optional"`
+
 	UUID     string `pulumi:"uuid"`
 	ItemPath string `pulumi:"itemPath"`
 	// ContentHash is secret: it is a SHA-256 over the field values, so exposing
@@ -71,6 +103,23 @@ type ItemState struct {
 	// ManagedLabels records which labels this resource owns, so a later update
 	// can remove ones dropped from input without touching unmanaged fields.
 	ManagedLabels []string `pulumi:"managedLabels"`
+}
+
+// target rebuilds the connection half of the inputs from stored state, for the
+// paths that must reach Connect using what was persisted rather than what the
+// program currently declares (Delete, and Update's removal reconciliation).
+// Fields is intentionally absent — nothing on those paths needs it.
+func (s ItemState) target() ItemArgs {
+	return ItemArgs{
+		Kubeconfig:     s.Kubeconfig,
+		ConnectToken:   s.ConnectToken,
+		Namespace:      s.Namespace,
+		DeploymentName: s.DeploymentName,
+		ConnectPort:    s.ConnectPort,
+		Vault:          s.Vault,
+		Title:          s.Title,
+		Category:       s.Category,
+	}
 }
 
 func (a *ItemArgs) Annotate(ann infer.Annotator) {
@@ -389,7 +438,7 @@ func buildMergedItemBody(existing map[string]any, a ItemArgs, id string, priorMa
 }
 
 func (i Item) Create(ctx context.Context, req infer.CreateRequest[ItemArgs]) (infer.CreateResponse[ItemState], error) {
-	out := infer.CreateResponse[ItemState]{Output: ItemState{ItemArgs: req.Inputs}}
+	out := infer.CreateResponse[ItemState]{Output: stateOuts(req.Inputs, "", "")}
 	if req.DryRun {
 		return out, nil
 	}
@@ -480,7 +529,7 @@ func (i Item) Update(ctx context.Context, req infer.UpdateRequest[ItemArgs, Item
 }
 
 func (i Item) Delete(ctx context.Context, req infer.DeleteRequest[ItemState]) (infer.DeleteResponse, error) {
-	c, done, err := i.connect(ctx, req.State.ItemArgs)
+	c, done, err := i.connect(ctx, req.State.target())
 	if err != nil {
 		return infer.DeleteResponse{}, err
 	}
@@ -526,10 +575,17 @@ func stateOuts(a ItemArgs, uuid, contentHash string) ItemState {
 		labels = append(labels, f.Label)
 	}
 	return ItemState{
-		ItemArgs:      a,
-		UUID:          uuid,
-		ItemPath:      fmt.Sprintf("vaults/%s/items/%s", a.Vault, uuid),
-		ContentHash:   contentHash,
-		ManagedLabels: labels,
+		Kubeconfig:     a.Kubeconfig,
+		ConnectToken:   a.ConnectToken,
+		Namespace:      a.Namespace,
+		DeploymentName: a.DeploymentName,
+		ConnectPort:    a.ConnectPort,
+		Vault:          a.Vault,
+		Title:          a.Title,
+		Category:       a.Category,
+		UUID:           uuid,
+		ItemPath:       fmt.Sprintf("vaults/%s/items/%s", a.Vault, uuid),
+		ContentHash:    contentHash,
+		ManagedLabels:  labels,
 	}
 }

--- a/provider/onepassword/migrations.go
+++ b/provider/onepassword/migrations.go
@@ -1,0 +1,52 @@
+package onepassword
+
+import (
+	"context"
+
+	"github.com/pulumi/pulumi-go-provider/infer"
+)
+
+// State migration off the dynamic provider.
+//
+// Live state written by the dynamic provider carries `__provider`, the
+// serialized JavaScript closure this plugin exists to stop storing. infer
+// treats an unrecognized property as a decode FAILURE rather than something
+// quietly ignored:
+//
+//	Unrecognized field '__provider' on 'onepassword.ItemState'
+//
+// so without this the alias retype fails at the first preview instead of
+// diffing to nothing. Same shape as the d1 migration; see that file for the
+// mechanism.
+//
+// One shape suffices. There is no sentinel-encoded optional to discriminate —
+// the TypeScript's stateOuts wrote real values for every property it emitted,
+// defaulting deploymentName/connectPort/category rather than leaving empty
+// markers. The only obstacle is __provider.
+//
+// The remaining shape difference between old and new state is `fields`, and it
+// resolves itself: the dynamic provider never wrote field values into outputs,
+// and ItemState no longer expects them. See the comment on ItemState.
+type itemStateV0 struct {
+	ItemState
+	// Provider is the serialized dynamic-provider closure. Declared only so it
+	// can be dropped — nothing reads it.
+	//
+	// Deliberately NOT optional, and that tag is load-bearing. infer tries this
+	// migrator before the normal decode, so `optional` would make the shape
+	// match plugin-native state too and route every future read through the
+	// migration rather than only legacy state. Required is what makes native
+	// state miss this shape and fall through. Guarded by
+	// TestProviderTagIsRequiredSoTheMigrationOnlyMatchesLegacyState.
+	Provider string `pulumi:"__provider"`
+}
+
+// StateMigrations satisfies infer.CustomStateMigrations[ItemState].
+func (Item) StateMigrations(context.Context) []infer.StateMigrationFunc[ItemState] {
+	return []infer.StateMigrationFunc[ItemState]{
+		infer.StateMigration(func(_ context.Context, old itemStateV0) (infer.MigrationResult[ItemState], error) {
+			migrated := old.ItemState
+			return infer.MigrationResult[ItemState]{Result: &migrated}, nil
+		}),
+	}
+}

--- a/provider/onepassword/migrations_test.go
+++ b/provider/onepassword/migrations_test.go
@@ -1,0 +1,230 @@
+package onepassword
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/blang/semver"
+	p "github.com/pulumi/pulumi-go-provider"
+	"github.com/pulumi/pulumi-go-provider/infer"
+	"github.com/pulumi/pulumi-go-provider/integration"
+	"github.com/pulumi/pulumi/sdk/v3/go/property"
+)
+
+// liveItemState mirrors gateway/prod's `mcp-consumer-tokens` exactly, read off
+// the stack rather than imagined:
+//
+//	pulumi stack export -C deploy/platform/gateway -s prod
+//	  outputs: __provider, category, connectPort, connectToken, contentHash,
+//	           deploymentName, itemPath, kubeconfig, managedLabels, namespace,
+//	           title, uuid, vault
+//
+// Two things are load-bearing about this shape. `__provider` is present, and
+// `fields` is ABSENT — the dynamic provider deliberately never persisted field
+// values, keeping only labels and a content hash. ItemState matches that; see
+// the comment there.
+// managedFields is the single source of truth for the fixture's fields: the
+// inputs carry them, and the stored contentHash is derived from them, so the
+// fixture cannot drift into a state where the hash disagrees with the values.
+func managedFields() []Field {
+	return []Field{
+		{Label: "claude-code", Value: "tok-1"},
+		{Label: "goose", Value: "tok-2"},
+		{Label: "hermes", Value: "tok-3"},
+	}
+}
+
+func fieldsProperty(fs []Field) property.Value {
+	out := make([]property.Value, 0, len(fs))
+	for _, f := range fs {
+		out = append(out, property.New(property.NewMap(map[string]property.Value{
+			"label": property.New(f.Label),
+			"value": property.New(f.Value),
+		})))
+	}
+	return property.New(out)
+}
+
+func mustContentHash(t *testing.T, category string, fs []Field) string {
+	t.Helper()
+	h, err := ContentHash(category, fs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return h
+}
+
+func liveItemState(t *testing.T) property.Map {
+	t.Helper()
+	return property.NewMap(map[string]property.Value{
+		"kubeconfig":     property.New("apiVersion: v1\nkind: Config\n"),
+		"connectToken":   property.New("op-token"),
+		"namespace":      property.New("1password"),
+		"deploymentName": property.New("onepassword-connect"),
+		"connectPort":    property.New(8080.0),
+		"vault":          property.New("hs2ojq6awbjnsmvx5qwwekcvvq"),
+		"title":          property.New("mcp-gateway-consumer-tokens"),
+		"category":       property.New("API_CREDENTIAL"),
+		"uuid":           property.New("x5yluqpkzwhby3326f2embsh64"),
+		"itemPath":       property.New("vaults/hs2ojq6awbjnsmvx5qwwekcvvq/items/x5yluqpkzwhby3326f2embsh64"),
+		"contentHash":    property.New(mustContentHash(t, "API_CREDENTIAL", managedFields())),
+		"managedLabels": property.New([]property.Value{
+			property.New("claude-code"), property.New("goose"), property.New("hermes"),
+		}),
+		"__provider": property.New("4;/deleted/worktree/node_modules/...;closure"),
+	})
+}
+
+// newInputs is what the retyped wrapper sends: the connection and identity
+// inputs plus `fields`, and none of the outputs.
+func newInputs(t *testing.T) property.Map {
+	t.Helper()
+	return liveItemState(t).
+		Delete("__provider", "uuid", "itemPath", "contentHash", "managedLabels").
+		Set("fields", fieldsProperty(managedFields()))
+}
+
+func testServer(t *testing.T) integration.Server {
+	t.Helper()
+	prov, err := infer.NewProviderBuilder().
+		WithNamespace("jmmaloney4").
+		WithResources(infer.Resource(Item{})).
+		Build()
+	if err != nil {
+		t.Fatal(err)
+	}
+	srv, err := integration.NewServer(context.Background(), "sector7",
+		semver.MustParse("0.21.0"), integration.WithProvider(prov))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return srv
+}
+
+const itemURN = "urn:pulumi:prod::gateway::sector7:onepassword:Item::mcp-consumer-tokens"
+
+// THE migration gate: the exact call the engine makes during the alias retype.
+// Must succeed and report no changes, or the cutover fails at preview instead
+// of diffing to nothing.
+//
+// Without the migration this fails with
+// `Unrecognized field '__provider' on 'onepassword.ItemState'`.
+func TestDiffAcceptsLiveDynamicProviderState(t *testing.T) {
+	srv := testServer(t)
+
+	resp, err := srv.Diff(p.DiffRequest{
+		ID:     "x5yluqpkzwhby3326f2embsh64",
+		Urn:    itemURN,
+		State:  liveItemState(t),
+		Inputs: newInputs(t),
+	})
+	if err != nil {
+		t.Fatalf("Diff must accept live dynamic-provider state: %v", err)
+	}
+	if resp.HasChanges {
+		t.Fatalf("retype must diff to nothing; got %+v", resp.DetailedDiff)
+	}
+}
+
+// Dropping __provider is the ONLY thing the migration may do. A genuinely
+// edited field value must still plan an update — for this resource that means
+// rewriting a live secret, so being swallowed and being spurious are both bad.
+func TestRealFieldChangeSurvivesTheMigration(t *testing.T) {
+	srv := testServer(t)
+
+	inputs := newInputs(t).Set("fields", fieldsProperty([]Field{
+		{Label: "claude-code", Value: "ROTATED"},
+	}))
+
+	resp, err := srv.Diff(p.DiffRequest{
+		ID:     "x5yluqpkzwhby3326f2embsh64",
+		Urn:    itemURN,
+		State:  liveItemState(t),
+		Inputs: inputs,
+	})
+	if err != nil {
+		t.Fatalf("edited fields must decode: %v", err)
+	}
+	if !resp.HasChanges {
+		t.Fatal("a rotated secret must plan a change, not be swallowed by the migration")
+	}
+}
+
+// State that never passed through the dynamic provider has no __provider and
+// must decode by the normal path, proving the migration is additive-safe.
+func TestPluginNativeStateStillDecodes(t *testing.T) {
+	srv := testServer(t)
+
+	resp, err := srv.Diff(p.DiffRequest{
+		ID:     "x5yluqpkzwhby3326f2embsh64",
+		Urn:    itemURN,
+		State:  liveItemState(t).Delete("__provider"),
+		Inputs: newInputs(t),
+	})
+	if err != nil {
+		t.Fatalf("plugin-native state must decode without a migration: %v", err)
+	}
+	if resp.HasChanges {
+		t.Fatalf("unchanged plugin-native state must diff to nothing; got %+v", resp.DetailedDiff)
+	}
+}
+
+// Same guard as d1's. infer runs migrations BEFORE the normal decode and skips
+// a migrator only when decoding into its old shape FAILS, so `,optional` here
+// would make itemStateV0 match plugin-native state too and route every read
+// through the migration — permanently, not just for legacy state.
+//
+// Structural rather than behavioural on purpose: the migration is an identity
+// copy of the embedded ItemState, so the two tags are largely indistinguishable
+// from outside, and any signal that does exist would be an accident of the
+// current field set rather than designed behaviour.
+func TestProviderTagIsRequiredSoTheMigrationOnlyMatchesLegacyState(t *testing.T) {
+	f, ok := reflect.TypeOf(itemStateV0{}).FieldByName("Provider")
+	if !ok {
+		t.Fatal("itemStateV0.Provider is gone; if the field was renamed, update this guard rather than deleting it")
+	}
+	if tag := f.Tag.Get("pulumi"); tag != "__provider" {
+		t.Fatalf("itemStateV0.Provider must be tagged exactly `pulumi:\"__provider\"`, got %q.\n"+
+			"Adding ,optional makes this shape match plugin-native state as well, so the\n"+
+			"migration would run on every state read instead of only on state written by\n"+
+			"the dynamic provider.", tag)
+	}
+}
+
+// The security property this resource is built around: field VALUES must never
+// be persisted. The dynamic provider's stateOuts omitted them deliberately,
+// keeping only labels and a hash; embedding ItemArgs in ItemState silently
+// reversed that and would have written every managed secret into state.
+//
+// Asserted against the reflected shape rather than a Diff, because the failure
+// is "a property exists at all", not "a property has the wrong value".
+//
+// Verified against both ways this can regress, and they fail differently:
+//
+//   - adding an explicit `Fields` field — caught here, with the message below.
+//   - re-embedding ItemArgs — caught EARLIER and less legibly, by infer
+//     panicking with "could not annotate field: could not find field" as it
+//     walks Annotate over a struct whose promoted fields are shadowed by the
+//     explicit ones. That aborts the test binary before this assertion runs.
+//
+// So the property is protected either way, but only the first case produces a
+// message that explains itself. The embed check below is kept regardless: it
+// costs nothing and would become the primary signal if the shadowing that
+// currently triggers the panic ever stopped applying.
+func TestItemStateNeverCarriesFieldValues(t *testing.T) {
+	tp := reflect.TypeOf(ItemState{})
+	for i := range tp.NumField() {
+		f := tp.Field(i)
+		if f.Name == "Fields" || f.Tag.Get("pulumi") == "fields" {
+			t.Fatalf("ItemState must not carry field values: found %s `%s`.\n"+
+				"Create and Update write ItemState wholesale, so any Fields here is "+
+				"persisted into state for every managed secret.", f.Name, f.Tag)
+		}
+		// Embedding ItemArgs would reintroduce Fields transitively, which is
+		// exactly how this regressed the first time.
+		if f.Anonymous && f.Type == reflect.TypeOf(ItemArgs{}) {
+			t.Fatal("ItemState must not embed ItemArgs — it carries Fields transitively")
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Two defects with one root cause: `ItemState` embedded `ItemArgs`.

### 1. Security — secret field values were being persisted

The dynamic provider this replaces **never** wrote field values into state. Its `stateOuts` listed the connection and identity inputs explicitly and stopped, keeping only `managedLabels` (labels, not values) and `contentHash` (a digest over the values):

```ts
return { kubeconfig, connectToken, namespace, deploymentName, connectPort,
         vault, title, category, uuid, itemPath, contentHash,
         managedLabels: i.fields.map((f) => f.label) };   // no `fields`
```

Embedding `ItemArgs` silently reversed that. `Create` and `Update` both write `ItemState{ItemArgs: a, …}`, so **every managed secret would be persisted**. Encrypted — `Field.Value` is tagged secret — but present, which is a weaker property than absent. The reason `contentHash` is *itself* marked secret is precisely to avoid handing out an offline oracle over those values; storing the values alongside it defeats the intent.

### 2. Migration — live state cannot decode

The same embedding made `ItemState` require `fields`, which live state does not have. The five dynamic `OnePasswordItem`s in gateway/ergon/matrix/litellm carry no such key, so the alias retype could not have decoded them *even before* reaching `__provider`.

## Fix

`ItemState` now lists its properties explicitly, mirroring `stateOuts`. Verified with `pulumi package get-schema` that the output set is exactly the 12 keys live state holds, and that `fields` remains an **input**:

| | |
|---|---|
| outputs | `category, connectPort, connectToken, contentHash, deploymentName, itemPath, kubeconfig, managedLabels, namespace, title, uuid, vault` |
| inputs | …same, minus the four computed, **plus `fields`** |

That is byte-identical to live state except for `__provider`, which the new migration drops.

Nothing read persisted `Fields` — `Diff` hashes the *incoming* fields against the stored `contentHash`, and `Update` reconciles removals from `ManagedLabels`, both matching the TypeScript. `ItemState.target()` rebuilds the connection half for `Delete`.

Zero live instances are typed `sector7:onepassword:Item` yet, so this schema change costs nothing.

## Tests — each verified to fail when its subject is broken

| test | negative control |
|---|---|
| `TestDiffAcceptsLiveDynamicProviderState` | remove `StateMigrations` → `Unrecognized field '__provider'` ✓ |
| `TestRealFieldChangeSurvivesTheMigration` | a rotated secret must still plan a change |
| `TestPluginNativeStateStillDecodes` | additive-safety |
| `TestProviderTagIsRequiredSoTheMigrationOnlyMatchesLegacyState` | the load-bearing tag, as in d1 |
| `TestItemStateNeverCarriesFieldValues` | add an explicit `Fields` → fires with a legible message ✓ |

The fixture is gateway/prod's `mcp-consumer-tokens`, read off the stack rather than invented, and it **derives** `contentHash` from the same fields the inputs carry so it cannot drift into disagreeing with itself. My first draft hardcoded a placeholder hash and failed for exactly that reason — a useful failure, and now structurally impossible.

## One thing the comment is careful about

The two ways `TestItemStateNeverCarriesFieldValues` can regress fail *differently*, and the comment says so rather than overclaiming:

- **explicit `Fields` field** → caught by the assertion, with an explanatory message
- **re-embedding `ItemArgs`** → caught earlier and less legibly, by `infer` panicking with `could not annotate field: could not find field`, which aborts the test binary before the assertion runs

Protected either way; only one explains itself. I verified both paths rather than assuming the assertion covered them.

## Test plan

- [x] `nix build .#checks.x86_64-linux.provider-go-test` — pass (all 8 packages)
- [x] Both negative controls confirmed
- [x] `pulumi package get-schema` — output/input sets match live state

## Not in this PR

The TypeScript retype of `OnePasswordItem` and the alias cutover across gateway → ergon → matrix → litellm. This is the provider-side prerequisite.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

https://claude.ai/code/session_014fxmGtPEGqWumJw8yyHfHb