### PR TITLE
feat(r2): retype R2Object onto the resource plugin

### DIFF
--- a/packages/sector7/r2/r2object.ts
+++ b/packages/sector7/r2/r2object.ts
@@ -7,7 +7,6 @@ import {
 	type CustomResourceOptions,
 	dynamic,
 	type Input,
-	type Output,
 	type Resource,
 } from "@pulumi/pulumi";
 
@@ -23,146 +22,6 @@ export type DynamicResourceOptions = Omit<
 	CustomResourceOptions,
 	"provider" | "providers"
 >;
-
-// ---------------------------------------------------------------------------
-// AWS Signature Version 4 — minimal implementation for S3 PUT/DELETE only.
-// Uses node:crypto (dynamically imported) and global fetch(). No external deps.
-// See: https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_sigv.html
-// ---------------------------------------------------------------------------
-
-interface SigV4Credentials {
-	accessKeyId: string;
-	secretAccessKey: string;
-}
-
-/**
- * Derive the signing key for a given date/region/service.
- * HMAC chain: (secret) → dateKey → regionKey → serviceKey → signingKey
- */
-const deriveSigningKey = async (
-	nodeCrypto: typeof import("node:crypto"),
-	secretAccessKey: string,
-	dateStamp: string,
-	region: string,
-	service: string,
-): Promise<Buffer> => {
-	const hmac = (key: Buffer | string, data: string) =>
-		nodeCrypto.createHmac("sha256", key).update(data).digest();
-	const dateKey = hmac(`AWS4${secretAccessKey}`, dateStamp);
-	const regionKey = hmac(dateKey, region);
-	const serviceKey = hmac(regionKey, service);
-	return hmac(serviceKey, "aws4_request");
-};
-
-/**
- * Build an AWS Sig V4 signed request and execute it via fetch().
- *
- * This is deliberately scoped to the two operations we need:
- *   - PUT    (upload object body)
- *   - DELETE (remove object)
- *
- * No query strings, no multipart, no chunked encoding.
- */
-const signedFetch = async (
-	method: "PUT" | "DELETE",
-	url: string,
-	creds: SigV4Credentials,
-	body?: Buffer,
-	contentType?: string,
-): Promise<Response> => {
-	const nodeCrypto = (await import(
-		"node:crypto"
-	)) as typeof import("node:crypto");
-
-	const parsed = new URL(url);
-	const host = parsed.host;
-	const now = new Date();
-	const amzDate = now
-		.toISOString()
-		.replace(/[-:]/g, "")
-		.replace(/\.\d+Z$/, "Z");
-	const dateStamp = amzDate.slice(0, 8);
-	const region = "auto";
-	const service = "s3";
-
-	// Payload hash
-	const payloadHash = body
-		? nodeCrypto.createHash("sha256").update(body).digest("hex")
-		: nodeCrypto.createHash("sha256").update("").digest("hex");
-
-	// Canonical headers — must be sorted by lowercase name.
-	// Only include content-type when it has a value so the signed
-	// headers match the actual fetch headers exactly.
-	const headers: Record<string, string> = {
-		host,
-		"x-amz-content-sha256": payloadHash,
-		"x-amz-date": amzDate,
-	};
-	if (contentType) {
-		headers["content-type"] = contentType;
-	}
-
-	const signedHeaderNames = Object.keys(headers).sort().join(";");
-	const canonicalHeaders =
-		Object.keys(headers)
-			.sort()
-			.map((k) => `${k}:${headers[k].trim()}`)
-			.join("\n") + "\n";
-
-	// Canonical request
-	const canonicalQueryString = "";
-	const canonicalRequest = [
-		method,
-		parsed.pathname,
-		canonicalQueryString,
-		canonicalHeaders,
-		signedHeaderNames,
-		payloadHash,
-	].join("\n");
-
-	// String to sign
-	const credentialScope = `${dateStamp}/${region}/${service}/aws4_request`;
-	const stringToSign = [
-		"AWS4-HMAC-SHA256",
-		amzDate,
-		credentialScope,
-		nodeCrypto.createHash("sha256").update(canonicalRequest).digest("hex"),
-	].join("\n");
-
-	// Sign
-	const signingKey = await deriveSigningKey(
-		nodeCrypto,
-		creds.secretAccessKey,
-		dateStamp,
-		region,
-		service,
-	);
-	const signature = nodeCrypto
-		.createHmac("sha256", signingKey)
-		.update(stringToSign)
-		.digest("hex");
-
-	const authorization =
-		`AWS4-HMAC-SHA256 Credential=${creds.accessKeyId}/${credentialScope}, ` +
-		`SignedHeaders=${signedHeaderNames}, Signature=${signature}`;
-
-	// Build fetch headers (must match canonical exactly)
-	const fetchHeaders: Record<string, string> = {
-		Authorization: authorization,
-		Host: host,
-		"X-Amz-Content-Sha256": payloadHash,
-		"X-Amz-Date": amzDate,
-	};
-	if (contentType) {
-		fetchHeaders["Content-Type"] = contentType;
-	}
-
-	return fetch(parsed.href, {
-		method,
-		headers: fetchHeaders,
-		body: body ? new Uint8Array(body) : undefined,
-	});
-};
 
 // ---------------------------------------------------------------------------
 // Types
@@ -292,29 +151,6 @@ export interface UploadStaticAssetsArgs {
 	dependsOn?: Input<Input<Resource>[]>;
 }
 
-/**
- * Resolved inputs as seen inside the dynamic provider callbacks.
- * All values are plain strings — Pulumi resolves Input<T> before invoking the provider.
- */
-interface R2ObjectArgs {
-	accountId: string;
-	bucketName: string;
-	key: string;
-	filePath: string;
-	contentType: string;
-	accessKeyId: string;
-	secretAccessKey: string;
-}
-
-/** State persisted in Pulumi for each R2Object resource. */
-interface R2ObjectState extends R2ObjectArgs {
-	/**
-	 * MD5 hex digest of the uploaded file content (matches the S3/R2 ETag format).
-	 * Stored in state and compared on the next `diff` call to detect content changes.
-	 */
-	etag: string;
-}
-
 const rejectCloudProviderOptions = (
 	resourceName: string,
 	opts?: CustomResourceOptions,
@@ -352,243 +188,49 @@ const omitCloudProviderOptions = (
 	return dynamicOpts;
 };
 
-// ---------------------------------------------------------------------------
-// File helpers
-// ---------------------------------------------------------------------------
-
-const tryStatFileSync = (
-	fs: typeof import("node:fs"),
-	filePath: string,
-): boolean => {
-	try {
-		return fs.statSync(filePath).isFile();
-	} catch (error) {
-		if ((error as NodeJS.ErrnoException).code === "ENOENT") return false;
-		throw error;
-	}
-};
-
-const tryReadFileSync = (
-	fs: typeof import("node:fs"),
-	filePath: string,
-): Buffer | undefined => {
-	try {
-		return fs.readFileSync(filePath);
-	} catch (error) {
-		if ((error as NodeJS.ErrnoException).code === "ENOENT") return undefined;
-		throw error;
-	}
-};
-
-// ---------------------------------------------------------------------------
-// R2 operations via native S3 signing (no AWS SDK)
-// ---------------------------------------------------------------------------
-
-// RFC 3986 strict encoding: encodeURIComponent plus the characters
-// AWS Sig V4 requires for path segments but encodeURIComponent skips.
-// These characters are: ! ' ( ) *
-const rfc3986Encode = (s: string): string =>
-	encodeURIComponent(s).replace(
-		/[!'()*]/g,
-		(c) => `%${c.charCodeAt(0).toString(16).toUpperCase()}`,
-	);
-
-/** Upload a file to R2 and return the normalized ETag. */
-const uploadObjectToR2 = async (args: R2ObjectArgs): Promise<string> => {
-	const fs = (await import("node:fs")) as typeof import("node:fs");
-	const nodeCrypto = (await import(
-		"node:crypto"
-	)) as typeof import("node:crypto");
-
-	const {
-		accountId,
-		bucketName,
-		key,
-		filePath,
-		contentType,
-		accessKeyId,
-		secretAccessKey,
-	} = args;
-	const body = fs.readFileSync(filePath);
-	const url = `https://${accountId}.r2.cloudflarestorage.com/${bucketName}/${key.split("/").map(rfc3986Encode).join("/")}`;
-
-	const response = await signedFetch(
-		"PUT",
-		url,
-		{ accessKeyId, secretAccessKey },
-		body,
-		contentType,
-	);
-
-	if (!response.ok) {
-		const text = await response.text();
-		throw new Error(
-			`R2 PUT ${key} failed: ${response.status} ${response.statusText}\n${text}`,
-		);
-	}
-
-	const etag = response.headers.get("ETag");
-	return (
-		etag ?? nodeCrypto.createHash("md5").update(body).digest("hex")
-	).replace(/"/g, "");
-};
-
-/** Delete an object from R2. */
-const deleteObjectFromR2 = async (args: {
-	accountId: string;
-	bucketName: string;
-	key: string;
-	accessKeyId: string;
-	secretAccessKey: string;
-}): Promise<void> => {
-	const url = `https://${args.accountId}.r2.cloudflarestorage.com/${args.bucketName}/${args.key.split("/").map(rfc3986Encode).join("/")}`;
-	const response = await signedFetch("DELETE", url, {
-		accessKeyId: args.accessKeyId,
-		secretAccessKey: args.secretAccessKey,
-	});
-
-	// R2 returns 204 on successful delete; tolerate 404 (already gone)
-	if (response.status !== 204 && response.status !== 404) {
-		const text = await response.text();
-		throw new Error(
-			`R2 DELETE ${args.key} failed: ${response.status} ${response.statusText}\n${text}`,
-		);
-	}
-};
-
-// ---------------------------------------------------------------------------
-// Pulumi dynamic provider
-// ---------------------------------------------------------------------------
-
-/**
- * Pulumi dynamic resource provider that manages a single object in a
- * Cloudflare R2 bucket via the S3-compatible API.
- *
- * Notes
- * -----
- * Node built-in imports (fs, crypto) are inlined as dynamic import() calls
- * inside provider callbacks rather than imported at module top level.  Pulumi
- * serializes the provider object via V8 source capture; top-level ES module
- * imports of Node built-ins capture native-code functions that cannot be
- * serialized, causing a "Function code: function () { [native code] }" error.
- * Dynamic import() calls are emitted verbatim and evaluated at runtime after
- * deserialization.  See the Pulumi dynamic provider serialization docs:
- * https://www.pulumi.com/docs/concepts/resources/dynamic-providers/#how-dynamic-providers-are-serialized
- *
- * S3 requests are signed natively using AWS Signature Version 4 (node:crypto +
- * fetch) — no @aws-sdk/client-s3 dependency required (ADR-015).
- *
- * Lifecycle
- * ---------
- * - check  : verify the local file exists
- * - diff   : compare MD5(file) to stored etag; replace on key/bucket/account change
- * - create : PUT with body + content-type; store etag
- * - update : re-upload via PUT; store new etag
- * - delete : DELETE
- */
-const r2ObjectProvider: dynamic.ResourceProvider = {
-	async check(
-		_olds: R2ObjectState,
-		news: R2ObjectArgs,
-	): Promise<dynamic.CheckResult> {
-		const fs = (await import("node:fs")) as typeof import("node:fs");
-		const failures: dynamic.CheckFailure[] = [];
-		try {
-			if (!tryStatFileSync(fs, news.filePath)) {
-				failures.push({
-					property: "filePath",
-					reason: `file not found: ${news.filePath}`,
-				});
-			}
-		} catch (error) {
-			failures.push({
-				property: "filePath",
-				reason: `failed to stat file: ${news.filePath}: ${
-					error instanceof Error ? error.message : String(error)
-				}`,
-			});
-		}
-		return { inputs: news, failures };
-	},
-
-	async diff(
-		_id: string,
-		olds: R2ObjectState,
-		news: R2ObjectArgs,
-	): Promise<dynamic.DiffResult> {
-		const fs = (await import("node:fs")) as typeof import("node:fs");
-		const nodeCrypto = (await import(
-			"node:crypto"
-		)) as typeof import("node:crypto");
-
-		const replaces: string[] = [];
-		if (olds.key !== news.key) replaces.push("key");
-		if (olds.bucketName !== news.bucketName) replaces.push("bucketName");
-		if (olds.accountId !== news.accountId) replaces.push("accountId");
-		if (olds.accessKeyId !== news.accessKeyId) replaces.push("accessKeyId");
-		if (olds.secretAccessKey !== news.secretAccessKey)
-			replaces.push("secretAccessKey");
-
-		const currentFile = tryReadFileSync(fs, news.filePath);
-		const currentEtag = currentFile
-			? nodeCrypto.createHash("md5").update(currentFile).digest("hex")
-			: // Missing files should force a change without crashing refresh/diff.
-				"";
-		const changed =
-			replaces.length > 0 ||
-			currentEtag !== olds.etag ||
-			news.contentType !== olds.contentType;
-
-		return { changes: changed, replaces, deleteBeforeReplace: true };
-	},
-
-	async create(inputs: R2ObjectArgs): Promise<dynamic.CreateResult> {
-		const etag = await uploadObjectToR2(inputs);
-		const { bucketName, key } = inputs;
-		return { id: `${bucketName}/${key}`, outs: { ...inputs, etag } };
-	},
-
-	async update(
-		_id: string,
-		_olds: R2ObjectState,
-		news: R2ObjectArgs,
-	): Promise<dynamic.UpdateResult> {
-		const etag = await uploadObjectToR2(news);
-		return { outs: { ...news, etag } };
-	},
-
-	async delete(_id: string, props: R2ObjectState): Promise<void> {
-		await deleteObjectFromR2(props);
-	},
-};
-
 /**
  * A single object stored in a Cloudflare R2 bucket.
  *
- * Uses the S3-compatible API for all CRUD operations via native AWS Sig V4
- * signing (node:crypto + fetch).  Content changes are detected via MD5
- * comparison against the stored ETag — no external binary required.
+ * Backed by the `sector7` resource plugin. This was previously a Pulumi
+ * *dynamic* provider, which serialised its JavaScript closure into stack
+ * state and re-executed that stored copy on refresh and delete (garden
+ * ADR 163). The CRUD implementation — including AWS Sig V4 signing for the
+ * S3-compatible API — now lives in `sector7/provider/r2/object.go`.
  *
- * Parameters
- * ----------
- * name : str
- *     Pulumi resource name.
- * args : R2ObjectInputs
- *     Bucket coordinates, local file path, content-type, and R2 API credentials.
- * opts : pulumi.CustomResourceOptions, optional
- *     Standard Pulumi resource options.
+ * Content changes are detected via MD5 comparison against the stored ETag.
+ * A change to `key`, `bucketName` or `accountId` replaces the object; a
+ * content or contentType change updates it in place.
  */
-export class R2Object extends dynamic.Resource {
+export class R2Object extends pulumi.CustomResource {
 	/** ETag of the uploaded object as returned by R2 (MD5 hex, no quotes). */
-	public declare readonly etag: Output<string>;
+	public declare readonly etag: pulumi.Output<string>;
 
 	constructor(
 		name: string,
 		args: R2ObjectInputs,
-		opts?: DynamicResourceOptions,
+		opts?: CustomResourceOptions,
 	) {
-		rejectCloudProviderOptions("R2Object", opts);
-		super(r2ObjectProvider, name, { etag: undefined, ...args }, opts);
+		// Force credentials to secrets so they're encrypted in state even when
+		// the caller passes plain strings. The plugin schema already marks
+		// these secret; this covers the input side at construction too.
+		const securedArgs = {
+			...args,
+			accessKeyId: pulumi.secret(args.accessKeyId),
+			secretAccessKey: pulumi.secret(args.secretAccessKey),
+		};
+
+		super(
+			"sector7:r2:Object",
+			name,
+			{ etag: undefined, ...securedArgs },
+			pulumi.mergeOptions(opts, {
+				// What makes the move off the dynamic provider a no-op: the
+				// engine rewrites the URN in place, so `pulumi preview` is a
+				// complete, side-effect-free dry run and no R2 API call is
+				// made during the cutover.
+				aliases: [{ type: "pulumi-nodejs:dynamic:Resource" }],
+			}),
+		);
 	}
 }
 

--- a/packages/sector7/tests/r2object.test.ts
+++ b/packages/sector7/tests/r2object.test.ts
@@ -1,29 +1,27 @@
-import { createHash } from "node:crypto";
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-type R2ObjectProvider = {
-	check: (
-		olds: unknown,
-		news: Record<string, string>,
-	) => Promise<{ failures: Array<{ property: string; reason: string }> }>;
-	diff: (
-		id: string,
-		olds: Record<string, string>,
-		news: Record<string, string>,
-	) => Promise<{
-		changes: boolean;
-		replaces?: string[];
-		deleteBeforeReplace?: boolean;
-	}>;
+// R2Object's own CRUD/Diff logic (AWS Sig V4 signing, MD5 ETag comparison,
+// replace-on-key/bucket/account-change) moved to
+// provider/r2/object.go when this resource retyped onto the sector7 plugin
+// (garden ADR 163) — see object_test.go for that coverage. What's left here
+// is the TypeScript wrapper's OWN concerns: does construction reach the
+// plugin with the right token/alias/secret-wrapping, and does the
+// `uploadAssets`/`purgeZoneCache` orchestration around it still behave
+// correctly.
+
+type CustomResourceCall = {
+	type: string;
+	name: string;
+	args: Record<string, unknown>;
+	opts: Record<string, unknown> | undefined;
 };
 
 type DynamicResourceCall = {
 	name: string;
 	opts: Record<string, unknown> | undefined;
-	provider: R2ObjectProvider;
 };
 
 type AccountTokenCall = {
@@ -31,7 +29,7 @@ type AccountTokenCall = {
 	opts: Record<string, unknown> | undefined;
 };
 
-let provider: R2ObjectProvider | undefined;
+const customResourceCalls: CustomResourceCall[] = [];
 const dynamicResourceCalls: DynamicResourceCall[] = [];
 const accountTokenCalls: AccountTokenCall[] = [];
 
@@ -39,24 +37,40 @@ vi.mock("@pulumi/pulumi", () => {
 	const output = <T>(value: T) => ({
 		apply: <U>(fn: (value: T) => U) => fn(value),
 	});
+	// Spy, not a plain identity function: an identity wrapper can't
+	// distinguish "value passed through secret()" from "value passed through
+	// untouched", so a test asserting only on the resolved value would pass
+	// whether or not the constructor actually calls pulumi.secret(). Asserting
+	// on the spy's call arguments is what makes that distinction observable.
+	const secret = vi.fn(<T>(value: T) => value);
 
 	return {
 		all: <T>(value: T) => output(value),
 		output,
+		secret,
 		mergeOptions: (
-			left: Record<string, unknown>,
+			left: Record<string, unknown> | undefined,
 			right: Record<string, unknown>,
 		) => ({ ...left, ...right }),
+		CustomResource: class {
+			constructor(
+				type: string,
+				name: string,
+				args: Record<string, unknown>,
+				opts?: Record<string, unknown>,
+			) {
+				customResourceCalls.push({ type, name, args, opts });
+			}
+		},
 		dynamic: {
 			Resource: class {
 				constructor(
-					resourceProvider: R2ObjectProvider,
+					_resourceProvider: unknown,
 					name: string,
 					_args: Record<string, unknown>,
 					opts?: Record<string, unknown>,
 				) {
-					provider = resourceProvider;
-					dynamicResourceCalls.push({ name, opts, provider: resourceProvider });
+					dynamicResourceCalls.push({ name, opts });
 				}
 			},
 		},
@@ -81,6 +95,7 @@ vi.mock("@pulumi/cloudflare", () => ({
 	},
 }));
 
+import * as pulumi from "@pulumi/pulumi";
 import { purgeZoneCache, R2Object, uploadAssets } from "../r2/r2object.ts";
 
 const createArgs = (filePath: string) => ({
@@ -95,74 +110,37 @@ const createArgs = (filePath: string) => ({
 
 const cloudProviderOpt = { provider: { urn: "cloudflare-provider" } };
 
-describe("R2Object provider", () => {
+describe("R2Object construction", () => {
 	let tempDir: string;
 
 	beforeEach(() => {
 		tempDir = mkdtempSync(join(tmpdir(), "r2object-test-"));
-		provider = undefined;
-		dynamicResourceCalls.length = 0;
-		accountTokenCalls.length = 0;
-		new R2Object("asset", createArgs(join(tempDir, "bootstrap.txt")));
+		customResourceCalls.length = 0;
 	});
 
 	afterEach(() => {
 		rmSync(tempDir, { recursive: true, force: true });
 	});
 
-	it("reports a check failure when the file path no longer exists", async () => {
-		const missingPath = join(tempDir, "missing.txt");
+	it("registers under the sector7:r2:Object token with the dynamic-provider alias", () => {
+		new R2Object("asset", createArgs(join(tempDir, "index.html")));
 
-		const result = await provider!.check({}, createArgs(missingPath));
-
-		expect(result.failures).toEqual([
-			{
-				property: "filePath",
-				reason: `file not found: ${missingPath}`,
-			},
+		expect(customResourceCalls).toHaveLength(1);
+		const call = customResourceCalls[0];
+		expect(call.type).toBe("sector7:r2:Object");
+		// This is what makes the cutover a no-op: the engine matches this
+		// resource against state written by the old dynamic provider and
+		// rewrites the URN in place, instead of planning a delete+create.
+		expect(call.opts?.aliases).toEqual([
+			{ type: "pulumi-nodejs:dynamic:Resource" },
 		]);
 	});
 
-	it("treats a missing file as a diff instead of throwing ENOENT", async () => {
-		const missingPath = join(tempDir, "missing.txt");
-		const olds = {
-			...createArgs(missingPath),
-			etag: createHash("md5").update("previous contents").digest("hex"),
-		};
-
-		const result = await provider!.diff("bucket-123/index.html", olds, {
-			...createArgs(missingPath),
-		});
-
-		expect(result).toMatchObject({
-			changes: true,
-			replaces: [],
-			deleteBeforeReplace: true,
-		});
-	});
-
-	it("keeps unchanged files stable during diff", async () => {
-		const filePath = join(tempDir, "index.html");
-		const body = "<h1>hello</h1>";
-		writeFileSync(filePath, body);
-
-		const result = await provider!.diff(
-			"bucket-123/index.html",
-			{
-				...createArgs(filePath),
-				etag: createHash("md5").update(body).digest("hex"),
-			},
-			createArgs(filePath),
-		);
-
-		expect(result).toMatchObject({
-			changes: false,
-			replaces: [],
-			deleteBeforeReplace: true,
-		});
-	});
-
-	it("rejects cloud provider options when R2Object is constructed directly", () => {
+	it("accepts provider/providers, unlike the dynamic provider it replaces", () => {
+		// The old R2Object threw on provider/providers (it was a JS dynamic
+		// resource; routing it through a cloud provider bridge failed with a
+		// misleading unknown-token error). The plugin-backed resource has no
+		// such constraint — provider/providers are ordinary supported options.
 		expect(
 			() =>
 				new R2Object(
@@ -170,20 +148,28 @@ describe("R2Object provider", () => {
 					createArgs(join(tempDir, "index.html")),
 					cloudProviderOpt,
 				),
-		).toThrow(
-			/R2Object is a Pulumi dynamic resource; do not pass provider\/providers/,
-		);
+		).not.toThrow();
+
+		expect(customResourceCalls[0].opts).toMatchObject(cloudProviderOpt);
+	});
+
+	it("marks accessKeyId and secretAccessKey secret on the input side", () => {
+		vi.mocked(pulumi.secret).mockClear();
+
+		new R2Object("asset", createArgs(join(tempDir, "index.html")));
+
+		expect(pulumi.secret).toHaveBeenCalledWith("access-key");
+		expect(pulumi.secret).toHaveBeenCalledWith("secret-key");
 	});
 });
 
 describe("uploadAssets", () => {
 	beforeEach(() => {
-		provider = undefined;
-		dynamicResourceCalls.length = 0;
+		customResourceCalls.length = 0;
 		accountTokenCalls.length = 0;
 	});
 
-	it("keeps provider options on the Cloudflare token but strips them from dynamic R2 objects", () => {
+	it("keeps provider options on the Cloudflare token but strips them from R2 objects", () => {
 		uploadAssets(
 			"site",
 			{
@@ -202,15 +188,14 @@ describe("uploadAssets", () => {
 
 		expect(accountTokenCalls).toHaveLength(1);
 		expect(accountTokenCalls[0].opts).toMatchObject(cloudProviderOpt);
-		expect(dynamicResourceCalls).toHaveLength(1);
-		expect(dynamicResourceCalls[0].opts).not.toHaveProperty("provider");
-		expect(dynamicResourceCalls[0].opts).not.toHaveProperty("providers");
+		expect(customResourceCalls).toHaveLength(1);
+		expect(customResourceCalls[0].opts).not.toHaveProperty("provider");
+		expect(customResourceCalls[0].opts).not.toHaveProperty("providers");
 	});
 });
 
 describe("purgeZoneCache", () => {
 	beforeEach(() => {
-		provider = undefined;
 		dynamicResourceCalls.length = 0;
 		accountTokenCalls.length = 0;
 	});

--- a/packages/sector7/tests/zone-cache-purge.test.ts
+++ b/packages/sector7/tests/zone-cache-purge.test.ts
@@ -41,6 +41,13 @@ vi.mock("@pulumi/pulumi", () => ({
 		},
 	},
 	mergeOptions: (..._opts: unknown[]) => ({}),
+	secret: <T>(value: T) => value,
+	// r2object.ts also exports R2Object (`extends pulumi.CustomResource`) from
+	// the same module this file imports purgeZoneCache from — the class
+	// declaration is evaluated at module-load time regardless of which export
+	// this file actually uses, so CustomResource must exist here too or the
+	// import throws before any test in this file runs.
+	CustomResource: class {},
 }));
 
 import { purgeZoneCache } from "../r2/r2object.ts";


### PR DESCRIPTION
## Why

Last dynamic-provider resource in this package. The Go CRUD (AWS Sig V4 signing, MD5-based diff, replace-on-key/bucket/account change) and `__provider` migration landed in sector7#363; this deletes the JS dynamic provider that was shadowing it, completing ADR 163 for the r2 family.

## What

`r2object.ts`: **1036 → 678 lines**. Removed entirely: the native AWS Sig V4 signing implementation (`SigV4Credentials`, `deriveSigningKey`, `signedFetch`, `rfc3986Encode`), `uploadObjectToR2`/`deleteObjectFromR2`, the `r2ObjectProvider` `dynamic.ResourceProvider`, and `R2Object`'s own `rejectCloudProviderOptions` call — no longer meaningful, since `R2Object` is now plugin-backed and `provider`/`providers` are ordinary supported options (same as onepassword/matrix).

`ZoneCachePurge`, `uploadAssets` and `uploadStaticAssets` are **untouched** — `ZoneCachePurge` stays a dynamic resource (out of scope, no live TypeScript usage anywhere in `jmmaloney4/garden`), and the two upload helpers are orchestration around `R2Object`, not part of its own CRUD.

## Tests

Rewrote `r2object.test.ts`. The old "R2Object provider" describe block tested the dynamic provider's `check`/`diff` logic directly — that coverage now lives in `provider/r2/object_test.go` (already existed before this PR) and is superseded, not lost.

Added coverage for what the TS wrapper actually owns:
- registers under `sector7:r2:Object` with the dynamic-provider alias
- accepts `provider`/`providers` instead of throwing
- marks both credential fields secret on the input side — verified via a `vi.fn()` spy on `pulumi.secret`. An earlier identity-mock version of this test passed whether or not the constructor called `secret()` at all; negative-control testing caught that it wasn't actually asserting anything, which is why the spy version exists instead.

`zone-cache-purge.test.ts` needed a matching `CustomResource` stub added to its own `@pulumi/pulumi` mock: it only imports `purgeZoneCache` from this same module, but `class R2Object extends pulumi.CustomResource` is evaluated at module-load time regardless of which export a test file actually uses — its mock needed the export defined even though that file never constructs an `R2Object`.

## Verification

```
$ nix flake check --keep-going
✅ pre-commit   ✅ provider-go-test   ✅ provider-version-stamped
✅ renovate-config   ✅ treefmt   ✅ tsc   ✅ vitest
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014fxmGtPEGqWumJw8yyHfHb