### PR TITLE
fix(attic): accept an explicit kubeconfig for the admin port-forward

### DIFF
--- a/provider/attic/cache.go
+++ b/provider/attic/cache.go
@@ -38,7 +38,22 @@ type Cache struct {
 }
 
 type CacheArgs struct {
-	Namespace string `pulumi:"namespace"`
+	// Kubeconfig is YAML; empty means the ambient default config.
+	//
+	// Without it, the admin port-forward falls back to whatever kubeconfig is
+	// ambient in the process running `pulumi up`/`refresh` — which is not
+	// necessarily the identity the rest of the stack deploys with. This is the
+	// same gap that broke litellm's admin port-forward (sector7#350):
+	//
+	//	deployments.apps "litellm" is forbidden: User "pulumi-zeus" cannot get
+	//	resource "deployments" in API group "apps" in the namespace "litellm"
+	//
+	// AdminTarget.Kubeconfig in provider/litellm/client.go added the fix there;
+	// this mirrors it for attic. Secret because a kubeconfig carries client
+	// certificates and keys — matching onepassword.ItemArgs.Kubeconfig and
+	// litellm.AdminTarget.Kubeconfig.
+	Kubeconfig string `pulumi:"kubeconfig,optional" provider:"secret"`
+	Namespace  string `pulumi:"namespace"`
 	// HS256SecretBase64 is the server's signing secret; admin tokens are minted
 	// from it locally.
 	HS256SecretBase64     string   `pulumi:"hs256SecretBase64" provider:"secret"`
@@ -106,7 +121,8 @@ func (Cache) Diff(_ context.Context, req infer.DiffRequest[CacheArgs, CacheState
 	// An admin-target change does not alter the remote cache, but must flow into
 	// state so a later update/delete targets the new deployment and mints under
 	// the new secret.
-	if olds.Namespace != news.Namespace ||
+	if olds.Kubeconfig != news.Kubeconfig ||
+		olds.Namespace != news.Namespace ||
 		olds.DeploymentName != news.DeploymentName ||
 		olds.Port != news.Port ||
 		olds.HS256SecretBase64 != news.HS256SecretBase64 {
@@ -185,6 +201,7 @@ func (c Cache) connect(ctx context.Context, a CacheArgs, flags CachePermissionFl
 	}
 
 	conn, err := c.Transport.Connect(ctx, kube.Target{
+		Kubeconfig: a.Kubeconfig,
 		Namespace:  a.Namespace,
 		Deployment: a.DeploymentName,
 		Port:       a.Port,

--- a/provider/attic/cache_test.go
+++ b/provider/attic/cache_test.go
@@ -181,6 +181,84 @@ func TestRetentionPeriodWireForm(t *testing.T) {
 	}
 }
 
+// The kubeconfig must actually reach the transport.
+//
+// The ambient default config is whatever kubectl happens to point at, which is
+// usually NOT the identity the process running `pulumi up`/`refresh` deploys
+// with — this is the exact gap that broke litellm's admin port-forward
+// (sector7#350):
+//
+//	deployments.apps "litellm" is forbidden: User "pulumi-zeus" cannot get
+//	resource "deployments" in API group "apps" in the namespace "litellm"
+//
+// Dropping this input anywhere between the resource and kube.Target is
+// invisible to every other test — the Fake ignores the Target and returns the
+// same BaseURL regardless — and shows up only in production, as a
+// port-forward refused for the wrong user.
+func TestCacheKubeconfigReachesTheTransport(t *testing.T) {
+	const kubeconfig = "apiVersion: v1\nkind: Config\n# platform identity\n"
+
+	t.Run("forwarded when set", func(t *testing.T) {
+		h := newHarness(t, nil)
+		args := baseCacheArgs()
+		args.Kubeconfig = kubeconfig
+
+		if _, _, err := (Cache{Transport: h.tr}).connect(t.Context(), args, adminCreateFlags); err != nil {
+			t.Fatal(err)
+		}
+		if got := h.tr.LastTarget.Kubeconfig; got != kubeconfig {
+			t.Fatalf("kubeconfig did not reach kube.Target: got %q", got)
+		}
+		// The rest of the target must still be carried, or a correct
+		// kubeconfig would just point at the wrong deployment.
+		if h.tr.LastTarget.Namespace != "attic" ||
+			h.tr.LastTarget.Deployment != "attic" ||
+			h.tr.LastTarget.Port != 8080 {
+			t.Fatalf("rest of the target was dropped: %+v", h.tr.LastTarget)
+		}
+	})
+
+	t.Run("empty when unset, meaning ambient", func(t *testing.T) {
+		h := newHarness(t, nil)
+		if _, _, err := (Cache{Transport: h.tr}).connect(t.Context(), baseCacheArgs(), adminCreateFlags); err != nil {
+			t.Fatal(err)
+		}
+		if got := h.tr.LastTarget.Kubeconfig; got != "" {
+			t.Fatalf("unset kubeconfig must stay empty (ambient), got %q", got)
+		}
+	})
+}
+
+// A rotated kubeconfig has to land in state, or every later operation keeps
+// using the stale one — and it must be an in-place update, never a replace,
+// which would regenerate the cache's signing keypair and break every client's
+// trusted-public-keys.
+func TestCacheKubeconfigChangeIsAnAdminTargetDiff(t *testing.T) {
+	old := CacheState{CacheArgs: baseCacheArgs(), PublicKey: "k"}
+	news := baseCacheArgs()
+	news.Kubeconfig = "apiVersion: v1\nkind: Config\n# rotated\n"
+
+	r, err := Cache{}.Diff(t.Context(), infer.DiffRequest[CacheArgs, CacheState]{State: old, Inputs: news})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r.DetailedDiff["adminTarget"].Kind != pgo.Update {
+		t.Fatalf("a rotated kubeconfig must be an in-place adminTarget update; got %+v", r.DetailedDiff)
+	}
+	for name, d := range r.DetailedDiff {
+		if d.Kind == pgo.UpdateReplace {
+			t.Fatalf("a kubeconfig change must never replace a live cache (%s did)", name)
+		}
+	}
+
+	// Unchanged inputs must stay a no-op — this is what keeps a live cache
+	// from churning (and regenerating its keypair) on every apply.
+	r, _ = Cache{}.Diff(t.Context(), infer.DiffRequest[CacheArgs, CacheState]{State: old, Inputs: baseCacheArgs()})
+	if r.HasChanges {
+		t.Fatalf("unchanged inputs must not diff; got %+v", r.DetailedDiff)
+	}
+}
+
 func TestCacheDiffReplacesOnIdentityOnly(t *testing.T) {
 	old := CacheState{CacheArgs: baseCacheArgs(), PublicKey: "k"}
 

--- a/provider/internal/kube/kube.go
+++ b/provider/internal/kube/kube.go
@@ -17,9 +17,10 @@ import "context"
 
 // Target identifies a Deployment to forward to.
 type Target struct {
-	// Kubeconfig is YAML. Empty means the ambient default config, which is
-	// what every current sector7 call site relies on (litellm and attic never
-	// pass one; only OnePasswordItem may).
+	// Kubeconfig is YAML. Empty means the ambient default config, which every
+	// call site falls back to when its resource's own Kubeconfig input is
+	// unset — see AdminTarget.Kubeconfig (litellm), CacheArgs.Kubeconfig
+	// (attic), and ItemArgs.Kubeconfig (onepassword).
 	Kubeconfig string
 	Namespace  string
 	Deployment string


### PR DESCRIPTION
## Summary

- `attic`'s `Cache` resource has the same latent RBAC gap that already caused a real incident for `litellm` (sector7#350): its admin port-forward (`kube.Transport.Connect`) always used whatever kubeconfig is ambient in the process running `pulumi up`/`refresh`, with no way for a stack to pass a narrower or different kubeconfig explicitly.
- Adds an optional, secret `CacheArgs.Kubeconfig` field (`pulumi:"kubeconfig,optional" provider:"secret"`), threaded into the `kube.Target{...}` built in `Cache.connect` (`provider/attic/cache.go`) — same tag convention and doc-comment style as `litellm.AdminTarget.Kubeconfig` and `onepassword.ItemArgs.Kubeconfig`.
- `Cache.Diff` now treats a `Kubeconfig`-only change as part of the existing `adminTarget` in-place `Update`, not a replace — mirroring `AdminTarget.Changed` in litellm. A cache replace would regenerate its signing keypair and break every client's `trustedPublicKeys`, so this must stay in-place.
- Fixed a stale doc comment on `kube.Target.Kubeconfig` that claimed "litellm and attic never pass one; only OnePasswordItem may" — no longer true after sector7#350 and this PR.

## Scope

Input plumbing only, per the litellm precedent:
- **No `__provider` state migration** — attic never went through a dynamic-provider retype, so (unlike litellm) there is no legacy state shape to migrate against. This field is additive and optional; existing state simply decodes with `Kubeconfig: ""`.
- **No TypeScript changes** — `packages/sector7/attic/admin.ts` is untouched.
- **`MintArgs` (token.go) and `TokenArgs` (token_resource.go) are untouched** — verified neither has a `.Connect` call. `MintToken` signs JWTs entirely in-process (HMAC, no cluster connectivity), so there is nothing to route a kubeconfig through. The single `.Connect` call site in the whole `provider/attic` package is `cache.go:187`, and it now carries `Kubeconfig`.

## Test plan

- [x] `provider/attic/cache_test.go`: added `TestCacheKubeconfigReachesTheTransport` — proves a set `Kubeconfig` reaches `kube.Fake.LastTarget.Kubeconfig` (plus the rest of the target), and that an unset one stays empty (ambient), mirroring litellm's `TestAdminTargetKubeconfigReachesTheTransport`.
- [x] `provider/attic/cache_test.go`: added `TestCacheKubeconfigChangeIsAnAdminTargetDiff` — proves a rotated `Kubeconfig` diffs as an in-place `adminTarget` `Update`, never a `Replace`, and that unchanged inputs stay a no-op. Mirrors litellm's `TestKubeconfigChangeIsAnAdminTargetDiff`.
- [x] `nix build .#checks.x86_64-linux.provider-go-test --no-link` — green (`provider/attic` package, all subtests).
- [x] `nix flake check --keep-going -L` — green (treefmt, pre-commit, tsc, vitest, provider-version-stamped, renovate-config; `provider-go-test` verified separately above).

## Risks

- Low. Purely additive optional field; default behaviour (empty `Kubeconfig` → ambient config) is unchanged for every existing stack. The `Diff` change only affects the *kind* of update `Kubeconfig` triggers (in-place vs. none — it was previously not a tracked field at all), not whether it changes.

## Related

- Precedent: sector7#350 (`fix(litellm): accept an explicit kubeconfig for the admin port-forward`)
