### PR TITLE
feat(attic): retype Cache/Token onto the resource plugin

### DIFF
--- a/packages/sector7/attic/admin.ts
+++ b/packages/sector7/attic/admin.ts
@@ -1,735 +1,78 @@
 import * as pulumi from "@pulumi/pulumi";
-import {
-	type CustomResourceOptions,
-	dynamic,
-	type Output,
-} from "@pulumi/pulumi";
-import { withPortForward } from "../k8s/port-forward.ts";
 import type { AtticCacheArgs, AtticTokenArgs } from "./config-types.ts";
-import {
-	type AtticCacheGrants,
-	type AtticCachePermissionFlags,
-	mintAtticToken,
-	parseDurationSeconds,
-} from "./token.ts";
+import { parseDurationSeconds } from "./token.ts";
 
 /**
- * Resource options accepted by sector7 dynamic resources.
+ * An Attic binary cache, administered through the sector7 resource plugin.
  *
- * Pulumi dynamic resources are executed by the Node.js dynamic provider runtime,
- * not by a cloud provider plugin. Passing `provider` or `providers` makes Pulumi
- * route the resource through the wrong provider bridge, which fails with a
- * misleading `pulumi-nodejs:dynamic:Resource` unknown-token error.
- */
-export type DynamicResourceOptions = Omit<
-	CustomResourceOptions,
-	"provider" | "providers"
->;
-
-// ---------------------------------------------------------------------------
-// Resolved provider input/state shapes
-//
-// Pulumi resolves every `Input<T>` before invoking the dynamic provider, so the
-// callbacks below see plain JSON values only. Optional fields are normalized to
-// sentinel empty values ("" / [] / {}) by the wrapping component so the provider
-// never has to reason about `undefined`.
-// ---------------------------------------------------------------------------
-
-/** Coordinates + signing secret for reaching the Attic cache-config API. */
-interface AdminTarget {
-	namespace: string;
-	hs256SecretBase64: string;
-	deploymentName: string;
-	port: number;
-}
-
-interface CacheProviderInputs extends AdminTarget {
-	cacheName: string;
-	isPublic: boolean;
-	priority: number;
-	storeDir: string;
-	upstreamCacheKeyNames: string[];
-	/** "" when unset (server default / `Global`). */
-	retentionPeriodSeconds: number | "";
-}
-
-interface CacheProviderState extends CacheProviderInputs {
-	/** Public NAR-signing key, read back from the cache config. */
-	publicKey: string;
-}
-
-interface TokenProviderInputs {
-	hs256SecretBase64: string;
-	sub: string;
-	validitySeconds: number;
-	caches: AtticCacheGrants;
-}
-
-interface TokenProviderState extends TokenProviderInputs {
-	/** The signed JWT (a bearer credential — kept out of the resource id). */
-	token: string;
-	/** Baked `exp`, unix seconds. */
-	expiresAt: number;
-	/** Baked `nbf`, unix seconds. */
-	notBefore: number;
-}
-
-// ---------------------------------------------------------------------------
-// Runtime helpers
-//
-// Like the LiteLLM admin providers, the in-process port-forward lives in the
-// shared `../k8s/port-forward` module (`withPortForward`), whose lazy
-// `await import()` of @kubernetes/client-node / node:net keeps the provider
-// closures serializable. The helpers below similarly reach `node:http` through a
-// lazy `await import()` inside `atticFetch` (and `mintAtticToken` lazily imports
-// node:crypto), so they hold no top-level native imports either.
-// https://www.pulumi.com/docs/concepts/resources/dynamic-providers/#how-dynamic-providers-are-serialized
-// ---------------------------------------------------------------------------
-
-const ADMIN_SUB = "sector7-attic-cache";
-/** Short admin-token validity — only needs to outlive a single API call. */
-const ADMIN_TOKEN_VALIDITY_SECONDS = 300;
-
-const ADMIN_CREATE_FLAGS: AtticCachePermissionFlags = {
-	pull: true,
-	createCache: true,
-	configureCache: true,
-	configureCacheRetention: true,
-};
-const ADMIN_UPDATE_FLAGS: AtticCachePermissionFlags = {
-	pull: true,
-	configureCache: true,
-	configureCacheRetention: true,
-};
-const ADMIN_DELETE_FLAGS: AtticCachePermissionFlags = {
-	pull: true,
-	destroyCache: true,
-};
-
-/**
- * Mint a short-lived admin token scoped to a single cache and the permissions a
- * specific operation needs (least privilege), signed from the server's HS256
- * secret. No server contact — the token is self-contained.
- */
-async function mintAdminToken(
-	target: AdminTarget,
-	cacheName: string,
-	flags: AtticCachePermissionFlags,
-): Promise<string> {
-	const now = Math.floor(Date.now() / 1000);
-	return mintAtticToken({
-		secretBase64: target.hs256SecretBase64,
-		sub: ADMIN_SUB,
-		issuedAtSeconds: now,
-		expiresAtSeconds: now + ADMIN_TOKEN_VALIDITY_SECONDS,
-		caches: { [cacheName]: flags },
-	});
-}
-
-/** Open a short-lived port-forward to a ready Attic pod for `fn`. */
-async function withCacheBaseUrl<T>(
-	target: AdminTarget,
-	fn: (baseUrl: string) => Promise<T>,
-): Promise<T> {
-	return withPortForward(
-		{
-			namespace: target.namespace,
-			deploymentName: target.deploymentName,
-			port: target.port,
-		},
-		fn,
-	);
-}
-
-interface AtticResponse {
-	status: number;
-	ok: boolean;
-	text: string;
-	// biome-ignore lint/suspicious/noExplicitAny: cache-config responses are dynamic JSON
-	json: any;
-}
-
-/**
- * Low-level cache-config request that surfaces the status so callers can branch.
+ * Backed by `provider/attic/cache.go`. This was previously a Pulumi
+ * *dynamic* provider wrapped in a `ComponentResource`, which serialised its
+ * JavaScript closure into stack state and re-executed that stored copy on
+ * refresh and delete (garden ADR 163).
  *
- * Uses `node:http` (lazily imported) rather than the global `fetch`. Attic
- * validates the HTTP `Host` header against its `allowed-hosts` list, but the
- * transport reaches the pod through a `127.0.0.1:<ephemeral-port>` port-forward,
- * so the wire `Host` must be overridden to the in-cluster Service FQDN that
- * `allowed-hosts` actually permits. undici (the global `fetch`) treats `Host` as
- * a forbidden header and silently drops a caller override — so a `fetch()` here
- * sends `Host: 127.0.0.1:<port>` and Attic rejects it with 400 "Bad Host".
- * `node:http` honors a caller-supplied `Host`, so it is the correct transport.
+ * This retype is more involved than a flat dynamic-provider cutover
+ * (compare MatrixRoom, R2Object): the OLD shape was a `ComponentResource`
+ * (type `sector7:attic:Cache`) wrapping an inner `dynamic.Resource` CHILD
+ * (type `pulumi-nodejs:dynamic:Resource`, name `${name}-cache`) that held
+ * the actual state — not a single flat resource. The Go plugin's Cache type
+ * registers as `sector7:atticprovider:Cache`, not the more obvious
+ * `sector7:attic:Cache` (see `Cache.Annotate` in cache.go): reusing
+ * `sector7:attic:Cache` would make this resource's own identity
+ * coincidentally collide with the OLD component's already-live URN, and
+ * empirically (verified against a real nested old state with a throwaway
+ * plugin before this was written) the engine treats that coincidental
+ * direct match as authoritative and never falls back to consulting the
+ * alias below at all — silently discarding the child's real state instead
+ * of adopting it. With a non-colliding token, nothing in old state matches
+ * this resource's own identity, so the alias is the only candidate and the
+ * child is adopted cleanly; the old component carries no real state
+ * (`ComponentResource`s are `custom: false`, with no id) and is simply
+ * dropped as harmless bookkeeping cleanup once nothing references it.
  */
-async function atticFetch(
-	baseUrl: string,
-	token: string,
-	target: AdminTarget,
-	path: string,
-	method: "GET" | "POST" | "PATCH" | "DELETE",
-	body?: unknown,
-): Promise<AtticResponse> {
-	const http = await import("node:http");
-	const payload = body !== undefined ? JSON.stringify(body) : undefined;
-	const host = `${target.deploymentName}.${target.namespace}.svc.cluster.local`;
-	const headers: Record<string, string> = {
-		Authorization: `Bearer ${token}`,
-		Host: host,
-	};
-	if (payload !== undefined) {
-		headers["Content-Type"] = "application/json";
-		headers["Content-Length"] = String(Buffer.byteLength(payload));
-	}
-	return await new Promise<AtticResponse>((resolve, reject) => {
-		const req = http.request(
-			`${baseUrl}${path}`,
-			{ method, headers },
-			(res) => {
-				const chunks: Buffer[] = [];
-				res.on("data", (chunk: Buffer) => chunks.push(chunk));
-				res.on("end", () => {
-					const text = Buffer.concat(chunks).toString("utf8");
-					const status = res.statusCode ?? 0;
-					const ok = status >= 200 && status < 300;
-					// biome-ignore lint/suspicious/noExplicitAny: cache-config responses are dynamic JSON
-					let json: any;
-					try {
-						json = text ? JSON.parse(text) : {};
-					} catch {
-						json = undefined;
-					}
-					resolve({ status, ok, text, json });
-				});
-			},
-		);
-		req.on("error", reject);
-		if (payload !== undefined) req.write(payload);
-		req.end();
-	});
-}
-
-/** Throw on a non-2xx cache-config response; otherwise return the parsed body. */
-function ensureOk(
-	res: AtticResponse,
-	method: string,
-	path: string,
-	// biome-ignore lint/suspicious/noExplicitAny: cache-config responses are dynamic JSON
-): any {
-	if (!res.ok) {
-		throw new Error(
-			`Attic ${method} ${path} failed: ${res.status}\n${res.text}`,
-		);
-	}
-	return res.json;
-}
-
-/** Render the optional retention into Attic's `RetentionPeriodConfig` wire form. */
-function retentionPeriod(
-	retentionPeriodSeconds: number | "",
-): "Global" | { Period: number } {
-	return retentionPeriodSeconds === ""
-		? "Global"
-		: { Period: retentionPeriodSeconds };
-}
-
-/** `CreateCacheRequest` body (POST) — keypair is always server-generated. */
-function buildCreateBody(inputs: CacheProviderInputs): Record<string, unknown> {
-	return {
-		keypair: "Generate",
-		is_public: inputs.isPublic,
-		store_dir: inputs.storeDir,
-		priority: inputs.priority,
-		upstream_cache_key_names: inputs.upstreamCacheKeyNames,
-	};
-}
-
-/**
- * `CacheConfig` body (PATCH) reconciling the mutable fields. Deliberately omits
- * `keypair` (never rotate) and `store_dir` (immutable in our model — a change is
- * a replacement), so adoption preserves the existing signing key.
- */
-function buildPatchBody(inputs: CacheProviderInputs): Record<string, unknown> {
-	return {
-		is_public: inputs.isPublic,
-		priority: inputs.priority,
-		upstream_cache_key_names: inputs.upstreamCacheKeyNames,
-		retention_period: retentionPeriod(inputs.retentionPeriodSeconds),
-	};
-}
-
-/** GET the cache config and return its public signing key. */
-async function readPublicKey(
-	baseUrl: string,
-	token: string,
-	target: AdminTarget,
-	cacheName: string,
-): Promise<string> {
-	const path = `/_api/v1/cache-config/${cacheName}`;
-	const config = ensureOk(
-		await atticFetch(baseUrl, token, target, path, "GET"),
-		"GET",
-		path,
-	);
-	// Fail fast on a missing key: silently returning "" would persist an unusable
-	// signing key in state and hide a broken/incompatible Attic API response.
-	const publicKey = config?.public_key;
-	if (typeof publicKey !== "string" || publicKey.length === 0) {
-		throw new Error(
-			`Attic GET ${path} returned no public_key — cannot resolve the cache signing key`,
-		);
-	}
-	return publicKey;
-}
-
-/**
- * True when any admin-connection field changed. Such a change does not alter the
- * remote cache, but it must still flow into stored state so a later update/delete
- * targets the new deployment and mints under the new secret — so diff() treats it
- * as an in-place change.
- */
-function adminTargetChanged(olds: AdminTarget, news: AdminTarget): boolean {
-	return (
-		olds.namespace !== news.namespace ||
-		olds.deploymentName !== news.deploymentName ||
-		olds.port !== news.port ||
-		olds.hs256SecretBase64 !== news.hs256SecretBase64
-	);
-}
-
-/** Stable JSON for order-insensitive comparison in diff(). */
-function stableJson(value: unknown): string {
-	if (Array.isArray(value)) {
-		return JSON.stringify([...value].map(stableValue).sort());
-	}
-	return JSON.stringify(stableValue(value));
-}
-
-function stableValue(value: unknown): unknown {
-	if (Array.isArray(value)) return value.map(stableValue);
-	if (value && typeof value === "object") {
-		const obj = value as Record<string, unknown>;
-		return Object.keys(obj)
-			.sort()
-			.reduce<Record<string, unknown>>((acc, key) => {
-				acc[key] = stableValue(obj[key]);
-				return acc;
-			}, {});
-	}
-	return value;
-}
-
-// ---------------------------------------------------------------------------
-// Cache provider
-// ---------------------------------------------------------------------------
-
-const cacheProvider: dynamic.ResourceProvider = {
-	async check(
-		_olds: CacheProviderState,
-		news: CacheProviderInputs,
-	): Promise<dynamic.CheckResult> {
-		const failures: dynamic.CheckFailure[] = [];
-		for (const property of [
-			"namespace",
-			"hs256SecretBase64",
-			"deploymentName",
-			"cacheName",
-		] as const) {
-			if (!news[property]) {
-				failures.push({ property, reason: `${property} is required` });
-			}
-		}
-		// "" means "unset" (server default / Global); any provided retention must be
-		// a positive number of seconds. Catch it at preview rather than on apply.
-		if (
-			news.retentionPeriodSeconds !== "" &&
-			(typeof news.retentionPeriodSeconds !== "number" ||
-				!Number.isFinite(news.retentionPeriodSeconds) ||
-				news.retentionPeriodSeconds <= 0)
-		) {
-			failures.push({
-				property: "retentionPeriodSeconds",
-				reason: "retentionPeriodSeconds must be a positive number of seconds",
-			});
-		}
-		return { inputs: news, failures };
-	},
-
-	async diff(
-		_id: string,
-		olds: CacheProviderState,
-		news: CacheProviderInputs,
-	): Promise<dynamic.DiffResult> {
-		const replaces: string[] = [];
-		// Renaming a cache or changing its store dir is a different cache.
-		if (olds.cacheName !== news.cacheName) replaces.push("cacheName");
-		if (olds.storeDir !== news.storeDir) replaces.push("storeDir");
-		const changed =
-			replaces.length > 0 ||
-			adminTargetChanged(olds, news) ||
-			olds.isPublic !== news.isPublic ||
-			olds.priority !== news.priority ||
-			stableJson(olds.upstreamCacheKeyNames) !==
-				stableJson(news.upstreamCacheKeyNames) ||
-			(olds.retentionPeriodSeconds ?? "") !==
-				(news.retentionPeriodSeconds ?? "");
-		return { changes: changed, replaces, deleteBeforeReplace: false };
-	},
-
-	async create(inputs: CacheProviderInputs): Promise<dynamic.CreateResult> {
-		const token = await mintAdminToken(
-			inputs,
-			inputs.cacheName,
-			ADMIN_CREATE_FLAGS,
-		);
-		return withCacheBaseUrl(inputs, async (baseUrl) => {
-			const path = `/_api/v1/cache-config/${inputs.cacheName}`;
-			const res = await atticFetch(
-				baseUrl,
-				token,
-				inputs,
-				path,
-				"POST",
-				buildCreateBody(inputs),
-			);
-			if (res.ok) {
-				// Created fresh. CreateCacheRequest has no retention field, so apply a
-				// requested retention with a follow-up PATCH.
-				if (inputs.retentionPeriodSeconds !== "") {
-					ensureOk(
-						await atticFetch(baseUrl, token, inputs, path, "PATCH", {
-							retention_period: retentionPeriod(inputs.retentionPeriodSeconds),
-						}),
-						"PATCH",
-						path,
-					);
-				}
-			} else if (
-				res.status === 400 &&
-				res.text.includes("CacheAlreadyExists")
-			) {
-				// Idempotent adoption: reconcile the existing cache's config in place.
-				// POST is create-only, so going through PATCH preserves the keypair —
-				// and thus every client's trusted-public-keys.
-				//
-				// First verify the immutable store_dir matches: buildPatchBody omits
-				// store_dir (a change is modeled as a replacement, not an update), so
-				// adopting a same-named cache that points at a different store dir would
-				// silently record the desired storeDir in state while the remote keeps
-				// its own. Fail loudly instead of misrepresenting drift.
-				//
-				// Fail *closed*: if the GET doesn't report a string store_dir we cannot
-				// confirm the immutable field, so refuse rather than adopt an unverified
-				// cache and record an assumed storeDir in state.
-				const existing = ensureOk(
-					await atticFetch(baseUrl, token, inputs, path, "GET"),
-					"GET",
-					path,
-				);
-				if (
-					typeof existing?.store_dir !== "string" ||
-					existing.store_dir !== inputs.storeDir
-				) {
-					throw new Error(
-						`Attic cache "${inputs.cacheName}" already exists but its store_dir (${JSON.stringify(existing?.store_dir)}) is absent or differs from the requested "${inputs.storeDir}". store_dir is immutable — refusing to adopt; align storeDir or choose a different cacheName.`,
-					);
-				}
-				ensureOk(
-					await atticFetch(
-						baseUrl,
-						token,
-						inputs,
-						path,
-						"PATCH",
-						buildPatchBody(inputs),
-					),
-					"PATCH",
-					path,
-				);
-			} else {
-				ensureOk(res, "POST", path);
-			}
-			const publicKey = await readPublicKey(
-				baseUrl,
-				token,
-				inputs,
-				inputs.cacheName,
-			);
-			return { id: inputs.cacheName, outs: { ...inputs, publicKey } };
-		});
-	},
-
-	async update(
-		_id: string,
-		_olds: CacheProviderState,
-		news: CacheProviderInputs,
-	): Promise<dynamic.UpdateResult> {
-		const token = await mintAdminToken(
-			news,
-			news.cacheName,
-			ADMIN_UPDATE_FLAGS,
-		);
-		return withCacheBaseUrl(news, async (baseUrl) => {
-			const path = `/_api/v1/cache-config/${news.cacheName}`;
-			ensureOk(
-				await atticFetch(
-					baseUrl,
-					token,
-					news,
-					path,
-					"PATCH",
-					buildPatchBody(news),
-				),
-				"PATCH",
-				path,
-			);
-			const publicKey = await readPublicKey(
-				baseUrl,
-				token,
-				news,
-				news.cacheName,
-			);
-			return { outs: { ...news, publicKey } };
-		});
-	},
-
-	async delete(id: string, props: CacheProviderState): Promise<void> {
-		const cacheName = id || props.cacheName;
-		if (!cacheName) return;
-		const token = await mintAdminToken(props, cacheName, ADMIN_DELETE_FLAGS);
-		await withCacheBaseUrl(props, async (baseUrl) => {
-			const path = `/_api/v1/cache-config/${cacheName}`;
-			const res = await atticFetch(baseUrl, token, props, path, "DELETE");
-			// Idempotent delete: a cache already removed out of band (404) means the
-			// desired end state is reached, so don't fail `pulumi destroy`/replacement.
-			if (res.status === 404) return;
-			ensureOk(res, "DELETE", path);
-		});
-	},
-};
-
-// ---------------------------------------------------------------------------
-// Token provider
-// ---------------------------------------------------------------------------
-
-const tokenProvider: dynamic.ResourceProvider = {
-	async check(
-		_olds: TokenProviderState,
-		news: TokenProviderInputs,
-	): Promise<dynamic.CheckResult> {
-		const failures: dynamic.CheckFailure[] = [];
-		if (!news.hs256SecretBase64) {
-			failures.push({
-				property: "hs256SecretBase64",
-				reason: "hs256SecretBase64 is required",
-			});
-		}
-		if (!news.sub) {
-			failures.push({ property: "sub", reason: "sub is required" });
-		}
-		if (
-			typeof news.validitySeconds !== "number" ||
-			!Number.isFinite(news.validitySeconds) ||
-			news.validitySeconds <= 0
-		) {
-			// Must be finite: a non-finite validity makes `exp = now + validity`
-			// non-finite, which JSON serializes to `null` — a token that looks minted
-			// but is invalid at runtime.
-			failures.push({
-				property: "validitySeconds",
-				reason: "validity must be a finite positive duration",
-			});
-		}
-		return { inputs: news, failures };
-	},
-
-	async diff(
-		_id: string,
-		olds: TokenProviderState,
-		news: TokenProviderInputs,
-	): Promise<dynamic.DiffResult> {
-		// A signed JWT is immutable: any change to a claim input mints a new token,
-		// so every meaningful change is a replacement. The baked exp/nbf/token are
-		// state (not inputs), so a no-op `up` does not churn the token.
-		const replaces: string[] = [];
-		if (olds.hs256SecretBase64 !== news.hs256SecretBase64) {
-			replaces.push("hs256SecretBase64");
-		}
-		if (olds.sub !== news.sub) replaces.push("sub");
-		if (olds.validitySeconds !== news.validitySeconds) {
-			replaces.push("validitySeconds");
-		}
-		if (stableJson(olds.caches ?? {}) !== stableJson(news.caches ?? {})) {
-			replaces.push("caches");
-		}
-		return {
-			changes: replaces.length > 0,
-			replaces,
-			deleteBeforeReplace: false,
-		};
-	},
-
-	async create(inputs: TokenProviderInputs): Promise<dynamic.CreateResult> {
-		const { randomUUID } = await import("node:crypto");
-		const now = Math.floor(Date.now() / 1000);
-		const expiresAt = now + inputs.validitySeconds;
-		const token = await mintAtticToken({
-			secretBase64: inputs.hs256SecretBase64,
-			sub: inputs.sub,
-			issuedAtSeconds: now,
-			expiresAtSeconds: expiresAt,
-			caches: inputs.caches,
-		});
-		// The resource id is a random opaque handle — NEVER the token, which is a
-		// bearer credential and would otherwise sit in plaintext in Pulumi state.
-		return {
-			id: randomUUID(),
-			outs: { ...inputs, token, expiresAt, notBefore: now },
-		};
-	},
-
-	async update(
-		_id: string,
-		_olds: TokenProviderState,
-		news: TokenProviderInputs,
-	): Promise<dynamic.UpdateResult> {
-		// Reached only if diff() ever reports a non-replace change (it does not
-		// today). Re-mint defensively so outputs stay consistent with inputs.
-		const now = Math.floor(Date.now() / 1000);
-		const expiresAt = now + news.validitySeconds;
-		const token = await mintAtticToken({
-			secretBase64: news.hs256SecretBase64,
-			sub: news.sub,
-			issuedAtSeconds: now,
-			expiresAtSeconds: expiresAt,
-			caches: news.caches,
-		});
-		return { outs: { ...news, token, expiresAt, notBefore: now } };
-	},
-
-	async delete(): Promise<void> {
-		// No-op: Attic tokens are stateless JWTs with no server-side record to
-		// remove. A token is invalidated only by its `exp` lapsing or by rotating
-		// the shared HS256 secret (which invalidates every token). Dropping the
-		// resource stops Pulumi from re-issuing it; it cannot revoke a live token.
-	},
-};
-
-// ---------------------------------------------------------------------------
-// Public dynamic resources
-// ---------------------------------------------------------------------------
-
-/** Build the normalized, fully-resolved provider inputs for a cache. */
-function cacheProviderInputs(args: AtticCacheArgs) {
-	return {
-		namespace: args.namespace,
-		hs256SecretBase64: args.hs256SecretBase64,
-		deploymentName: pulumi.output(args.deploymentName ?? "attic"),
-		port: pulumi.output(args.port ?? 8080),
-		cacheName: args.cacheName,
-		isPublic: pulumi.output(args.isPublic ?? true),
-		priority: pulumi.output(args.priority ?? 0),
-		storeDir: pulumi.output(args.storeDir ?? "/nix/store"),
-		upstreamCacheKeyNames: pulumi.output(args.upstreamCacheKeyNames ?? []),
-		retentionPeriodSeconds: pulumi
-			.output(args.retentionPeriodSeconds)
-			.apply((value) => (value === undefined ? "" : value)),
-	};
-}
-
-class AtticCacheRecord extends dynamic.Resource {
-	public declare readonly publicKey: Output<string>;
-
-	constructor(
-		name: string,
-		args: ReturnType<typeof cacheProviderInputs>,
-		opts?: DynamicResourceOptions,
-	) {
-		super(cacheProvider, name, { publicKey: undefined, ...args }, opts);
-	}
-}
-
-/**
- * An Attic binary cache, managed as a first-class Pulumi resource.
- *
- * Replaces the `attic-cache-bootstrap` `local.Command`: `create` is find-or-create
- * (a pre-existing cache is adopted via PATCH, preserving its keypair), and config
- * changes (`isPublic`, `priority`, `upstreamCacheKeyNames`, retention) reconcile
- * in place on the next `pulumi up`. Renaming the cache or changing its store dir
- * triggers a replacement.
- *
- * Transport: the provider opens a short-lived port-forward to a ready pod of the
- * Attic deployment and calls `/_api/v1/cache-config/*` over `localhost`, minting
- * its own short-lived admin token from the HS256 secret — the same reachability
- * model as the old `kubectl exec`/`port-forward` script, with no tailnet dependency.
- */
-export class AtticCache extends pulumi.ComponentResource {
+export class AtticCache extends pulumi.CustomResource {
 	public declare readonly cacheName: pulumi.Output<string>;
 	public declare readonly publicKey: pulumi.Output<string>;
 
 	constructor(
 		name: string,
 		args: AtticCacheArgs,
-		opts?: pulumi.ComponentResourceOptions,
+		opts?: pulumi.CustomResourceOptions,
 	) {
-		super("sector7:attic:Cache", name, args, opts);
+		// Force hs256SecretBase64 to a secret so it's encrypted in state even
+		// when the caller passes a plain string. The plugin schema already
+		// marks it secret; this covers the input side at construction too.
+		const securedArgs = {
+			...args,
+			hs256SecretBase64: pulumi.secret(args.hs256SecretBase64),
+		};
 
-		const record = new AtticCacheRecord(
-			`${name}-cache`,
-			cacheProviderInputs(args),
-			{ parent: this, additionalSecretOutputs: ["hs256SecretBase64"] },
-		);
-
-		this.cacheName = pulumi.output(args.cacheName);
-		this.publicKey = record.publicKey;
-		this.registerOutputs({
-			cacheName: this.cacheName,
-			publicKey: this.publicKey,
-		});
-	}
-}
-
-/** Build the normalized, fully-resolved provider inputs for a token. */
-function tokenProviderInputs(args: AtticTokenArgs) {
-	return {
-		hs256SecretBase64: args.hs256SecretBase64,
-		sub: args.sub,
-		validitySeconds: pulumi.output(args.validity).apply(parseDurationSeconds),
-		caches: pulumi.output(args.caches).apply((value) => value ?? {}),
-	};
-}
-
-class AtticTokenRecord extends dynamic.Resource {
-	public declare readonly token: Output<string>;
-	public declare readonly expiresAt: Output<number>;
-	public declare readonly notBefore: Output<number>;
-
-	constructor(
-		name: string,
-		args: ReturnType<typeof tokenProviderInputs>,
-		opts?: DynamicResourceOptions,
-	) {
 		super(
-			tokenProvider,
+			"sector7:atticprovider:Cache",
 			name,
-			{ token: undefined, expiresAt: undefined, notBefore: undefined, ...args },
-			opts,
+			{ publicKey: undefined, ...securedArgs },
+			pulumi.mergeOptions(opts, {
+				aliases: [
+					{
+						type: "pulumi-nodejs:dynamic:Resource",
+						name: `${name}-cache`,
+						// The OLD component's ACTUAL live token — see the class
+						// doc above. Not this resource's own (deliberately
+						// different) type.
+						parent: pulumi.createUrn(name, "sector7:attic:Cache"),
+					},
+				],
+			}),
 		);
 	}
 }
 
 /**
- * An Attic access token, managed as a first-class Pulumi resource.
+ * An Attic access token, administered through the sector7 resource plugin.
  *
- * Replaces the `attic-ci-token` `local.Command`. The token is a stateless HS256
- * JWT minted in-process from the server's signing secret — no server contact and
- * no port-forward. `exp` is baked at create from `validity`; changing `sub`,
- * `validity`, `caches`, or the secret mints a new token (a replacement).
- *
- * Caveat: a stateless JWT cannot be individually revoked. `delete` is a no-op;
- * revocation is `exp` lapsing or rotating the shared secret (which invalidates
- * every token). Prefer short `validity` and least-privilege `caches` scopes.
+ * Backed by `provider/attic/token_resource.go`. Same retype shape and the
+ * same reason for the `atticprovider` token as `AtticCache` above.
  */
-export class AtticToken extends pulumi.ComponentResource {
+export class AtticToken extends pulumi.CustomResource {
 	public declare readonly token: pulumi.Output<string>;
 	public declare readonly expiresAt: pulumi.Output<number>;
 	public declare readonly notBefore: pulumi.Output<number>;
@@ -737,23 +80,36 @@ export class AtticToken extends pulumi.ComponentResource {
 	constructor(
 		name: string,
 		args: AtticTokenArgs,
-		opts?: pulumi.ComponentResourceOptions,
+		opts?: pulumi.CustomResourceOptions,
 	) {
-		super("sector7:attic:Token", name, args, opts);
+		const securedArgs = {
+			hs256SecretBase64: pulumi.secret(args.hs256SecretBase64),
+			sub: args.sub,
+			validitySeconds: pulumi.output(args.validity).apply(parseDurationSeconds),
+			caches: args.caches,
+		};
 
-		const record = new AtticTokenRecord(
-			`${name}-token`,
-			tokenProviderInputs(args),
-			{ parent: this, additionalSecretOutputs: ["token", "hs256SecretBase64"] },
+		super(
+			"sector7:atticprovider:Token",
+			name,
+			{
+				token: undefined,
+				expiresAt: undefined,
+				notBefore: undefined,
+				...securedArgs,
+			},
+			pulumi.mergeOptions(opts, {
+				aliases: [
+					{
+						type: "pulumi-nodejs:dynamic:Resource",
+						name: `${name}-token`,
+						// The OLD component's ACTUAL live token — see AtticCache's
+						// class doc above. Not this resource's own (deliberately
+						// different) type.
+						parent: pulumi.createUrn(name, "sector7:attic:Token"),
+					},
+				],
+			}),
 		);
-
-		this.token = pulumi.secret(record.token);
-		this.expiresAt = record.expiresAt;
-		this.notBefore = record.notBefore;
-		this.registerOutputs({
-			token: this.token,
-			expiresAt: this.expiresAt,
-			notBefore: this.notBefore,
-		});
 	}
 }

--- a/packages/sector7/tests/attic.test.ts
+++ b/packages/sector7/tests/attic.test.ts
@@ -1,179 +1,68 @@
-import * as crypto from "node:crypto";
-import { EventEmitter } from "node:events";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-// ---------------------------------------------------------------------------
-// Mocks (same capture pattern as litellm-admin.test.ts)
+// AtticCache / AtticToken's own CRUD/Diff logic (cache-config HTTP calls,
+// JWT minting) moved to provider/attic/cache.go and
+// provider/attic/token_resource.go when these resources retyped onto the
+// sector7 plugin (garden ADR 163) — see cache_test.go / token_resource_test.go
+// for that coverage. What's left here is the TypeScript wrapper's OWN
+// concerns: does construction reach the plugin with the right
+// token/alias/secret-wrapping.
 //
-// AtticCache / AtticToken are ComponentResources that each construct an inner
-// `dynamic.Resource`. We mock @pulumi/pulumi to (a) make the component
-// constructors inert and (b) capture the ResourceProvider passed to
-// dynamic.Resource's super(), then exercise the provider directly.
-//
-// The cache provider opens a port-forward and calls the cache-config API over
-// `node:http`; we stub @kubernetes/client-node and node:net so it yields a local
-// base URL without a real cluster, and mock `node:http` to capture the requests
-// (the provider uses node:http rather than fetch because Attic validates the Host
-// header and undici drops a caller-supplied Host override). The token provider
-// needs neither — it mints a JWT in-process via the real node:crypto.
-// ---------------------------------------------------------------------------
+// The alias here is more involved than a flat dynamic-provider cutover
+// (compare matrix/r2): the OLD shape was a ComponentResource wrapping an
+// inner dynamic.Resource CHILD, so the alias must target the CHILD's exact
+// nested URN (type, name suffix, AND parent) — see admin.ts's class docs for
+// why the token itself also had to change to avoid a coincidental identity
+// collision with the old component.
 
-type Provider = {
-	check: (
-		olds: Record<string, unknown>,
-		news: Record<string, unknown>,
-	) => Promise<{
-		inputs: Record<string, unknown>;
-		failures: Array<{ property: string; reason: string }>;
-	}>;
-	diff: (
-		id: string,
-		olds: Record<string, unknown>,
-		news: Record<string, unknown>,
-	) => Promise<{ changes: boolean; replaces?: string[] }>;
-	create: (inputs: Record<string, unknown>) => Promise<{
-		id: string;
-		outs: Record<string, unknown>;
-	}>;
-	update: (
-		id: string,
-		olds: Record<string, unknown>,
-		news: Record<string, unknown>,
-	) => Promise<{ outs: Record<string, unknown> }>;
-	delete: (id: string, props: Record<string, unknown>) => Promise<void>;
+type CustomResourceCall = {
+	type: string;
+	name: string;
+	args: Record<string, unknown>;
+	opts: Record<string, unknown> | undefined;
 };
 
-const capturedProviders: Provider[] = [];
+const customResourceCalls: CustomResourceCall[] = [];
 
 vi.mock("@pulumi/pulumi", () => {
-	// biome-ignore lint/suspicious/noExplicitAny: minimal Output stand-in for tests
-	const output = (value: any): any => ({
-		// biome-ignore lint/suspicious/noExplicitAny: identity apply for tests
-		apply: (fn: (v: any) => any) => output(fn(value)),
+	const output = <T>(value: T) => ({
+		apply: <U>(fn: (value: T) => U) => fn(value),
 	});
+	// Spy, not a plain identity function: an identity wrapper can't
+	// distinguish "value passed through secret()" from "value passed through
+	// untouched", so a test asserting only on the resolved value would pass
+	// whether or not the constructor actually calls pulumi.secret(). Asserting
+	// on the spy's call arguments is what makes that distinction observable.
+	const secret = vi.fn(<T>(value: T) => value);
+	// Mirrors the real SDK's format (createUrn.ts): a stable, inspectable
+	// stand-in good enough to assert the alias's parent targets the OLD
+	// component's URN and not this resource's own (different) type.
+	const createUrn = vi.fn(
+		(name: string, type: string) => `urn:mock:${type}::${name}`,
+	);
+
 	return {
-		ComponentResource: class {
-			registerOutputs() {}
-		},
-		dynamic: {
-			Resource: class {
-				constructor(provider: Provider) {
-					capturedProviders.push(provider);
-				}
-			},
-		},
 		output,
-		// biome-ignore lint/suspicious/noExplicitAny: identity for tests
-		secret: (v: any) => v,
+		secret,
+		createUrn,
+		mergeOptions: (
+			left: Record<string, unknown> | undefined,
+			right: Record<string, unknown>,
+		) => ({ ...left, ...right }),
+		CustomResource: class {
+			constructor(
+				type: string,
+				name: string,
+				args: Record<string, unknown>,
+				opts?: Record<string, unknown>,
+			) {
+				customResourceCalls.push({ type, name, args, opts });
+			}
+		},
 	};
 });
 
-const apiStubs = {
-	readNamespacedDeployment: vi.fn().mockResolvedValue({
-		spec: { selector: { matchLabels: { app: "attic" } } },
-	}),
-	listNamespacedPod: vi.fn().mockResolvedValue({
-		items: [
-			{
-				metadata: { name: "attic-pod-1" },
-				status: {
-					phase: "Running",
-					conditions: [{ type: "Ready", status: "True" }],
-				},
-			},
-		],
-	}),
-};
-
-vi.mock("@kubernetes/client-node", () => ({
-	KubeConfig: class {
-		loadFromDefault() {}
-		makeApiClient(_ctor: { name: string }) {
-			return apiStubs;
-		}
-	},
-	AppsV1Api: class AppsV1Api {},
-	CoreV1Api: class CoreV1Api {},
-	PortForward: class {
-		portForward() {
-			return Promise.resolve();
-		}
-	},
-}));
-
-vi.mock("node:net", () => ({
-	createServer: () => {
-		const server = {
-			// biome-ignore lint/suspicious/noExplicitAny: minimal EventEmitter-ish stub
-			once: (_event: string, _cb: any) => server,
-			listen: (_port: number, _host: string, cb: () => void) => {
-				cb();
-				return server;
-			},
-			address: () => ({ port: 41000 }),
-			close: (cb?: () => void) => {
-				cb?.();
-				return server;
-			},
-		};
-		return server;
-	},
-}));
-
-// `node:http` mock. `atticFetch` reaches the cache-config API through
-// `await import("node:http")`; this intercepts it and routes every request to the
-// responder installed by `installFetch`, recording each call (including the Host
-// header the provider sets, so a test can assert it matches Attic's allowed-hosts).
-type HttpCall = {
-	path: string;
-	method: string;
-	body: unknown;
-	host: string | undefined;
-};
-const httpState: {
-	responder: (
-		path: string,
-		method: string,
-		body: unknown,
-	) => { status?: number; body?: unknown } | undefined;
-	calls: HttpCall[];
-} = { responder: () => ({}), calls: [] };
-
-// biome-ignore lint/suspicious/noExplicitAny: minimal http.request stand-in
-function mockHttpRequest(url: any, options: any, cb: any): any {
-	const req: any = new EventEmitter();
-	let bodyStr = "";
-	req.write = (chunk: string) => {
-		bodyStr += chunk;
-		return true;
-	};
-	req.end = () => {
-		const path = String(url).replace(/^http:\/\/127\.0\.0\.1:\d+/, "");
-		const method = options?.method ?? "GET";
-		const body = bodyStr ? JSON.parse(bodyStr) : undefined;
-		const host = options?.headers?.Host;
-		httpState.calls.push({ path, method, body, host });
-		const r = httpState.responder(path, method, body) ?? {};
-		const status = r.status ?? 200;
-		const payload = r.body ?? {};
-		const text =
-			typeof payload === "string" ? payload : JSON.stringify(payload);
-		const res: any = new EventEmitter();
-		res.statusCode = status;
-		queueMicrotask(() => {
-			cb(res);
-			res.emit("data", Buffer.from(text, "utf8"));
-			res.emit("end");
-		});
-	};
-	return req;
-}
-
-vi.mock("node:http", () => ({
-	default: { request: mockHttpRequest },
-	request: mockHttpRequest,
-}));
-
+import * as pulumi from "@pulumi/pulumi";
 import { AtticCache, AtticToken } from "../attic/admin.ts";
 import {
 	ATTIC_CLAIM_NAMESPACE,
@@ -183,395 +72,129 @@ import {
 
 const SECRET_B64 = Buffer.from("attic-test-signing-secret").toString("base64");
 
-const cacheTarget = {
+const cacheArgs = {
 	namespace: "attic-prod",
 	hs256SecretBase64: SECRET_B64,
 	deploymentName: "attic",
 	port: 8080,
+	cacheName: "mycache",
+	isPublic: true,
 };
 
-function cacheInputs(overrides: Record<string, unknown> = {}) {
-	return {
-		...cacheTarget,
-		cacheName: "mycache",
-		isPublic: true,
-		priority: 0,
-		storeDir: "/nix/store",
-		upstreamCacheKeyNames: [] as string[],
-		retentionPeriodSeconds: "" as number | "",
-		...overrides,
-	};
-}
+const tokenArgs = {
+	hs256SecretBase64: SECRET_B64,
+	sub: "github-actions-ci",
+	validity: "1y",
+	caches: { mycache: { pull: true, push: true } },
+};
 
-// Install a responder for the mocked `node:http` transport, returning canned
-// cache-config responses; responder may set a status (defaults 200) and a body
-// (object → JSON, string → raw text). Returns the recorded call log.
-function installFetch(
-	responder: (
-		path: string,
-		method: string,
-		body: unknown,
-	) => { status?: number; body?: unknown } | undefined,
-) {
-	httpState.responder = responder;
-	httpState.calls = [];
-	return httpState.calls;
-}
-
-let cacheProvider: Provider;
-let tokenProvider: Provider;
-
-beforeEach(() => {
-	capturedProviders.length = 0;
-	new AtticCache("c", {
-		...cacheTarget,
-		cacheName: "mycache",
-	});
-	new AtticToken("t", {
-		hs256SecretBase64: SECRET_B64,
-		sub: "github-actions-ci",
-		validity: "1y",
-		caches: { mycache: { pull: true, push: true } },
-	});
-	[cacheProvider, tokenProvider] = capturedProviders;
-	vi.unstubAllGlobals();
-});
-
-describe("AtticCache provider — diff", () => {
-	it("treats a config change as an in-place update (no replacement)", async () => {
-		const olds = { ...cacheInputs(), publicKey: "pk:1" };
-		const result = await cacheProvider.diff("mycache", olds, {
-			...cacheInputs(),
-			priority: 41,
-		});
-		expect(result.changes).toBe(true);
-		expect(result.replaces ?? []).toEqual([]);
+describe("AtticCache construction", () => {
+	beforeEach(() => {
+		customResourceCalls.length = 0;
+		vi.mocked(pulumi.createUrn).mockClear();
 	});
 
-	it("ignores upstream-key ordering", async () => {
-		const olds = {
-			...cacheInputs({ upstreamCacheKeyNames: ["a", "b", "c"] }),
-			publicKey: "pk:1",
-		};
-		const result = await cacheProvider.diff("mycache", olds, {
-			...cacheInputs({ upstreamCacheKeyNames: ["c", "a", "b"] }),
-		});
-		expect(result.changes).toBe(false);
+	it("registers under sector7:atticprovider:Cache, not sector7:attic:Cache", () => {
+		new AtticCache("attic-cache-mycache", cacheArgs);
+
+		expect(customResourceCalls).toHaveLength(1);
+		// Deliberately NOT "sector7:attic:Cache" — that token is what the OLD
+		// ComponentResource already used live; reusing it here would collide.
+		// See admin.ts's class doc for the full reasoning.
+		expect(customResourceCalls[0].type).toBe("sector7:atticprovider:Cache");
 	});
 
-	it("replaces when the cache name changes", async () => {
-		const olds = { ...cacheInputs(), publicKey: "pk:1" };
-		const result = await cacheProvider.diff("mycache", olds, {
-			...cacheInputs(),
-			cacheName: "othercache",
-		});
-		expect(result.replaces).toEqual(["cacheName"]);
+	it("aliases to the OLD nested child's exact URN: type, name suffix, and parent", () => {
+		new AtticCache("attic-cache-mycache", cacheArgs);
+
+		const call = customResourceCalls[0];
+		expect(call.opts?.aliases).toEqual([
+			{
+				type: "pulumi-nodejs:dynamic:Resource",
+				name: "attic-cache-mycache-cache",
+				parent: "urn:mock:sector7:attic:Cache::attic-cache-mycache",
+			},
+		]);
+		// The parent URN is built from the OLD component's token
+		// ("sector7:attic:Cache"), never this resource's own
+		// ("sector7:atticprovider:Cache") — a mixup here would target an alias
+		// no old state actually has.
+		expect(pulumi.createUrn).toHaveBeenCalledWith(
+			"attic-cache-mycache",
+			"sector7:attic:Cache",
+		);
 	});
 
-	it("replaces when the store dir changes", async () => {
-		const olds = { ...cacheInputs(), publicKey: "pk:1" };
-		const result = await cacheProvider.diff("mycache", olds, {
-			...cacheInputs(),
-			storeDir: "/alt/store",
-		});
-		expect(result.replaces).toEqual(["storeDir"]);
+	it("marks hs256SecretBase64 secret on the input side", () => {
+		vi.mocked(pulumi.secret).mockClear();
+
+		new AtticCache("attic-cache-mycache", cacheArgs);
+
+		expect(pulumi.secret).toHaveBeenCalledWith(SECRET_B64);
 	});
 
-	it("treats an admin-target change as an in-place update", async () => {
-		const olds = { ...cacheInputs(), publicKey: "pk:1" };
-		const result = await cacheProvider.diff("mycache", olds, {
-			...cacheInputs(),
-			hs256SecretBase64: Buffer.from("rotated").toString("base64"),
-			deploymentName: "attic-canary",
-		});
-		expect(result.changes).toBe(true);
-		expect(result.replaces ?? []).toEqual([]);
+	it("passes cacheName and isPublic straight through as inputs", () => {
+		new AtticCache("attic-cache-mycache", cacheArgs);
+
+		const call = customResourceCalls[0];
+		expect(call.args.cacheName).toBe("mycache");
+		expect(call.args.isPublic).toBe(true);
 	});
 });
 
-describe("AtticCache provider — lifecycle", () => {
-	it("creates a fresh cache and reads back its public key", async () => {
-		const calls = installFetch((_path, method) => {
-			if (method === "POST")
-				return { status: 200, body: { public_key: "pk:new" } };
-			if (method === "GET") return { body: { public_key: "pk:new" } };
-			return {};
-		});
-		const result = await cacheProvider.create(cacheInputs());
-		expect(result.id).toBe("mycache");
-		expect(result.outs.publicKey).toBe("pk:new");
-		const methods = calls.map((c) => c.method);
-		expect(methods).toEqual(["POST", "GET"]);
-		expect(calls[0].path).toBe("/_api/v1/cache-config/mycache");
-		expect(calls[0].body).toMatchObject({
-			keypair: "Generate",
-			is_public: true,
-		});
+describe("AtticToken construction", () => {
+	beforeEach(() => {
+		customResourceCalls.length = 0;
+		vi.mocked(pulumi.createUrn).mockClear();
 	});
 
-	it("sends the in-cluster Service FQDN as the Host header (allowed-hosts match)", async () => {
-		// Regression guard: the provider port-forwards to 127.0.0.1, but Attic
-		// validates Host against allowed-hosts. Every request must carry the
-		// <deployment>.<namespace>.svc.cluster.local Host so it is accepted — never
-		// the 127.0.0.1 the transport actually connects to.
-		const calls = installFetch((_path, method) => {
-			if (method === "POST")
-				return { status: 200, body: { public_key: "pk:new" } };
-			if (method === "GET") return { body: { public_key: "pk:new" } };
-			return {};
-		});
-		await cacheProvider.create(cacheInputs());
-		expect(calls.length).toBeGreaterThan(0);
-		for (const c of calls) {
-			expect(c.host).toBe("attic.attic-prod.svc.cluster.local");
-		}
+	it("registers under sector7:atticprovider:Token, not sector7:attic:Token", () => {
+		new AtticToken("attic-ci-token-mycache", tokenArgs);
+
+		expect(customResourceCalls).toHaveLength(1);
+		expect(customResourceCalls[0].type).toBe("sector7:atticprovider:Token");
 	});
 
-	it("adopts an existing cache via PATCH on CacheAlreadyExists", async () => {
-		const calls = installFetch((_path, method) => {
-			if (method === "POST")
-				return { status: 400, body: "Error: CacheAlreadyExists" };
-			if (method === "PATCH") return { body: {} };
-			if (method === "GET")
-				return { body: { public_key: "pk:existing", store_dir: "/nix/store" } };
-			return {};
-		});
-		const result = await cacheProvider.create(cacheInputs());
-		expect(result.outs.publicKey).toBe("pk:existing");
-		const methods = calls.map((c) => c.method);
-		// Adoption GETs to verify the immutable store_dir, then reconciles via PATCH
-		// (never re-POST, which would regenerate the keypair), then re-reads the key.
-		expect(methods).toEqual(["POST", "GET", "PATCH", "GET"]);
-		const patch = calls.find((c) => c.method === "PATCH");
-		expect(patch?.body).toMatchObject({ is_public: true, priority: 0 });
-	});
+	it("aliases to the OLD nested child's exact URN: type, name suffix, and parent", () => {
+		new AtticToken("attic-ci-token-mycache", tokenArgs);
 
-	it("refuses to adopt a cache whose immutable store_dir differs", async () => {
-		installFetch((_path, method) => {
-			if (method === "POST")
-				return { status: 400, body: "Error: CacheAlreadyExists" };
-			if (method === "GET")
-				return { body: { public_key: "pk", store_dir: "/alt/store" } };
-			return {};
-		});
-		await expect(cacheProvider.create(cacheInputs())).rejects.toThrow(
-			/store_dir/,
+		const call = customResourceCalls[0];
+		expect(call.opts?.aliases).toEqual([
+			{
+				type: "pulumi-nodejs:dynamic:Resource",
+				name: "attic-ci-token-mycache-token",
+				parent: "urn:mock:sector7:attic:Token::attic-ci-token-mycache",
+			},
+		]);
+		expect(pulumi.createUrn).toHaveBeenCalledWith(
+			"attic-ci-token-mycache",
+			"sector7:attic:Token",
 		);
 	});
 
-	it("refuses to adopt when the existing store_dir is unverifiable", async () => {
-		installFetch((_path, method) => {
-			if (method === "POST")
-				return { status: 400, body: "Error: CacheAlreadyExists" };
-			if (method === "GET") return { body: { public_key: "pk" } }; // no store_dir
-			return {};
-		});
-		await expect(cacheProvider.create(cacheInputs())).rejects.toThrow(
-			/store_dir/,
-		);
+	it("marks hs256SecretBase64 secret on the input side", () => {
+		vi.mocked(pulumi.secret).mockClear();
+
+		new AtticToken("attic-ci-token-mycache", tokenArgs);
+
+		expect(pulumi.secret).toHaveBeenCalledWith(SECRET_B64);
 	});
 
-	it("PATCHes a fresh cache's retention when requested", async () => {
-		const calls = installFetch((_path, method) => {
-			if (method === "POST") return { status: 200, body: { public_key: "pk" } };
-			if (method === "PATCH") return { body: {} };
-			if (method === "GET") return { body: { public_key: "pk" } };
-			return {};
-		});
-		await cacheProvider.create(cacheInputs({ retentionPeriodSeconds: 86400 }));
-		const patch = calls.find((c) => c.method === "PATCH");
-		expect(patch?.body).toMatchObject({ retention_period: { Period: 86400 } });
+	it("parses the public validity string/number into validitySeconds for the plugin", () => {
+		new AtticToken("attic-ci-token-mycache", tokenArgs);
+		expect(customResourceCalls[0].args.validitySeconds).toBe(31536000); // "1y"
+
+		customResourceCalls.length = 0;
+		new AtticToken("attic-ci-token-mycache", { ...tokenArgs, validity: 3600 });
+		expect(customResourceCalls[0].args.validitySeconds).toBe(3600);
 	});
 
-	it("updates a cache via PATCH and re-reads the public key", async () => {
-		const calls = installFetch((_path, method) => {
-			if (method === "PATCH") return { body: {} };
-			if (method === "GET") return { body: { public_key: "pk:2" } };
-			return {};
-		});
-		const olds = { ...cacheInputs(), publicKey: "pk:1" };
-		const result = await cacheProvider.update("mycache", olds, {
-			...cacheInputs(),
-			priority: 10,
-		});
-		expect(result.outs.publicKey).toBe("pk:2");
-		const methods = calls.map((c) => c.method);
-		expect(methods).toEqual(["PATCH", "GET"]);
-		expect(calls[0].body).toMatchObject({ priority: 10 });
-	});
+	it("passes sub and caches straight through as inputs", () => {
+		new AtticToken("attic-ci-token-mycache", tokenArgs);
 
-	it("deletes a cache via DELETE", async () => {
-		const calls = installFetch(() => ({ body: {} }));
-		await cacheProvider.delete("mycache", {
-			...cacheInputs(),
-			publicKey: "pk:1",
-		});
-		expect(calls).toHaveLength(1);
-		expect(calls[0].method).toBe("DELETE");
-		expect(calls[0].path).toBe("/_api/v1/cache-config/mycache");
-	});
-
-	it("treats a 404 on delete as success (idempotent under drift)", async () => {
-		const calls = installFetch(() => ({ status: 404, body: "NoSuchCache" }));
-		await expect(
-			cacheProvider.delete("mycache", { ...cacheInputs(), publicKey: "pk:1" }),
-		).resolves.toBeUndefined();
-		expect(calls[0].method).toBe("DELETE");
-	});
-
-	it("fails fast when the cache config has no public_key", async () => {
-		installFetch((_path, method) => {
-			if (method === "POST") return { status: 200, body: {} };
-			if (method === "GET") return { body: {} }; // missing public_key
-			return {};
-		});
-		await expect(cacheProvider.create(cacheInputs())).rejects.toThrow(
-			/public_key/,
-		);
-	});
-});
-
-describe("AtticCache provider — check", () => {
-	it("rejects a non-positive retention period", async () => {
-		const res = await cacheProvider.check(
-			{},
-			{ ...cacheInputs(), retentionPeriodSeconds: 0 },
-		);
-		expect(res.failures.map((f) => f.property)).toContain(
-			"retentionPeriodSeconds",
-		);
-	});
-
-	it("accepts an unset or positive retention period", async () => {
-		const unset = await cacheProvider.check({}, cacheInputs());
-		expect(unset.failures).toEqual([]);
-		const positive = await cacheProvider.check(
-			{},
-			{ ...cacheInputs(), retentionPeriodSeconds: 86400 },
-		);
-		expect(positive.failures).toEqual([]);
-	});
-
-	it("flags missing required fields", async () => {
-		const res = await cacheProvider.check(
-			{},
-			{ ...cacheInputs(), namespace: "", cacheName: "" },
-		);
-		const props = res.failures.map((f) => f.property);
-		expect(props).toContain("namespace");
-		expect(props).toContain("cacheName");
-	});
-});
-
-describe("AtticToken provider", () => {
-	const tokenInputs = {
-		hs256SecretBase64: SECRET_B64,
-		sub: "github-actions-ci",
-		validitySeconds: 3600,
-		caches: { mycache: { pull: true, push: true } },
-	};
-
-	function decodeSegment(seg: string): Record<string, unknown> {
-		return JSON.parse(Buffer.from(seg, "base64url").toString("utf8"));
-	}
-
-	it("mints a verifiable JWT with the Attic claim shape, not leaking it into the id", async () => {
-		const result = await tokenProvider.create(tokenInputs);
-		const token = result.outs.token as string;
-		const [headerSeg, payloadSeg, signatureSeg] = token.split(".");
-
-		// id is an opaque uuid, never the token itself.
-		expect(result.id).not.toContain(token);
-		expect(result.id).toMatch(/^[0-9a-f-]{36}$/);
-
-		// Signature verifies against the base64-decoded secret.
-		const expected = crypto
-			.createHmac("sha256", Buffer.from(SECRET_B64, "base64"))
-			.update(`${headerSeg}.${payloadSeg}`)
-			.digest("base64url");
-		expect(signatureSeg).toBe(expected);
-
-		expect(decodeSegment(headerSeg)).toMatchObject({
-			alg: "HS256",
-			typ: "JWT",
-		});
-		const payload = decodeSegment(payloadSeg);
-		expect(payload.sub).toBe("github-actions-ci");
-		expect(payload.exp).toBe((payload.nbf as number) + 3600);
-		expect(result.outs.expiresAt).toBe(
-			(result.outs.notBefore as number) + 3600,
-		);
-		// Permission short-keys under the Attic namespace claim. Values MUST be the
-		// integer 1, not boolean true — Attic deserializes them as integers and 401s
-		// on a JSON boolean (matches `atticadm make-token --dump-claims`).
-		expect(payload[ATTIC_CLAIM_NAMESPACE]).toEqual({
-			caches: { mycache: { r: 1, w: 1 } },
-		});
-	});
-
-	it("emits granted permission flags as the integer 1, never booleans", async () => {
-		const result = await tokenProvider.create({
-			...tokenInputs,
-			caches: { "team-*": { pull: true, createCache: true } },
-		});
-		const payload = decodeSegment((result.outs.token as string).split(".")[1]);
-		const grants = (
-			payload[ATTIC_CLAIM_NAMESPACE] as {
-				caches: Record<string, Record<string, unknown>>;
-			}
-		).caches["team-*"];
-		// Only granted flags present, each strictly the integer 1 (not `true`).
-		expect(grants).toEqual({ r: 1, cc: 1 });
-		for (const v of Object.values(grants)) {
-			expect(v).toBe(1);
-			expect(typeof v).toBe("number");
-		}
-	});
-
-	it("replaces on any claim-affecting input change", async () => {
-		const olds = {
-			...tokenInputs,
-			token: "old",
-			expiresAt: 1,
-			notBefore: 0,
-		};
-		expect((await tokenProvider.diff("id", olds, tokenInputs)).changes).toBe(
-			false,
-		);
-		expect(
-			(await tokenProvider.diff("id", olds, { ...tokenInputs, sub: "other" }))
-				.replaces,
-		).toEqual(["sub"]);
-		expect(
-			(
-				await tokenProvider.diff("id", olds, {
-					...tokenInputs,
-					validitySeconds: 7200,
-				})
-			).replaces,
-		).toEqual(["validitySeconds"]);
-		expect(
-			(
-				await tokenProvider.diff("id", olds, {
-					...tokenInputs,
-					caches: { mycache: { pull: true } },
-				})
-			).replaces,
-		).toEqual(["caches"]);
-	});
-
-	it("delete is a no-op (stateless JWT cannot be revoked)", async () => {
-		await expect(
-			tokenProvider.delete("id", { ...tokenInputs, token: "x" }),
-		).resolves.toBeUndefined();
-	});
-
-	it("rejects a non-finite validity in check (would serialize exp as null)", async () => {
-		const res = await tokenProvider.check(
-			{},
-			{ ...tokenInputs, validitySeconds: Number.POSITIVE_INFINITY },
-		);
-		expect(res.failures.map((f) => f.property)).toContain("validitySeconds");
+		const call = customResourceCalls[0];
+		expect(call.args.sub).toBe("github-actions-ci");
+		expect(call.args.caches).toEqual({ mycache: { pull: true, push: true } });
 	});
 });
 
@@ -586,6 +209,30 @@ describe("mintAtticToken", () => {
 				caches: {},
 			}),
 		).rejects.toThrow(/hs256 secret/);
+	});
+
+	it("mints a verifiable JWT with the Attic claim shape", async () => {
+		const token = await mintAtticToken({
+			secretBase64: SECRET_B64,
+			sub: "github-actions-ci",
+			issuedAtSeconds: 1000,
+			expiresAtSeconds: 4600,
+			caches: { mycache: { pull: true, push: true } },
+		});
+		const [headerSeg, payloadSeg] = token.split(".");
+		const payload = JSON.parse(
+			Buffer.from(payloadSeg, "base64url").toString("utf8"),
+		);
+		expect(
+			JSON.parse(Buffer.from(headerSeg, "base64url").toString("utf8")),
+		).toMatchObject({
+			alg: "HS256",
+			typ: "JWT",
+		});
+		expect(payload.sub).toBe("github-actions-ci");
+		expect(payload[ATTIC_CLAIM_NAMESPACE]).toEqual({
+			caches: { mycache: { r: 1, w: 1 } },
+		});
 	});
 });
 

--- a/provider/attic/cache.go
+++ b/provider/attic/cache.go
@@ -37,6 +37,26 @@ type Cache struct {
 	Transport kube.Transport
 }
 
+// Annotate overrides Cache's derived token. Left at the package-derived
+// default it would be "sector7:attic:Cache" — which is exactly the type
+// token the OLD TypeScript AtticCache ComponentResource
+// (packages/sector7/attic/admin.ts) already used, before this plugin
+// existed. The retyped resource's own identity would then coincidentally
+// collide with that now-defunct component's URN, and empirically (verified
+// against a real nested old state) the engine treats a coincidental direct
+// identity match as authoritative and never falls back to consulting the
+// declared TypeScript-side alias at all — silently deleting the real child
+// resource (which holds the actual state) and replacing it from the
+// component's near-empty bookkeeping state instead of adopting it. Using a
+// distinct module name here sidesteps the collision entirely: nothing in
+// old state matches this token directly, so the child is adopted purely via
+// its declared alias, and the old component's stateless bookkeeping entry
+// is dropped as harmless cleanup (custom:false, no id — no provider Delete
+// RPC is ever issued for it).
+func (Cache) Annotate(a infer.Annotator) {
+	a.SetToken("atticprovider", "Cache")
+}
+
 type CacheArgs struct {
 	// Kubeconfig is YAML; empty means the ambient default config.
 	//

--- a/provider/attic/migrations.go
+++ b/provider/attic/migrations.go
@@ -1,0 +1,89 @@
+package attic
+
+import (
+	"context"
+
+	"github.com/pulumi/pulumi-go-provider/infer"
+)
+
+// State migrations off the dynamic provider.
+//
+// Cache and Token replace garden-local TypeScript dynamic providers
+// (packages/sector7/attic/admin.ts's AtticCacheRecord/AtticTokenRecord,
+// wrapped by the AtticCache/AtticToken ComponentResources). Live state
+// written by either one carries `__provider`, the serialized JavaScript
+// closure this plugin exists to stop storing. infer treats an unrecognized
+// property as a decode FAILURE rather than something quietly ignored:
+//
+//	Unrecognized field '__provider' on 'attic.CacheState'
+//	Unrecognized field '__provider' on 'attic.TokenState'
+//
+// so without a migration the alias retype does not diff to nothing; it fails
+// outright at the first preview. Same shape and same mechanism as d1,
+// onepassword and matrix; see provider/d1/migrations.go for the most
+// heavily-commented version of this pattern.
+//
+// This file only handles the STATE SHAPE (dropping __provider from the
+// decoded properties). It says nothing about the split
+// ComponentResource/dynamic.Resource URN structure the old TypeScript used —
+// that is a TypeScript-side alias concern (packages/sector7/attic/admin.ts),
+// entirely orthogonal to what gets migrated here.
+//
+// One shape suffices for each resource. Neither CacheArgs nor TokenArgs has a
+// sentinel-encoded optional the way litellm's maxBudget did — every property
+// is a plain string, bool, int, []string or map, so an empty/nil value is a
+// valid value of its own type and decodes fine whichever path it takes.
+// __provider is the only obstacle. Kubeconfig (added to CacheArgs in
+// sector7#359, after the dynamic provider existed) is `,optional`, so its
+// absence in legacy state is not an obstacle either.
+//
+// Both migrations are additive-safe: state that never passed through a
+// dynamic provider has no __provider, fails the migrator's decode ("doesn't
+// fit into the migrator", per infer's own docs), and falls through to the
+// normal path unchanged. Verified against the real gRPC path in
+// migrations_test.go using shapes modeled on the TypeScript outputs.
+
+type cacheStateV0 struct {
+	CacheState
+	// Provider is the serialized dynamic-provider closure. Declared only so it
+	// can be dropped — nothing reads it.
+	//
+	// Deliberately NOT optional, and that tag is load-bearing. infer tries this
+	// migrator before the normal decode, so `optional` would make the shape
+	// match plugin-native state too and route every future read through the
+	// migration rather than only legacy state. Required is what makes native
+	// state miss this shape and fall through. Guarded by
+	// TestProviderTagIsRequiredSoTheMigrationOnlyMatchesLegacyState.
+	Provider string `pulumi:"__provider"`
+}
+
+// StateMigrations satisfies infer.CustomStateMigrations[CacheState].
+func (Cache) StateMigrations(context.Context) []infer.StateMigrationFunc[CacheState] {
+	return []infer.StateMigrationFunc[CacheState]{
+		infer.StateMigration(func(_ context.Context, old cacheStateV0) (infer.MigrationResult[CacheState], error) {
+			migrated := old.CacheState
+			return infer.MigrationResult[CacheState]{Result: &migrated}, nil
+		}),
+	}
+}
+
+type tokenStateV0 struct {
+	TokenState
+	// Provider is the serialized dynamic-provider closure. Declared only so it
+	// can be dropped — nothing reads it.
+	//
+	// Deliberately NOT optional, for the same reason as cacheStateV0.Provider
+	// above. Guarded by
+	// TestProviderTagIsRequiredSoTheMigrationOnlyMatchesLegacyState.
+	Provider string `pulumi:"__provider"`
+}
+
+// StateMigrations satisfies infer.CustomStateMigrations[TokenState].
+func (Token) StateMigrations(context.Context) []infer.StateMigrationFunc[TokenState] {
+	return []infer.StateMigrationFunc[TokenState]{
+		infer.StateMigration(func(_ context.Context, old tokenStateV0) (infer.MigrationResult[TokenState], error) {
+			migrated := old.TokenState
+			return infer.MigrationResult[TokenState]{Result: &migrated}, nil
+		}),
+	}
+}

--- a/provider/attic/migrations_test.go
+++ b/provider/attic/migrations_test.go
@@ -98,9 +98,14 @@ func testServer(t *testing.T) integration.Server {
 	return srv
 }
 
+// Cache/Token.Annotate (cache.go, token_resource.go) override the
+// package-derived token to "sector7:atticprovider:{Cache,Token}", precisely
+// to avoid colliding with the OLD ComponentResource's own
+// "sector7:attic:{Cache,Token}" token — see those methods for why. These
+// URNs use the overridden token accordingly.
 const (
-	cacheURN = "urn:pulumi:prod::attic::sector7:attic:Cache::attic-cache-jmmaloney4"
-	tokenURN = "urn:pulumi:prod::attic::sector7:attic:Token::attic-host-token-itachi"
+	cacheURN = "urn:pulumi:prod::attic::sector7:atticprovider:Cache::attic-cache-jmmaloney4"
+	tokenURN = "urn:pulumi:prod::attic::sector7:atticprovider:Token::attic-host-token-itachi"
 )
 
 // THE migration gate for Cache: the exact call the engine makes during the

--- a/provider/attic/migrations_test.go
+++ b/provider/attic/migrations_test.go
@@ -1,0 +1,258 @@
+package attic
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/blang/semver"
+	p "github.com/pulumi/pulumi-go-provider"
+	"github.com/pulumi/pulumi-go-provider/infer"
+	"github.com/pulumi/pulumi-go-provider/integration"
+	"github.com/pulumi/pulumi/sdk/v3/go/property"
+)
+
+// liveCacheState mirrors attic/prod's `attic-cache-jmmaloney4-cache` (the
+// dynamic.Resource child of the AtticCache ComponentResource) exactly, read
+// off the stack rather than imagined:
+//
+//	pulumi stack export -C deploy/services/attic -s prod
+//	  outputs: __provider, cacheName, deploymentName, hs256SecretBase64,
+//	           isPublic, namespace, port, priority, publicKey,
+//	           retentionPeriodSeconds, storeDir, upstreamCacheKeyNames
+//
+// kubeconfig is absent — it did not exist on the dynamic provider (added in
+// sector7#359, after every live cache was already created), and it is
+// `,optional` on CacheArgs, so its absence here is not an obstacle. hs256
+// secret and publicKey values are placeholders; only the SHAPE matters for
+// this test, and the real values are encrypted ciphertext in the export
+// anyway.
+//
+// The URN this test uses for Diff calls is the NEW flat resource's own URN
+// (no `$pulumi-nodejs:dynamic:Resource` nesting) — the engine resolves which
+// prior state entry to diff against via the TypeScript-side alias BEFORE
+// calling Diff, so by the time the provider sees the request it is always
+// diffing against the plugin's own (unnested) URN, regardless of how deeply
+// nested the state it matched against used to be. That nesting is a
+// TypeScript alias concern (packages/sector7/attic/admin.ts), not something
+// this migration or its tests need to encode.
+func liveCacheState() property.Map {
+	return property.NewMap(map[string]property.Value{
+		"namespace":              property.New("attic-prod"),
+		"hs256SecretBase64":      property.New("c2VjcmV0LWJhc2U2NA=="),
+		"deploymentName":         property.New("attic"),
+		"port":                   property.New(8080.0),
+		"cacheName":              property.New("jmmaloney4"),
+		"isPublic":               property.New(true),
+		"priority":               property.New(0.0),
+		"storeDir":               property.New("/nix/store"),
+		"upstreamCacheKeyNames":  property.New([]property.Value{}),
+		"retentionPeriodSeconds": property.New(7776000.0),
+		"publicKey":              property.New("jmmaloney4:URPxyEP2mpmt258ZARk35bnkJtt7efjgv62LAP9Y3bA="),
+		"__provider":             property.New("exports.handler = __f0; ... closure"),
+	})
+}
+
+func newCacheInputs() property.Map {
+	return liveCacheState().Delete("__provider", "publicKey")
+}
+
+// liveTokenState mirrors attic/prod's `attic-host-token-itachi-token`
+// exactly, read off the stack the same way as liveCacheState above.
+func liveTokenState() property.Map {
+	return property.NewMap(map[string]property.Value{
+		"hs256SecretBase64": property.New("c2VjcmV0LWJhc2U2NA=="),
+		"sub":               property.New("host-itachi-jmmaloney4"),
+		"validitySeconds":   property.New(31536000.0),
+		"caches": property.New(property.NewMap(map[string]property.Value{
+			"jmmaloney4": property.New(property.NewMap(map[string]property.Value{
+				"pull": property.New(true),
+				"push": property.New(true),
+			})),
+		})),
+		"token":      property.New("eyJhbGciOiJIUzI1NiJ9.fake.signature"),
+		"expiresAt":  property.New(1813159693.0),
+		"notBefore":  property.New(1781623693.0),
+		"__provider": property.New("exports.handler = __f0; var __provider = {check: __f1, ...}; ... closure"),
+	})
+}
+
+func newTokenInputs() property.Map {
+	return liveTokenState().Delete("__provider", "token", "expiresAt", "notBefore")
+}
+
+func testServer(t *testing.T) integration.Server {
+	t.Helper()
+	prov, err := infer.NewProviderBuilder().
+		WithNamespace("jmmaloney4").
+		WithResources(infer.Resource(Cache{}), infer.Resource(Token{})).
+		Build()
+	if err != nil {
+		t.Fatal(err)
+	}
+	srv, err := integration.NewServer(context.Background(), "sector7",
+		semver.MustParse("0.21.0"), integration.WithProvider(prov))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return srv
+}
+
+const (
+	cacheURN = "urn:pulumi:prod::attic::sector7:attic:Cache::attic-cache-jmmaloney4"
+	tokenURN = "urn:pulumi:prod::attic::sector7:attic:Token::attic-host-token-itachi"
+)
+
+// THE migration gate for Cache: the exact call the engine makes during the
+// alias retype. Must succeed and report no changes, or the cutover fails at
+// preview instead of diffing to nothing.
+//
+// Without the migration this fails with
+// `Unrecognized field '__provider' on 'attic.CacheState'`.
+func TestCacheDiffAcceptsLiveDynamicProviderState(t *testing.T) {
+	srv := testServer(t)
+
+	resp, err := srv.Diff(p.DiffRequest{
+		ID:     "jmmaloney4",
+		Urn:    cacheURN,
+		State:  liveCacheState(),
+		Inputs: newCacheInputs(),
+	})
+	if err != nil {
+		t.Fatalf("Diff must accept live dynamic-provider state: %v", err)
+	}
+	if resp.HasChanges {
+		t.Fatalf("retype must diff to nothing; got %+v", resp.DetailedDiff)
+	}
+}
+
+// Dropping __provider is the ONLY thing the migration may do. A genuine
+// config change must still plan a change.
+func TestCacheRealChangeSurvivesTheMigration(t *testing.T) {
+	srv := testServer(t)
+
+	inputs := newCacheInputs().Set("isPublic", property.New(false))
+
+	resp, err := srv.Diff(p.DiffRequest{
+		ID:     "jmmaloney4",
+		Urn:    cacheURN,
+		State:  liveCacheState(),
+		Inputs: inputs,
+	})
+	if err != nil {
+		t.Fatalf("edited inputs must decode: %v", err)
+	}
+	if !resp.HasChanges {
+		t.Fatal("a real config change must plan a change, not be swallowed by the migration")
+	}
+}
+
+// State that never passed through the dynamic provider has no __provider and
+// must decode by the normal path, proving the migration is additive-safe.
+func TestCachePluginNativeStateStillDecodes(t *testing.T) {
+	srv := testServer(t)
+
+	resp, err := srv.Diff(p.DiffRequest{
+		ID:     "jmmaloney4",
+		Urn:    cacheURN,
+		State:  liveCacheState().Delete("__provider"),
+		Inputs: newCacheInputs(),
+	})
+	if err != nil {
+		t.Fatalf("plugin-native state must decode without a migration: %v", err)
+	}
+	if resp.HasChanges {
+		t.Fatalf("unchanged plugin-native state must diff to nothing; got %+v", resp.DetailedDiff)
+	}
+}
+
+// THE migration gate for Token: the exact call the engine makes during the
+// alias retype. Must succeed and report no changes, or the cutover fails at
+// preview instead of diffing to nothing.
+//
+// Without the migration this fails with
+// `Unrecognized field '__provider' on 'attic.TokenState'`.
+func TestTokenDiffAcceptsLiveDynamicProviderState(t *testing.T) {
+	srv := testServer(t)
+
+	resp, err := srv.Diff(p.DiffRequest{
+		ID:     "host-itachi-jmmaloney4",
+		Urn:    tokenURN,
+		State:  liveTokenState(),
+		Inputs: newTokenInputs(),
+	})
+	if err != nil {
+		t.Fatalf("Diff must accept live dynamic-provider state: %v", err)
+	}
+	if resp.HasChanges {
+		t.Fatalf("retype must diff to nothing; got %+v", resp.DetailedDiff)
+	}
+}
+
+// Dropping __provider is the ONLY thing the migration may do. A genuine
+// change (here: caches grant) must still plan a change — this token is a
+// stateless JWT, so a real change means minting a new one (a replacement),
+// and it must not be swallowed by the migration.
+func TestTokenRealChangeSurvivesTheMigration(t *testing.T) {
+	srv := testServer(t)
+
+	inputs := newTokenInputs().Set("validitySeconds", property.New(86400.0))
+
+	resp, err := srv.Diff(p.DiffRequest{
+		ID:     "host-itachi-jmmaloney4",
+		Urn:    tokenURN,
+		State:  liveTokenState(),
+		Inputs: inputs,
+	})
+	if err != nil {
+		t.Fatalf("edited inputs must decode: %v", err)
+	}
+	if !resp.HasChanges {
+		t.Fatal("a real validity change must plan a change, not be swallowed by the migration")
+	}
+}
+
+// State that never passed through the dynamic provider has no __provider and
+// must decode by the normal path, proving the migration is additive-safe.
+func TestTokenPluginNativeStateStillDecodes(t *testing.T) {
+	srv := testServer(t)
+
+	resp, err := srv.Diff(p.DiffRequest{
+		ID:     "host-itachi-jmmaloney4",
+		Urn:    tokenURN,
+		State:  liveTokenState().Delete("__provider"),
+		Inputs: newTokenInputs(),
+	})
+	if err != nil {
+		t.Fatalf("plugin-native state must decode without a migration: %v", err)
+	}
+	if resp.HasChanges {
+		t.Fatalf("unchanged plugin-native state must diff to nothing; got %+v", resp.DetailedDiff)
+	}
+}
+
+// Same guard as d1/onepassword/matrix/r2's. infer runs migrations BEFORE the
+// normal decode and skips a migrator only when decoding into its old shape
+// FAILS, so `,optional` here would make {cache,token}StateV0 match
+// plugin-native state too and route every read through the migration —
+// permanently, not just for legacy state.
+func TestProviderTagIsRequiredSoTheMigrationOnlyMatchesLegacyState(t *testing.T) {
+	t.Run("Cache", func(t *testing.T) {
+		f, ok := reflect.TypeOf(cacheStateV0{}).FieldByName("Provider")
+		if !ok {
+			t.Fatal("cacheStateV0.Provider is gone; if the field was renamed, update this guard rather than deleting it")
+		}
+		if tag := f.Tag.Get("pulumi"); tag != "__provider" {
+			t.Fatalf("cacheStateV0.Provider must be tagged exactly `pulumi:\"__provider\"`, got %q.", tag)
+		}
+	})
+	t.Run("Token", func(t *testing.T) {
+		f, ok := reflect.TypeOf(tokenStateV0{}).FieldByName("Provider")
+		if !ok {
+			t.Fatal("tokenStateV0.Provider is gone; if the field was renamed, update this guard rather than deleting it")
+		}
+		if tag := f.Tag.Get("pulumi"); tag != "__provider" {
+			t.Fatalf("tokenStateV0.Provider must be tagged exactly `pulumi:\"__provider\"`, got %q.", tag)
+		}
+	})
+}

--- a/provider/attic/token_resource.go
+++ b/provider/attic/token_resource.go
@@ -20,6 +20,16 @@ import (
 // to remove.
 type Token struct{}
 
+// Annotate overrides Token's derived token, for the same reason as
+// Cache.Annotate in cache.go: the package-derived default
+// "sector7:attic:Token" collides with the OLD TypeScript AtticToken
+// ComponentResource's own type token, and that coincidental identity match
+// would silently defeat the TypeScript-side alias to the real child
+// resource. See Cache.Annotate for the full explanation.
+func (Token) Annotate(a infer.Annotator) {
+	a.SetToken("atticprovider", "Token")
+}
+
 type TokenArgs struct {
 	HS256SecretBase64 string `pulumi:"hs256SecretBase64" provider:"secret"`
 	Sub               string `pulumi:"sub"`


### PR DESCRIPTION
## Why

Completes ADR 163: the last remaining sector7 dynamic provider. `AtticCache`/`AtticToken` move from Pulumi *dynamic* providers (which serialize their JS closure into stack state and re-execute the stored copy on refresh/delete — the root cause of a prior production incident) onto the Go resource plugin.

## What changed (scope grew from the original Go-only migration)

1. **State migrations** (`provider/attic/migrations.go`): drop the legacy `__provider` field from decoded state — same shape as d1/onepassword/matrix.
2. **Token-collision fix, found during validation** (`Cache.Annotate` / `Token.Annotate` in `cache.go` / `token_resource.go`): the plugin now registers as `sector7:atticprovider:{Cache,Token}` instead of the package-derived `sector7:attic:{Cache,Token}`.
3. **TypeScript retype** (`packages/sector7/attic/admin.ts`): `AtticCache`/`AtticToken` become thin `CustomResource` wrappers, aliased to the old nested `dynamic.Resource` child's exact URN (type, name suffix, and parent).

## Why the token had to change (#2)

Attic's old structure is architecturally different from every other migrated family: `AtticCache`/`AtticToken` were `ComponentResource`s (type `sector7:attic:Cache`/`Token`) wrapping an inner `dynamic.Resource` CHILD that held the real state — not a single flat dynamic resource like matrix/r2/onepassword/litellm/d1.

The Go plugin's package-derived token would have been `sector7:attic:Cache`/`Token` — the *exact same string* the old `ComponentResource` already used live. I verified empirically (a throwaway Go plugin built against a real nested old state, not just reasoned about) that this collision is dangerous: when the new resource's own identity coincidentally matches the old component's URN, the Pulumi engine treats that as a **direct match and never consults the declared alias at all**. The real child (holding the actual secrets/id) gets silently discarded and replaced from the component's near-empty bookkeeping state instead of being adopted.

With the collision removed (`sector7:atticprovider:*`), the alias is the only candidate; the child adopts cleanly as an in-place `update` (verified via a real `pulumi up` against the repro state — the adopted resource's `created` timestamp and `id` are preserved, not regenerated). The old component (`custom: false`, no `id`) drops out of state as harmless bookkeeping cleanup — no provider `Delete` RPC is ever issued for it.

## Fixtures

Modeled on real `attic/prod` state (`pulumi stack export -C deploy/services/attic -s prod`), field names and shapes read off the actual stack rather than imagined.

## Verification

- Negative control on both `Cache` and `Token` migrations: flipping the `__provider` tag to `,optional` fails the guard test with the exact expected message.
- Negative control on the token-collision fix: reverting to `sector7:attic:{Cache,Token}` fails the new construction tests with the expected mismatch.
- Full nested-alias mechanism verified end-to-end against a real local Pulumi backend: built a throwaway Go plugin mirroring the real fix, deployed a faithful old component+child structure, then previewed and applied the new flat-resource program against it — clean `update`, id/creation-timestamp preserved, no data loss.
- `go test ./...` (all packages), `pnpm vitest run` (278 tests), `tsc --noEmit`, `biome check` all pass on the full tree.
- `nix build .#checks.provider-go-test` passes against the staged tree (the untracked-files gap from the original migration commit does not recur here — everything was staged before running).

**Caught and fixed a real process error along the way** (original migration commit): the new files were never `git add`ed, so nix's flake-check evaluation was silently running against the *old* source tree for every check up to that point, including an apparently-clean first negative-control run that had not actually exercised anything. Staged the files and reran both the positive test and the negative control from scratch before trusting either.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014fxmGtPEGqWumJw8yyHfHb