### PR TITLE
fix(nix-output,nix-image): pipe scripts via stdin instead of a resolved path

### DIFF
--- a/packages/sector7/nix-image/nix-image.ts
+++ b/packages/sector7/nix-image/nix-image.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from "node:fs";
 import * as command from "@pulumi/command";
 import * as pulumi from "@pulumi/pulumi";
 import { NixOutput } from "../nix-output/nix-output.ts";
@@ -115,6 +116,14 @@ export class NixImage extends pulumi.ComponentResource {
 		});
 
 		const pushScriptPath = getScriptPath("nix-image-push.sh");
+		// The script's own CONTENT is what should drive the tracked `create`
+		// input, not its resolved filesystem path — see the matching comment in
+		// nix-output.ts. getScriptPath() returns an absolute path through
+		// node_modules, which changes on every checkout AND on every single
+		// sector7 version bump (pnpm encodes the resolved version into the
+		// .pnpm store directory name), forcing a replace of both commands below
+		// regardless of whether the script itself changed.
+		const pushScriptContent = readFileSync(pushScriptPath, "utf8");
 		const commandLogStem = `.pulumi/command-logs/${name}`;
 
 		const mode = args.mode ?? "build";
@@ -134,7 +143,8 @@ export class NixImage extends pulumi.ComponentResource {
 			const resolveCmd = new command.local.Command(
 				`${name}-resolve`,
 				{
-					create: pulumi.interpolate`bash "${pushScriptPath}"`,
+					create: "bash -s",
+					stdin: pushScriptContent,
 					environment: {
 						...baseEnv,
 						SCRIPT_MODE: "resolve",
@@ -182,7 +192,8 @@ export class NixImage extends pulumi.ComponentResource {
 			const pushCmd = new command.local.Command(
 				`${name}-push`,
 				{
-					create: pulumi.interpolate`bash "${pushScriptPath}"`,
+					create: "bash -s",
+					stdin: pushScriptContent,
 					environment: {
 						...baseEnv,
 						SCRIPT_MODE: "push",

--- a/packages/sector7/nix-output/nix-output.ts
+++ b/packages/sector7/nix-output/nix-output.ts
@@ -1,4 +1,5 @@
 import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
 import * as command from "@pulumi/command";
 import * as pulumi from "@pulumi/pulumi";
 import { getScriptPath } from "../scripts/index.ts";
@@ -183,6 +184,17 @@ export class NixOutput extends pulumi.ComponentResource {
 		});
 
 		const scriptPath = getScriptPath("nix-output-resolve.sh");
+		// The script's own CONTENT is what should drive the tracked `create`
+		// input, not its resolved filesystem path. getScriptPath() returns an
+		// absolute path through node_modules, which is both checkout-location-
+		// dependent (same bug class as REPO_ROOT above) AND changes on every
+		// single sector7 version bump — pnpm encodes the resolved package
+		// version into the .pnpm store directory name. Baking that path into
+		// `create` forced a replace of this Command on every version bump
+		// regardless of whether the script itself changed. Piping the content
+		// via `stdin` with a fixed `create` command makes the tracked input
+		// depend only on what the script actually does.
+		const scriptContent = readFileSync(scriptPath, "utf8");
 		const commandLogStem = `.pulumi/command-logs/${name}`;
 		const mode = args.mode ?? "resolve";
 		const previewStrategy = args.previewStrategy ?? "resource";
@@ -239,7 +251,8 @@ export class NixOutput extends pulumi.ComponentResource {
 		const cmd = new command.local.Command(
 			`${name}-resolve`,
 			{
-				create: pulumi.interpolate`bash "${scriptPath}"`,
+				create: "bash -s",
+				stdin: scriptContent,
 				environment: env,
 				triggers: [
 					args.nixAttr,

--- a/packages/sector7/tests/nix-image.test.ts
+++ b/packages/sector7/tests/nix-image.test.ts
@@ -26,16 +26,20 @@ beforeAll(() => {
 		newResource: (args) => {
 			const state = args.inputs;
 
-			// For command.local.Command, simulate stdout with appropriate markers
+			// For command.local.Command, simulate stdout with appropriate markers.
+			// `create` is now a fixed "bash -s" for every script-backed command
+			// (the script content is piped via `stdin` instead, so a spurious
+			// resolved-path change never forces a replace) — so which script
+			// this is has to be identified from stdin's content, not create.
 			if (args.type === "command:local:Command") {
-				const create = state.create as string | undefined;
+				const stdin = state.stdin as string | undefined;
 
-				if (create?.includes("nix-output-resolve.sh")) {
+				if (stdin?.includes("Resolve or build a nix flake attribute")) {
 					// NixOutput: simulate store path output
 					const storePath = "/nix/store/abc123-my-image";
 					(state as Record<string, unknown>).stdout =
 						`=== Resolved: ${storePath} ===\nSTORE_PATH_OUTPUT:${storePath}\n`;
-				} else if (create?.includes("nix-image-push.sh")) {
+				} else if (stdin?.includes("Push a nix2container image")) {
 					// Push or resolve: simulate digest output
 					(state as Record<string, unknown>).stdout =
 						"=== Pushed registry/example:dev ===\n=== Digest: sha256:abc123def456 ===\nDIGEST_OUTPUT:sha256:abc123def456\n";
@@ -137,8 +141,11 @@ describe("NixImage", () => {
 		const cmd = cmds[0];
 		expect(cmd.type).toBe("command:local:Command");
 
-		const createCmd = cmd.inputs.create as string;
-		expect(createCmd).toContain("nix-image-push.sh");
+		// The script content is piped via stdin now, not referenced by path in
+		// `create` — a fixed `create` is the whole point of the fix.
+		expect(cmd.inputs.create).toBe("bash -s");
+		const stdin = cmd.inputs.stdin as string;
+		expect(stdin).toContain("Push a nix2container image");
 		expect(cmd.inputs.environment).toMatchObject({
 			IMAGE_NAME: "my-image",
 			IMAGE_TAG: "v1.0.0",

--- a/packages/sector7/tests/nix-output.test.ts
+++ b/packages/sector7/tests/nix-output.test.ts
@@ -26,21 +26,21 @@ function installMocks(preview = false): void {
 			newResource: (args: pulumi.runtime.MockResourceArgs) => {
 				const state = args.inputs;
 
-				// For command.local.Command, simulate stdout with STORE_PATH_OUTPUT marker
+				// For command.local.Command, simulate stdout with STORE_PATH_OUTPUT
+				// marker. Every command:local:Command in this file's tests is the
+				// nix-output-resolve.sh one — `create` is now a fixed "bash -s"
+				// with the script piped via `stdin` (see the fix in nix-output.ts),
+				// so there's nothing script-specific left to gate on here.
 				if (args.type === "command:local:Command") {
-					const create = state.create as string | undefined;
+					const env = state.environment as Record<string, string> | undefined;
+					const subPath = env?.SUB_PATH;
+					const baseStorePath = "/nix/store/abc123-myapp-1.0.0";
+					const storePath = subPath
+						? `${baseStorePath}/${subPath}`
+						: baseStorePath;
 
-					if (create?.includes("nix-output-resolve.sh")) {
-						const env = state.environment as Record<string, string> | undefined;
-						const subPath = env?.SUB_PATH;
-						const baseStorePath = "/nix/store/abc123-myapp-1.0.0";
-						const storePath = subPath
-							? `${baseStorePath}/${subPath}`
-							: baseStorePath;
-
-						(state as Record<string, unknown>).stdout =
-							`=== Resolved: ${storePath} ===\nSTORE_PATH_OUTPUT:${storePath}\n`;
-					}
+					(state as Record<string, unknown>).stdout =
+						`=== Resolved: ${storePath} ===\nSTORE_PATH_OUTPUT:${storePath}\n`;
 				}
 
 				resources.push({
@@ -112,6 +112,15 @@ describe("NixOutput", () => {
 			SCRIPT_MODE: "resolve",
 			COMMAND_LOG_STEM: ".pulumi/command-logs/test-default",
 		});
+		// `create` must be a FIXED string — not a resolved filesystem path
+		// through node_modules, which would change on every checkout AND on
+		// every sector7 version bump. The script content is piped via `stdin`
+		// instead, so what's tracked is what the script does, not where it
+		// happens to live on disk.
+		expect(cmd.inputs.create).toBe("bash -s");
+		expect(cmd.inputs.stdin).toContain(
+			"Resolve or build a nix flake attribute",
+		);
 	});
 
 	// The spawned command always builds/resolves against the ambient


### PR DESCRIPTION
## Why

A second, separate machine-path-drift bug in the same family as #360 and garden#1607 — found while previewing `ergon/prod` immediately after #360 merged, to confirm the fix worked. It didn't clean the diff up.

`getScriptPath()` resolves an absolute path through `node_modules` (`__dirname` + filename). That path is baked directly into the tracked `create` command string on three `command.local.Command` resources: `NixOutput`'s resolve command, and `NixImage`'s `resolveCmd`/`pushCmd`.

This is actually **worse** than the `REPO_ROOT` bug #360 fixed: the path varies not only by checkout location, but on **every single sector7 version bump** — pnpm encodes the resolved package version into the `.pnpm` virtual-store directory name (`.pnpm/@jmmaloney4+sector7@<url>_<hash>/`). So every release, regardless of whether it touched these scripts at all, forced a replace of every `NixOutput`/`NixImage`-backed resource on the next apply — an unnecessary image rebuild and repush for every consumer (ergon, litellm, ...), every time sector7 bumps.

## Fix

Read the script's own content at construction time (a local, synchronous, non-diffed read) and pipe it via the Command's `stdin` property, with a fixed `create: "bash -s"` instead of the resolved path. The tracked input now depends on **what the script does**, not **where it happens to live on disk** — a real diff only fires when the script's content genuinely changes.

## Verification

End-to-end isolated repro: applied a `command.local.Command` using this pattern from one absolute path (simulating `__dirname`), then previewed the identical program from a completely different path:

```
Resources:
    2 unchanged
```

Negative control: reverted to the path-based `create` and confirmed the "create stays a fixed string" assertion in `nix-output.test.ts` fails, with the exact resolved path leaking through.

## Tests

Updated both test files' mock detection — previously keyed on `create.includes("<script>.sh")`, which no longer distinguishes anything since `create` is now always `"bash -s"`. Switched to matching distinctive content in `stdin`. Added explicit assertions that `create` is the fixed string and `stdin` carries the expected script content.

```
$ nix flake check --keep-going
✅ pre-commit   ✅ provider-go-test   ✅ provider-version-stamped
✅ renovate-config   ✅ treefmt   ✅ tsc   ✅ vitest (35/35 targeted, full suite green)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014fxmGtPEGqWumJw8yyHfHb
