### PR TITLE
fix(ci): unbreak `nix flake check` (four independent breakages)

### DIFF
--- a/docs/renovate/README.md
+++ b/docs/renovate/README.md
@@ -19,19 +19,19 @@ See also: [configuration](./configuration.md) (every default, group, and knob),
 The presets live in [`renovate/`](../../renovate/) at the repo root, one JSON
 file per concern, plus an aggregate that composes them:
 
-| Preset | Role |
-| ------ | ---- |
-| `default.json` | Base config: timezone, schedule, automerge policy, rate limits, labels, stability delay, digest pinning, dependency dashboard, and repo-wide `packageRules`. |
-| `minor-patch-automerge.json` | The per-ecosystem **PR groups** for minor/patch/digest updates, most with automerge enabled. |
-| `major-updates.json` | Forces every **major** update into its own non-automerged PR with a reviewer. |
-| `security.json` | Vulnerability-alert handling (automerged, labelled). |
-| `lock-maintenance.json` | Weekly lock-file maintenance. |
-| `nix.json` | Custom regex managers for Nix (`fetchPypi`, `mkHelmChartFromGitHub`, `nix run github:` pins). |
-| `pulumi.json` | Custom regex manager for annotated versions in `Pulumi.*.yaml`. |
-| `docker-images.json` | Custom regex manager for annotated container-image string literals in `.ts` sources. |
-| `yaml-manifests.json` | Custom regex managers for annotated container images and Helm chart versions in `.yaml`. |
-| `sector7-release-tarballs.json` | Updates `@jmmaloney4/sector7` GitHub release-tarball URLs in `package.json`. |
-| `all.json` | **Aggregate** — extends every preset above. Most consumers use only this. |
+| Preset                          | Role                                                                                                                                                         |
+| ------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `default.json`                  | Base config: timezone, schedule, automerge policy, rate limits, labels, stability delay, digest pinning, dependency dashboard, and repo-wide `packageRules`. |
+| `minor-patch-automerge.json`    | The per-ecosystem **PR groups** for minor/patch/digest updates, most with automerge enabled.                                                                 |
+| `major-updates.json`            | Forces every **major** update into its own non-automerged PR with a reviewer.                                                                                |
+| `security.json`                 | Vulnerability-alert handling (automerged, labelled).                                                                                                         |
+| `lock-maintenance.json`         | Weekly lock-file maintenance.                                                                                                                                |
+| `nix.json`                      | Custom regex managers for Nix (`fetchPypi`, `mkHelmChartFromGitHub`, `nix run github:` pins).                                                                |
+| `pulumi.json`                   | Custom regex manager for annotated versions in `Pulumi.*.yaml`.                                                                                              |
+| `docker-images.json`            | Custom regex manager for annotated container-image string literals in `.ts` sources.                                                                         |
+| `yaml-manifests.json`           | Custom regex managers for annotated container images and Helm chart versions in `.yaml`.                                                                     |
+| `sector7-release-tarballs.json` | Updates `@jmmaloney4/sector7` GitHub release-tarball URLs in `package.json`.                                                                                 |
+| `all.json`                      | **Aggregate** — extends every preset above. Most consumers use only this.                                                                                    |
 
 A consumer's own configuration file always wins: settings declared directly in
 the repo override anything inherited from a preset (Renovate merge precedence).
@@ -74,13 +74,13 @@ for the most common failure.
 
 ## Where things live
 
-| Thing | Location |
-| ----- | -------- |
-| Preset sources | [`renovate/*.json`](../../renovate/) |
-| Quick-reference for preset authors | [`renovate/README.md`](../../renovate/README.md) |
-| Local validation | `nix build .#checks.<system>.renovate-config` (runs `renovate-config-validator --strict` over every preset + `.github/renovate.json*`) |
-| Config-file flake check | defined in [`flake.nix`](../../flake.nix) (`checks.renovate-config`) |
-| Consumer example | a repo's `.github/renovate.json5` extending `github>jmmaloney4/sector7//renovate/all.json` |
+| Thing                              | Location                                                                                                                               |
+| ---------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
+| Preset sources                     | [`renovate/*.json`](../../renovate/)                                                                                                   |
+| Quick-reference for preset authors | [`renovate/README.md`](../../renovate/README.md)                                                                                       |
+| Local validation                   | `nix build .#checks.<system>.renovate-config` (runs `renovate-config-validator --strict` over every preset + `.github/renovate.json*`) |
+| Config-file flake check            | defined in [`flake.nix`](../../flake.nix) (`checks.renovate-config`)                                                                   |
+| Consumer example                   | a repo's `.github/renovate.json5` extending `github>jmmaloney4/sector7//renovate/all.json`                                             |
 
 ## Why it's built this way
 

--- a/docs/renovate/workflows.md
+++ b/docs/renovate/workflows.md
@@ -7,6 +7,7 @@ is a single task. For what every setting means, see
 ## Adopt the presets in a new repo
 
 1. Create `.github/renovate.json5` in the consumer repo.
+
 2. Extend the aggregate preset:
 
    ```json5
@@ -17,6 +18,7 @@ is a single task. For what every setting means, see
    ```
 
 3. Ensure the Renovate (Mend) app is installed on the repo.
+
 4. The first run opens the **Renovate Dashboard 🤖** issue; updates flow from
    there.
 

--- a/flake.nix
+++ b/flake.nix
@@ -29,7 +29,7 @@
       jackpkgs.projectRoot = ./.;
       jackpkgs.nodejs = {
         enable = true;
-        pnpmDepsHash = "sha256-wC91tGjpyAS929g21f7tfXN8Enm61aYSERlLhZ+3qP8=";
+        pnpmDepsHash = "sha256-QkhFw4knCylOpGSpYoCd2Na14c/eeXM+q8J/id5fo+U=";
         projectRoot = ./.;
       };
       jackpkgs.checks.typescript.tsc.enable = true;

--- a/packages/sector7/pulumi-config/index.ts
+++ b/packages/sector7/pulumi-config/index.ts
@@ -8,8 +8,8 @@ export {
 } from "./mixed-config.js";
 
 export {
-	createOnePasswordSecretRefs,
 	type CreateOnePasswordSecretRefsOptions,
+	createOnePasswordSecretRefs,
 	mergeSecretRefEnvs,
 	parseOnePasswordItemReference,
 } from "./op-secret-helpers.js";

--- a/packages/sector7/pulumi-config/op-secret-helpers.ts
+++ b/packages/sector7/pulumi-config/op-secret-helpers.ts
@@ -6,8 +6,8 @@
  * into Kubernetes Secrets consumable by pods via secretKeyRef.
  */
 
-import type * as pulumi from "@pulumi/pulumi";
 import * as k8s from "@pulumi/kubernetes";
+import type * as pulumi from "@pulumi/pulumi";
 
 /**
  * Parse a 1Password CLI secret-reference URI (`op://`) into the CRD
@@ -123,11 +123,17 @@ function normalizeSecretKeyName(name: string): string {
  */
 export function mergeSecretRefEnvs(
 	...envMaps: (
-		| Record<string, { secretName: pulumi.Input<string>; key: pulumi.Input<string> }>
+		| Record<
+				string,
+				{ secretName: pulumi.Input<string>; key: pulumi.Input<string> }
+		  >
 		| undefined
 	)[]
 ):
-	| Record<string, { secretName: pulumi.Input<string>; key: pulumi.Input<string> }>
+	| Record<
+			string,
+			{ secretName: pulumi.Input<string>; key: pulumi.Input<string> }
+	  >
 	| undefined {
 	const merged: Record<
 		string,
@@ -203,11 +209,7 @@ export interface CreateOnePasswordSecretRefsOptions<
 	 * Optional guard to block op:// for certain item types.
 	 * Throws an error if the guard returns a message.
 	 */
-	blockRef?: (
-		item: T,
-		itemKey: string,
-		opRef: string,
-	) => string | undefined;
+	blockRef?: (item: T, itemKey: string, opRef: string) => string | undefined;
 }
 
 /**
@@ -250,7 +252,10 @@ export interface CreateOnePasswordSecretRefsOptions<
  */
 export function createOnePasswordSecretRefs<T extends Record<string, unknown>>(
 	options: CreateOnePasswordSecretRefsOptions<T>,
-): Record<string, { secretName: pulumi.Input<string>; key: pulumi.Input<string> }> {
+): Record<
+	string,
+	{ secretName: pulumi.Input<string>; key: pulumi.Input<string> }
+> {
 	const {
 		config,
 		configKey,
@@ -284,9 +289,7 @@ export function createOnePasswordSecretRefs<T extends Record<string, unknown>>(
 		);
 		// Kubernetes metadata.name must be DNS-1123 compliant: lowercase
 		// alphanumeric or hyphens, must start/end with alphanumeric.
-		const secretName = toDNS1123Name(
-			`${configKey}-${itemKey}-${fieldName}`,
-		);
+		const secretName = toDNS1123Name(`${configKey}-${itemKey}-${fieldName}`);
 		if (!secretName) {
 			throw new Error(
 				`Generated secret name is empty for item '${itemKey}'. ` +
@@ -297,7 +300,9 @@ export function createOnePasswordSecretRefs<T extends Record<string, unknown>>(
 
 		// Detect normalized secret name collisions — two different item keys can
 		// collapse to the same DNS-1123 name after sanitization.
-		if (Object.values(secretRefs).some((ref) => ref.secretName === secretName)) {
+		if (
+			Object.values(secretRefs).some((ref) => ref.secretName === secretName)
+		) {
 			throw new Error(
 				`Kubernetes secret name collision: two items produced secret '${secretName}'. ` +
 					"Ensure item keys remain unique after DNS-1123 normalization.",

--- a/packages/sector7/tests/nix-output-resolve.test.ts
+++ b/packages/sector7/tests/nix-output-resolve.test.ts
@@ -35,10 +35,18 @@ function makeTempDir(prefix: string): string {
 }
 
 /** Write an executable `nix` stub into a fresh dir and return that dir. */
+// Resolved once, rather than hard-coding `#!/usr/bin/env bash`: the nix build
+// sandbox has no /usr/bin/env, so that shebang made the stub unexecutable and
+// the script under test exited 126 under `nix flake check` while passing in a
+// dev shell.
+const STUB_BASH = spawnSync("bash", ["-c", "command -v bash"], {
+	encoding: "utf8",
+}).stdout.trim();
+
 function stubNix(body: string): string {
 	const binDir = makeTempDir("nix-stub-");
 	const nixPath = join(binDir, "nix");
-	writeFileSync(nixPath, `#!/usr/bin/env bash\n${body}\n`);
+	writeFileSync(nixPath, `#!${STUB_BASH}\n${body}\n`);
 	chmodSync(nixPath, 0o755);
 	return binDir;
 }

--- a/packages/sector7/tests/op-secret-helpers.test.ts
+++ b/packages/sector7/tests/op-secret-helpers.test.ts
@@ -6,7 +6,10 @@ import {
 
 describe("parseOnePasswordItemReference", () => {
 	it("parses a standard 3-segment op:// reference", () => {
-		const result = parseOnePasswordItemReference("op://v1/i2/f3", "test-account");
+		const result = parseOnePasswordItemReference(
+			"op://v1/i2/f3",
+			"test-account",
+		);
 		expect(result).toEqual({
 			itemPath: "vaults/v1/items/i2",
 			fieldName: "f3",
@@ -15,10 +18,7 @@ describe("parseOnePasswordItemReference", () => {
 
 	it("rejects section-qualified op:// references", () => {
 		expect(() =>
-			parseOnePasswordItemReference(
-				"op://v1/i2/section/f4",
-				"test-account",
-			),
+			parseOnePasswordItemReference("op://v1/i2/section/f4", "test-account"),
 		).toThrow("Section-qualified references are not supported");
 	});
 
@@ -113,7 +113,8 @@ describe("parseOnePasswordItemReference", () => {
 			"test-account",
 		);
 		expect(result).toEqual({
-			itemPath: "vaults/550e8400-e29b-41d4-a716-446655440000/items/550e8400-e29b-41d4-a716-446655440001",
+			itemPath:
+				"vaults/550e8400-e29b-41d4-a716-446655440000/items/550e8400-e29b-41d4-a716-446655440001",
 			fieldName: "credential",
 		});
 	});

--- a/packages/sector7/tests/port-forward.test.ts
+++ b/packages/sector7/tests/port-forward.test.ts
@@ -141,7 +141,9 @@ describe("loadKubernetesClient resolution routes", () => {
 	});
 
 	it("falls back on ERR_PACKAGE_PATH_NOT_EXPORTED as well as ERR_MODULE_NOT_FOUND", async () => {
-		const err: NodeJS.ErrnoException = new Error("Package subpath not exported");
+		const err: NodeJS.ErrnoException = new Error(
+			"Package subpath not exported",
+		);
 		err.code = "ERR_PACKAGE_PATH_NOT_EXPORTED";
 		const calls: string[] = [];
 		const k8s = await loadKubernetesClient((specifier) => {
@@ -184,4 +186,3 @@ describe("isModuleResolutionError", () => {
 		expect(isModuleResolutionError(undefined)).toBe(false);
 	});
 });
-

--- a/packages/sector7/tests/renovate-pulumi.test.ts
+++ b/packages/sector7/tests/renovate-pulumi.test.ts
@@ -16,12 +16,17 @@ const pulumiConfig = JSON.parse(
 	}>;
 };
 
-// Select by a stable property (targets Pulumi config files) rather than by
-// array position, so reordering or adding managers can't silently make these
-// tests exercise the wrong configuration.
+// Select by a stable property rather than by array position, so reordering or
+// adding managers can't silently make these tests exercise the wrong
+// configuration.
+//
+// Targeting Pulumi config files is no longer discriminating on its own: the
+// container-image manager added in 779a418 matches the same file pattern. The
+// `versionKey` capture group is unique to the version manager these tests are
+// about, and it is the thing they actually assert on.
 function selectPulumiManager() {
 	const matches = pulumiConfig.customManagers.filter((m) =>
-		m.managerFilePatterns.some((pattern) => pattern.includes("Pulumi")),
+		m.matchStrings.some((pattern) => pattern.includes("(?<versionKey>")),
 	);
 	if (matches.length !== 1) {
 		throw new Error(

--- a/renovate/minor-patch-automerge.json
+++ b/renovate/minor-patch-automerge.json
@@ -20,7 +20,13 @@
 		},
 		{
 			"groupName": "Python Dependencies",
-			"matchManagers": ["pip_requirements", "pip_setup", "pipenv", "poetry", "pep621"],
+			"matchManagers": [
+				"pip_requirements",
+				"pip_setup",
+				"pipenv",
+				"poetry",
+				"pep621"
+			],
 			"matchDatasources": ["pypi"],
 			"matchUpdateTypes": ["minor", "patch"],
 			"automerge": true


### PR DESCRIPTION
## Why

`nix flake check` is fully red on `main`, and has been for two weeks. A stale `pnpmDepsHash` made `node_modules` unbuildable, which took **tsc, vitest and pre-commit** with it — so those three have not actually run on any PR since 2026-07-21. Two genuine regressions landed behind that wall.

I hit this while verifying an unrelated change and could not get a green gate to verify against, so this PR is split out on its own.

## What

| Breakage | Cause | Fix |
|---|---|---|
| `pnpm-deps` hash mismatch (#345) | 8ac19c9 bumped `@types/node` + lockfile without restamping the FOD hash | refresh `pnpmDepsHash` |
| `renovate-pulumi.test.ts` fails to collect | 779a418 added a second customManager matching the same file pattern; the "exactly one" guard threw at import | select by the unique `(?<versionKey>` capture group |
| `nix-output-resolve.test.ts` exits 126 | stub shebang `#!/usr/bin/env bash`; the nix sandbox has no `/usr/bin/env` | resolve `bash` and use an absolute shebang |
| `treefmt` (#347) | 7 files drifted | run the formatter |

### On #347 reporting one file

It is 7. `nix flake check` truncates a failing derivation's log to `Last 25 log lines`, which cuts the diff off mid-file. `nix log <drv>` shows the rest.

### On the 126

It reproduces **only** under `nix flake check` — the same test passes 2/2 in a dev shell, because `/usr/bin/env` exists there. Confirmed with a sandbox probe:

```
/build/tmp.5aF4Yjq5ZC/x: /usr/bin/env: bad interpreter: No such file or directory
```

## Risk

Low. The only edit outside tests and formatting is the dependency hash. No production code paths change.

## Verification

```
$ nix flake check --keep-going
✅ pre-commit   ✅ provider-go-test   ✅ provider-version-stamped
✅ renovate-config   ✅ treefmt   ✅ tsc   ✅ vitest
```

Fixes #345. Fixes #347.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014fxmGtPEGqWumJw8yyHfHb