### PR TITLE
feat(matrix): add __provider state migration for Room/BotAccount

### DIFF
--- a/provider/matrix/migrations.go
+++ b/provider/matrix/migrations.go
@@ -1,0 +1,87 @@
+package matrix
+
+import (
+	"context"
+
+	"github.com/pulumi/pulumi-go-provider/infer"
+)
+
+// State migrations off the dynamic provider.
+//
+// Room and BotAccount replace garden-local TypeScript dynamic providers
+// (deploy/services/matrix/matrix-room.ts, matrix-bot-account.ts — see the
+// package doc comment on botaccount.go). Live state written by either one
+// carries `__provider`, the serialized JavaScript closure this plugin exists
+// to stop storing. infer treats an unrecognized property as a decode FAILURE
+// rather than something quietly ignored:
+//
+//	Unrecognized field '__provider' on 'matrix.RoomState'
+//	Unrecognized field '__provider' on 'matrix.BotAccountState'
+//
+// so without a migration the alias retype does not diff to nothing; it fails
+// outright at the first preview. Same shape and same mechanism as d1 and
+// onepassword; see provider/d1/migrations.go for the most heavily-commented
+// version of this pattern.
+//
+// One shape suffices for each resource. Neither RoomState nor BotAccountState
+// has a sentinel-encoded optional the way litellm's maxBudget did — every
+// property is a plain string, []string or *bool, so an empty/nil value is a
+// valid value of its own type and decodes fine whichever path it takes.
+// __provider is the only obstacle. (RoomArgs.IsDirect is a *bool rather than
+// bool specifically so a room with no isDirect in its inputs decodes as nil
+// instead of a false that Diff would then treat as a real value — see
+// boolPtrEqual in room.go — but that is a property of RoomState itself, not
+// something this migration needs to work around.)
+//
+// Both migrations are additive-safe: state that never passed through a
+// dynamic provider has no __provider, fails the migrator's decode ("doesn't
+// fit into the migrator", per infer's own docs), and falls through to the
+// normal path unchanged. Verified against the real gRPC path in
+// migrations_test.go using shapes modeled on the TypeScript outputs.
+
+type roomStateV0 struct {
+	RoomState
+	// Provider is the serialized dynamic-provider closure. Declared only so it
+	// can be dropped — nothing reads it.
+	//
+	// Deliberately NOT optional, and that tag is load-bearing. infer tries this
+	// migrator before the normal decode, so `optional` would make the shape
+	// match plugin-native state too and route every future read through the
+	// migration rather than only legacy state. Required is what makes native
+	// state miss this shape and fall through. Guarded by
+	// TestProviderTagIsRequiredSoTheMigrationOnlyMatchesLegacyState.
+	Provider string `pulumi:"__provider"`
+}
+
+// StateMigrations satisfies infer.CustomStateMigrations[RoomState].
+func (Room) StateMigrations(context.Context) []infer.StateMigrationFunc[RoomState] {
+	return []infer.StateMigrationFunc[RoomState]{
+		infer.StateMigration(func(_ context.Context, old roomStateV0) (infer.MigrationResult[RoomState], error) {
+			migrated := old.RoomState
+			return infer.MigrationResult[RoomState]{Result: &migrated}, nil
+		}),
+	}
+}
+
+type botAccountStateV0 struct {
+	BotAccountState
+	// Provider is the serialized dynamic-provider closure. Declared only so it
+	// can be dropped — nothing reads it.
+	//
+	// Deliberately NOT optional, for the same reason as roomStateV0.Provider
+	// above: infer tries this migrator before the normal decode, and `optional`
+	// would make the shape match plugin-native state too, routing every future
+	// read through the migration instead of only legacy state. Guarded by
+	// TestProviderTagIsRequiredSoTheMigrationOnlyMatchesLegacyState.
+	Provider string `pulumi:"__provider"`
+}
+
+// StateMigrations satisfies infer.CustomStateMigrations[BotAccountState].
+func (BotAccount) StateMigrations(context.Context) []infer.StateMigrationFunc[BotAccountState] {
+	return []infer.StateMigrationFunc[BotAccountState]{
+		infer.StateMigration(func(_ context.Context, old botAccountStateV0) (infer.MigrationResult[BotAccountState], error) {
+			migrated := old.BotAccountState
+			return infer.MigrationResult[BotAccountState]{Result: &migrated}, nil
+		}),
+	}
+}

--- a/provider/matrix/migrations_test.go
+++ b/provider/matrix/migrations_test.go
@@ -1,0 +1,252 @@
+package matrix
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/blang/semver"
+	p "github.com/pulumi/pulumi-go-provider"
+	"github.com/pulumi/pulumi-go-provider/infer"
+	"github.com/pulumi/pulumi-go-provider/integration"
+	"github.com/pulumi/pulumi/sdk/v3/go/property"
+)
+
+// liveRoomState mirrors what the garden-local dynamic provider
+// (deploy/services/matrix/matrix-room.ts) actually wrote: MatrixRoomOutputs
+// spread with `roomId`, plus `__provider`, the serialized closure. isDirect is
+// deliberately absent — the dynamic provider only wrote it when the input was
+// set (`if (isDirect !== undefined) body.is_direct = isDirect`), and RoomArgs
+// models that same absence as a nil *bool rather than a zero value. See
+// boolPtrEqual in room.go.
+func liveRoomState() property.Map {
+	return property.NewMap(map[string]property.Value{
+		"homeserverUrl":  property.New("https://matrix.example.com"),
+		"accessToken":    property.New("syt-bot-token"),
+		"name":           property.New("garden-alerts"),
+		"topic":          property.New("automated alerts"),
+		"preset":         property.New("private_chat"),
+		"aliasLocalpart": property.New("garden-alerts"),
+		"invite": property.New([]property.Value{
+			property.New("@jack:example.com"),
+		}),
+		"roomId":     property.New("!abc123:example.com"),
+		"__provider": property.New("4;/deleted/worktree/node_modules/...;closure"),
+	})
+}
+
+// newRoomInputs is what the retyped wrapper sends: the same args, minus
+// __provider and roomId (both outputs, not inputs).
+func newRoomInputs() property.Map {
+	return liveRoomState().Delete("__provider", "roomId")
+}
+
+// liveBotAccountState mirrors what the garden-local dynamic provider
+// (deploy/services/matrix/matrix-bot-account.ts) actually wrote:
+// MatrixBotAccountOutputs spread with `userId`/`accessToken`, plus
+// `__provider`. password is present — every live call site already passes an
+// explicit RandomPassword rather than relying on the dynamic provider's
+// random-UUID fallback (see the Password field comment in botaccount.go), so
+// legacy state always carries a real value.
+func liveBotAccountState() property.Map {
+	return property.NewMap(map[string]property.Value{
+		"homeserverUrl":     property.New("https://matrix.example.com"),
+		"username":          property.New("garden-bot"),
+		"displayName":       property.New("Garden Bot"),
+		"registrationToken": property.New("reg-token"),
+		"password":          property.New("s3cr3t-password"),
+		"userId":            property.New("@garden-bot:example.com"),
+		"accessToken":       property.New("syt-bot-access-token"),
+		"__provider":        property.New("4;/deleted/worktree/node_modules/...;closure"),
+	})
+}
+
+// newBotAccountInputs is what the retyped wrapper sends: the same args, minus
+// __provider, userId and accessToken (all outputs, not inputs).
+func newBotAccountInputs() property.Map {
+	return liveBotAccountState().Delete("__provider", "userId", "accessToken")
+}
+
+func testServer(t *testing.T) integration.Server {
+	t.Helper()
+	prov, err := infer.NewProviderBuilder().
+		WithNamespace("jmmaloney4").
+		WithResources(infer.Resource(Room{}), infer.Resource(BotAccount{})).
+		Build()
+	if err != nil {
+		t.Fatal(err)
+	}
+	srv, err := integration.NewServer(context.Background(), "sector7",
+		semver.MustParse("0.21.0"), integration.WithProvider(prov))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return srv
+}
+
+const roomURN = "urn:pulumi:prod::matrix::sector7:matrix:Room::garden-alerts"
+
+// THE migration gate for Room: the exact call the engine makes during the
+// alias retype. Must succeed and report no changes, or the cutover fails at
+// preview instead of diffing to nothing.
+//
+// Without the migration this fails with
+// `Unrecognized field '__provider' on 'matrix.RoomState'`.
+func TestRoomDiffAcceptsLiveDynamicProviderState(t *testing.T) {
+	srv := testServer(t)
+
+	resp, err := srv.Diff(p.DiffRequest{
+		ID:     "!abc123:example.com",
+		Urn:    roomURN,
+		State:  liveRoomState(),
+		Inputs: newRoomInputs(),
+	})
+	if err != nil {
+		t.Fatalf("Diff must accept live dynamic-provider state: %v", err)
+	}
+	if resp.HasChanges {
+		t.Fatalf("retype must diff to nothing; got %+v", resp.DetailedDiff)
+	}
+}
+
+// Dropping __provider is the ONLY thing the migration may do. A genuinely
+// edited name must still plan an update.
+func TestRoomRealFieldChangeSurvivesTheMigration(t *testing.T) {
+	srv := testServer(t)
+
+	inputs := newRoomInputs().Set("name", property.New("garden-alerts-renamed"))
+
+	resp, err := srv.Diff(p.DiffRequest{
+		ID:     "!abc123:example.com",
+		Urn:    roomURN,
+		State:  liveRoomState(),
+		Inputs: inputs,
+	})
+	if err != nil {
+		t.Fatalf("edited name must decode: %v", err)
+	}
+	if !resp.HasChanges {
+		t.Fatal("a renamed room must plan a change, not be swallowed by the migration")
+	}
+	if _, ok := resp.DetailedDiff["name"]; !ok {
+		t.Fatalf("expected a name diff; got %+v", resp.DetailedDiff)
+	}
+}
+
+// State that never passed through the dynamic provider has no __provider and
+// must decode by the normal path, proving the migration is additive-safe.
+func TestRoomPluginNativeStateStillDecodes(t *testing.T) {
+	srv := testServer(t)
+
+	resp, err := srv.Diff(p.DiffRequest{
+		ID:     "!abc123:example.com",
+		Urn:    roomURN,
+		State:  liveRoomState().Delete("__provider"),
+		Inputs: newRoomInputs(),
+	})
+	if err != nil {
+		t.Fatalf("plugin-native state must decode without a migration: %v", err)
+	}
+	if resp.HasChanges {
+		t.Fatalf("unchanged plugin-native state must diff to nothing; got %+v", resp.DetailedDiff)
+	}
+}
+
+const botAccountURN = "urn:pulumi:prod::matrix::sector7:matrix:BotAccount::garden-bot"
+
+// THE migration gate for BotAccount: same call shape as Room's, above.
+//
+// Without the migration this fails with
+// `Unrecognized field '__provider' on 'matrix.BotAccountState'`.
+func TestBotAccountDiffAcceptsLiveDynamicProviderState(t *testing.T) {
+	srv := testServer(t)
+
+	resp, err := srv.Diff(p.DiffRequest{
+		ID:     "@garden-bot:example.com",
+		Urn:    botAccountURN,
+		State:  liveBotAccountState(),
+		Inputs: newBotAccountInputs(),
+	})
+	if err != nil {
+		t.Fatalf("Diff must accept live dynamic-provider state: %v", err)
+	}
+	if resp.HasChanges {
+		t.Fatalf("retype must diff to nothing; got %+v", resp.DetailedDiff)
+	}
+}
+
+// Dropping __provider is the ONLY thing the migration may do. A genuinely
+// rotated password must still plan an (in-place) update.
+func TestBotAccountRealFieldChangeSurvivesTheMigration(t *testing.T) {
+	srv := testServer(t)
+
+	inputs := newBotAccountInputs().Set("password", property.New("ROTATED"))
+
+	resp, err := srv.Diff(p.DiffRequest{
+		ID:     "@garden-bot:example.com",
+		Urn:    botAccountURN,
+		State:  liveBotAccountState(),
+		Inputs: inputs,
+	})
+	if err != nil {
+		t.Fatalf("edited password must decode: %v", err)
+	}
+	if !resp.HasChanges {
+		t.Fatal("a rotated password must plan a change, not be swallowed by the migration")
+	}
+	if _, ok := resp.DetailedDiff["password"]; !ok {
+		t.Fatalf("expected a password diff; got %+v", resp.DetailedDiff)
+	}
+}
+
+// State that never passed through the dynamic provider has no __provider and
+// must decode by the normal path, proving the migration is additive-safe.
+func TestBotAccountPluginNativeStateStillDecodes(t *testing.T) {
+	srv := testServer(t)
+
+	resp, err := srv.Diff(p.DiffRequest{
+		ID:     "@garden-bot:example.com",
+		Urn:    botAccountURN,
+		State:  liveBotAccountState().Delete("__provider"),
+		Inputs: newBotAccountInputs(),
+	})
+	if err != nil {
+		t.Fatalf("plugin-native state must decode without a migration: %v", err)
+	}
+	if resp.HasChanges {
+		t.Fatalf("unchanged plugin-native state must diff to nothing; got %+v", resp.DetailedDiff)
+	}
+}
+
+// Same guard as d1's and onepassword's. infer runs migrations BEFORE the
+// normal decode and skips a migrator only when decoding into its old shape
+// FAILS, so `,optional` here would make roomStateV0/botAccountStateV0 match
+// plugin-native state too and route every read through the migration —
+// permanently, not just for legacy state.
+func TestProviderTagIsRequiredSoTheMigrationOnlyMatchesLegacyState(t *testing.T) {
+	t.Run("Room", func(t *testing.T) {
+		f, ok := reflect.TypeOf(roomStateV0{}).FieldByName("Provider")
+		if !ok {
+			t.Fatal("roomStateV0.Provider is gone; if the field was renamed, update this guard rather than deleting it")
+		}
+		if tag := f.Tag.Get("pulumi"); tag != "__provider" {
+			t.Fatalf("roomStateV0.Provider must be tagged exactly `pulumi:\"__provider\"`, got %q.\n"+
+				"Adding ,optional makes this shape match plugin-native state as well, so the\n"+
+				"migration would run on every state read instead of only on state written by\n"+
+				"the dynamic provider.", tag)
+		}
+	})
+
+	t.Run("BotAccount", func(t *testing.T) {
+		f, ok := reflect.TypeOf(botAccountStateV0{}).FieldByName("Provider")
+		if !ok {
+			t.Fatal("botAccountStateV0.Provider is gone; if the field was renamed, update this guard rather than deleting it")
+		}
+		if tag := f.Tag.Get("pulumi"); tag != "__provider" {
+			t.Fatalf("botAccountStateV0.Provider must be tagged exactly `pulumi:\"__provider\"`, got %q.\n"+
+				"Adding ,optional makes this shape match plugin-native state as well, so the\n"+
+				"migration would run on every state read instead of only on state written by\n"+
+				"the dynamic provider.", tag)
+		}
+	})
+}


### PR DESCRIPTION
## Summary

Adds the `__provider` state migration for `matrix.Room` and `matrix.BotAccount` — the prerequisite for retyping `MatrixRoom`/`MatrixBotAccount` off the garden-local TypeScript dynamic providers (`deploy/services/matrix/matrix-room.ts`, `matrix-bot-account.ts`) onto this Go resource plugin, per ADR 163.

`infer` treats an unrecognized property in stored state as a hard decode **failure**, not something silently ignored. Legacy state written by the dynamic provider carries a `__provider` field (the serialized JS closure — the very thing ADR 163 exists to stop storing), which `RoomState`/`BotAccountState` don't declare. Without a migration, the upcoming alias-based retype would fail preview outright:

```
Unrecognized field '__provider' on 'matrix.RoomState'
Unrecognized field '__provider' on 'matrix.BotAccountState'
```

instead of diffing to nothing as intended.

This follows the exact pattern already used by `d1` and `onepassword`: a `roomStateV0`/`botAccountStateV0` struct per resource that embeds the current State plus a *required* `__provider` field, dropped by an identity-copy migration in `StateMigrations`.

### The gotcha this guards against

`infer` tries a migrator's old shape *before* the normal decode, and only falls through to the normal decode when that old-shape decode **fails**. So `__provider` must be tagged `pulumi:"__provider"` — **not** `,optional`. Tagging it optional makes the old shape a strict superset that *also* matches already-migrated, plugin-native state, so the migration would fire on every future read forever instead of only on legacy dynamic-provider state. This exact mistake was made and caught by review during the d1 migration (sector7#354).

`TestProviderTagIsRequiredSoTheMigrationOnlyMatchesLegacyState` guards this for both `Room` and `BotAccount`. I verified it's load-bearing by temporarily flipping both tags to `,optional` locally, confirming the guard test fails for both subtests, and flipping them back.

## Test plan

- [x] `go test ./...` in `provider/` — full suite green, including the new `provider/matrix/migrations_test.go`.
- [x] `nix build .#checks.x86_64-linux.provider-go-test --no-link -L` — green.
- [x] Guard test verified to actually catch the `,optional` mistake (flipped tag → test failed with the expected message → flipped back → green).
- [x] Real gRPC path exercised via `integration.NewServer` + `srv.Diff` (not just Go-level unit calls), for both resources:
  - legacy state (with `__provider`, modeled on the actual TypeScript dynamic-provider outputs) decodes and diffs to **zero changes** against freshly-retyped inputs;
  - a genuinely changed field (`name` for Room, `password` for BotAccount) still plans an update — the migration must not swallow real changes;
  - state with **no** `__provider` decodes fine via the normal path, unaffected (additive-safety).
- [x] `nix fmt` on the new files — no changes needed.
- [ ] `nix flake check --keep-going` (full repo) — running; will report result.

## Scope

The TypeScript retype of `MatrixRoom`/`MatrixBotAccount` onto the `pulumi-nodejs:dynamic:Resource` alias (the garden-local repo side) is explicitly **out of scope** for this PR — this only adds the Go-side migration that retype's `pulumi preview` will depend on.

## Risks

None to existing resources — this is a new, self-contained file (`provider/matrix/migrations.go` + its test) with no central registration point and no changes to `provider.go` or any other resource family.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014fxmGtPEGqWumJw8yyHfHb
