### PR TITLE
feat(r2): add __provider state migration for Object

### DIFF
--- a/provider/r2/migrations.go
+++ b/provider/r2/migrations.go
@@ -1,0 +1,59 @@
+package r2
+
+import (
+	"context"
+
+	"github.com/pulumi/pulumi-go-provider/infer"
+)
+
+// State migration off the dynamic provider.
+//
+// R2Object replaces the garden-local TypeScript dynamic provider
+// (packages/sector7/r2/r2object.ts, deployed today via
+// deploy/www/theoreticaledge.com's uploadStaticAssets/R2Object pipeline). The
+// dynamic provider's create/update handlers wrote state as `{ ...inputs, etag
+// }`, and the Pulumi dynamic-resource runtime additionally persists
+// `__provider`, the serialized JavaScript closure this plugin exists to stop
+// storing. infer treats an unrecognized property as a decode FAILURE rather
+// than something quietly ignored:
+//
+//	Unrecognized field '__provider' on 'r2.ObjectState'
+//
+// so without this migration the alias retype does not diff to nothing; it
+// fails outright at the first preview. Same shape and same mechanism as d1
+// and onepassword; see provider/d1/migrations.go for the most
+// heavily-commented version of this pattern.
+//
+// One shape suffices. There is no sentinel-encoded optional the way
+// litellm's maxBudget was — every ObjectArgs/ObjectState property is a plain
+// string, so an empty value is a valid value of its own type and decodes
+// fine whichever path it takes. __provider is the only obstacle.
+//
+// The migration is additive-safe: state that never passed through the
+// dynamic provider has no __provider, fails this migrator's decode ("doesn't
+// fit into the migrator", per infer's own docs), and falls through to the
+// normal path unchanged. Verified against the real gRPC path in
+// migrations_test.go using a shape modeled on r2object.ts's stateOuts.
+type objectStateV0 struct {
+	ObjectState
+	// Provider is the serialized dynamic-provider closure. Declared only so
+	// it can be dropped — nothing reads it.
+	//
+	// Deliberately NOT optional, and that tag is load-bearing. infer tries
+	// this migrator before the normal decode, so `optional` would make the
+	// shape match plugin-native state too and route every future read
+	// through the migration rather than only legacy state. Required is what
+	// makes native state miss this shape and fall through. Guarded by
+	// TestProviderTagIsRequiredSoTheMigrationOnlyMatchesLegacyState.
+	Provider string `pulumi:"__provider"`
+}
+
+// StateMigrations satisfies infer.CustomStateMigrations[ObjectState].
+func (Object) StateMigrations(context.Context) []infer.StateMigrationFunc[ObjectState] {
+	return []infer.StateMigrationFunc[ObjectState]{
+		infer.StateMigration(func(_ context.Context, old objectStateV0) (infer.MigrationResult[ObjectState], error) {
+			migrated := old.ObjectState
+			return infer.MigrationResult[ObjectState]{Result: &migrated}, nil
+		}),
+	}
+}

--- a/provider/r2/migrations_test.go
+++ b/provider/r2/migrations_test.go
@@ -1,0 +1,151 @@
+package r2
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/blang/semver"
+	p "github.com/pulumi/pulumi-go-provider"
+	"github.com/pulumi/pulumi-go-provider/infer"
+	"github.com/pulumi/pulumi-go-provider/integration"
+	"github.com/pulumi/pulumi/sdk/v3/go/property"
+)
+
+// liveObjectState mirrors what the TypeScript dynamic provider actually
+// wrote: r2object.ts's create/update handlers return `{ ...inputs, etag }`
+// (see uploadObjectToR2 and the create/update entries in r2ObjectProvider),
+// and the Pulumi dynamic-resource runtime layers `__provider` — the
+// serialized closure — on top of every dynamic.Resource's state
+// automatically. Every ObjectArgs property is a plain string, so there is no
+// sentinel-encoding hazard the way litellm's maxBudget had; __provider is
+// the only obstacle to a clean decode.
+func liveObjectState() property.Map {
+	return property.NewMap(map[string]property.Value{
+		"accountId":       property.New("acct-123"),
+		"bucketName":      property.New("theoreticaledge-static"),
+		"key":             property.New("assets/app.css"),
+		"filePath":        property.New("/deleted/worktree/dist/assets/app.css"),
+		"contentType":     property.New("text/css"),
+		"accessKeyId":     property.New("AKIDEXAMPLE"),
+		"secretAccessKey": property.New("secret-key"),
+		"etag":            property.New("5d41402abc4b2a76b9719d911017c592"),
+		"__provider":      property.New("4;/deleted/worktree/node_modules/...;closure"),
+	})
+}
+
+// newInputs is what the retyped wrapper sends: the same args, minus
+// `__provider` (which belonged to the dynamic provider) and minus `etag` (an
+// output, not an input).
+func newInputs() property.Map {
+	return liveObjectState().Delete("__provider", "etag")
+}
+
+func testServer(t *testing.T) integration.Server {
+	t.Helper()
+	prov, err := infer.NewProviderBuilder().
+		WithNamespace("jmmaloney4").
+		WithResources(infer.Resource(Object{})).
+		Build()
+	if err != nil {
+		t.Fatal(err)
+	}
+	srv, err := integration.NewServer(context.Background(), "sector7",
+		semver.MustParse("0.21.0"), integration.WithProvider(prov))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return srv
+}
+
+const objectURN = "urn:pulumi:prod::theoreticaledge.com::sector7:r2:Object::theoreticaledge-static-assets/app.css"
+
+// THE migration gate: the exact call the engine makes during the alias
+// retype. Must succeed and report no changes, or the cutover fails at
+// preview instead of diffing to nothing.
+//
+// Without the migration this fails with
+// `Unrecognized field '__provider' on 'r2.ObjectState'`.
+func TestDiffAcceptsLiveDynamicProviderState(t *testing.T) {
+	srv := testServer(t)
+
+	resp, err := srv.Diff(p.DiffRequest{
+		ID:     "theoreticaledge-static/assets/app.css",
+		Urn:    objectURN,
+		State:  liveObjectState(),
+		Inputs: newInputs(),
+	})
+	if err != nil {
+		t.Fatalf("Diff must accept live dynamic-provider state: %v", err)
+	}
+	if resp.HasChanges {
+		t.Fatalf("retype must diff to nothing; got %+v", resp.DetailedDiff)
+	}
+}
+
+// Dropping __provider is the ONLY thing the migration may do. A genuinely
+// changed input must still plan a change — for identity properties that
+// means UpdateReplace, per Object.Diff.
+func TestRealChangeSurvivesTheMigration(t *testing.T) {
+	srv := testServer(t)
+
+	inputs := newInputs().Set("key", property.New("assets/app2.css"))
+
+	resp, err := srv.Diff(p.DiffRequest{
+		ID:     "theoreticaledge-static/assets/app.css",
+		Urn:    objectURN,
+		State:  liveObjectState(),
+		Inputs: inputs,
+	})
+	if err != nil {
+		t.Fatalf("edited inputs must decode: %v", err)
+	}
+	if !resp.HasChanges {
+		t.Fatal("a real key change must plan a change, not be swallowed by the migration")
+	}
+	if d, ok := resp.DetailedDiff["key"]; !ok || d.Kind != p.UpdateReplace {
+		t.Fatalf("expected a key replace diff; got %+v", resp.DetailedDiff)
+	}
+}
+
+// State that never passed through the dynamic provider has no __provider and
+// must decode by the normal path, proving the migration is additive-safe.
+func TestPluginNativeStateStillDecodes(t *testing.T) {
+	srv := testServer(t)
+
+	resp, err := srv.Diff(p.DiffRequest{
+		ID:     "theoreticaledge-static/assets/app.css",
+		Urn:    objectURN,
+		State:  liveObjectState().Delete("__provider"),
+		Inputs: newInputs(),
+	})
+	if err != nil {
+		t.Fatalf("plugin-native state must decode without a migration: %v", err)
+	}
+	if resp.HasChanges {
+		t.Fatalf("unchanged plugin-native state must diff to nothing; got %+v", resp.DetailedDiff)
+	}
+}
+
+// Same guard as d1's and onepassword's. infer runs migrations BEFORE the
+// normal decode and skips a migrator only when decoding into its old shape
+// FAILS, so `,optional` here would make objectStateV0 match plugin-native
+// state too and route every read through the migration — permanently, not
+// just for legacy state.
+//
+// Structural rather than behavioural on purpose: the migration is an
+// identity copy of the embedded ObjectState, so the two tags are largely
+// indistinguishable from outside (verified below by reproducing that: this
+// guard is what actually catches the regression, not the Diff tests above).
+func TestProviderTagIsRequiredSoTheMigrationOnlyMatchesLegacyState(t *testing.T) {
+	f, ok := reflect.TypeOf(objectStateV0{}).FieldByName("Provider")
+	if !ok {
+		t.Fatal("objectStateV0.Provider is gone; if the field was renamed, update this guard rather than deleting it")
+	}
+	if tag := f.Tag.Get("pulumi"); tag != "__provider" {
+		t.Fatalf("objectStateV0.Provider must be tagged exactly `pulumi:\"__provider\"`, got %q.\n"+
+			"Adding ,optional makes this shape match plugin-native state as well, so the\n"+
+			"migration would run on every state read instead of only on state written by\n"+
+			"the dynamic provider.", tag)
+	}
+}


### PR DESCRIPTION
## Summary

Adds the `__provider` state migration for `r2.Object` — the next resource in ADR 163's dynamic-provider-to-Go-plugin cutover, after litellm, d1, and onepassword. The Go CRUD implementation for `Object`/`ObjectState` already exists in `provider/r2/object.go`; this PR adds only the migration the alias-based TypeScript retype will need once it lands (that retype is out of scope here — see below).

## Why

`infer` treats an unrecognized property in stored state as a hard decode **failure**, not something silently ignored. Legacy state written by the TypeScript dynamic provider (`packages/sector7/r2/r2object.ts`) carries a `__provider` field (the serialized JS closure) that `ObjectState` doesn't declare. Without a migration, the alias retype does not diff to nothing at preview time — it fails outright:

```
Unrecognized field '__provider' on 'r2.ObjectState'
```

## The load-bearing gotcha

`infer` tries each registered migration's "old" shape *before* falling through to the normal decode, on **every** read/diff, not just ones touching legacy state. So `objectStateV0.Provider` is tagged plain `` pulumi:"__provider" `` — **not** `,optional`. Tagging it optional would make the old shape a superset that also matches already-migrated, plugin-native state, so the migration would fire on every single future read instead of only on legacy dynamic-provider state.

This exact mistake was made and caught by review during the d1 migration (sector7#354). A guard test, `TestProviderTagIsRequiredSoTheMigrationOnlyMatchesLegacyState`, pins the tag so it can't regress silently — verified locally by temporarily flipping the tag to `,optional` and confirming the guard test fails, then reverting.

## Scope

Only `R2Object`/`ObjectState`. `provider/r2/zonecachepurge.go`'s `ZoneCachePurge` has no live TypeScript dynamic-resource usage anywhere in `jmmaloney4/garden` (verified by grep across the repo), so there is no legacy state to migrate for it — no migration was added there. The TypeScript retype of `packages/sector7/r2/r2object.ts` / `packages/sector7/r2/index.ts` into a thin `pulumi.CustomResource` wrapper with a `pulumi-nodejs:dynamic:Resource` alias is explicitly out of scope for this PR.

## Test plan

- [x] `provider/r2/migrations_test.go` exercises the real gRPC path via `integration.NewServer` + `srv.Diff` (not just Go-level unit calls):
  - `TestDiffAcceptsLiveDynamicProviderState` — live dynamic-provider state (with `__provider`) diffs to nothing against the retyped wrapper's inputs.
  - `TestRealChangeSurvivesTheMigration` — a genuine input change (`key`) still plans an `UpdateReplace`, proving the migration doesn't swallow real diffs.
  - `TestPluginNativeStateStillDecodes` — state with no `__provider` decodes via the normal path unaffected.
  - `TestProviderTagIsRequiredSoTheMigrationOnlyMatchesLegacyState` — structural guard on the tag; manually verified it fails when the tag is flipped to `,optional`.
- [x] `go test ./...` — full provider module green (all packages, including r2, d1, onepassword, matrix, litellm, attic).
- [x] `nix build .#checks.x86_64-linux.provider-go-test --no-link` — green.
- [x] `nix flake check --keep-going` (x86_64-linux) — all 7 applicable checks green: `provider-go-test`, `renovate-config`, `pre-commit`, `provider-version-stamped`, `tsc`, `treefmt`, `vitest`. (aarch64-darwin/aarch64-linux/x86_64-darwin omitted — cross-platform, not buildable from this runner.)

## Risks

Low. This is an additive-only Go file (`provider/r2/migrations.go`) plus its test — no changes to `object.go`'s CRUD logic, no changes to any TypeScript, no central registration required (`StateMigrations` is picked up structurally via `infer.CustomStateMigrations[ObjectState]`). Does not itself trigger the TypeScript cutover; that's a separate follow-up PR.
