### PR TITLE
refactor(provider): extract checkutil.RequireNonEmpty helper

### DIFF
--- a/provider/attic/cache.go
+++ b/provider/attic/cache.go
@@ -11,6 +11,7 @@ import (
 	p "github.com/pulumi/pulumi-go-provider"
 	"github.com/pulumi/pulumi-go-provider/infer"
 
+	"github.com/jmmaloney4/sector7/provider/internal/checkutil"
 	"github.com/jmmaloney4/sector7/provider/internal/diffutil"
 	"github.com/jmmaloney4/sector7/provider/internal/httpx"
 	"github.com/jmmaloney4/sector7/provider/internal/kube"
@@ -111,15 +112,11 @@ func (Cache) Check(ctx context.Context, req infer.CheckRequest) (infer.CheckResp
 	fail := func(prop, reason string) {
 		failures = append(failures, p.CheckFailure{Property: prop, Reason: reason})
 	}
-	if args.Namespace == "" {
-		fail("namespace", "namespace is required")
-	}
-	if args.HS256SecretBase64 == "" {
-		fail("hs256SecretBase64", "hs256SecretBase64 is required")
-	}
-	if args.CacheName == "" {
-		fail("cacheName", "cacheName is required")
-	}
+	checkutil.RequireNonEmpty(&failures,
+		checkutil.NamedField{Name: "namespace", Value: args.Namespace},
+		checkutil.NamedField{Name: "hs256SecretBase64", Value: args.HS256SecretBase64},
+		checkutil.NamedField{Name: "cacheName", Value: args.CacheName},
+	)
 	if args.RetentionPeriodSeconds != nil && *args.RetentionPeriodSeconds <= 0 {
 		fail("retentionPeriodSeconds", "retentionPeriodSeconds must be a positive number of seconds")
 	}

--- a/provider/internal/checkutil/checkutil.go
+++ b/provider/internal/checkutil/checkutil.go
@@ -1,0 +1,38 @@
+// Package checkutil provides the shared "required non-empty string" Check
+// idiom used across sector7's Pulumi resources.
+//
+// Every resource's infer.CustomCheck implementation needs to reject missing
+// required string inputs as a p.CheckFailure per field, so `pulumi preview`
+// surfaces every missing field at once instead of one at a time across
+// repeated runs. Before this package existed, at least seven resources
+// (r2.Object, r2.ZoneCachePurge, attic.Cache, onepassword.Item,
+// litellm.KeyRecord, matrix.Room, matrix.BotAccount) hand-rolled the same
+// loop-or-fail-closure with slightly drifting wording. RequireNonEmpty is the
+// single implementation they now all share.
+package checkutil
+
+import (
+	p "github.com/pulumi/pulumi-go-provider"
+)
+
+// NamedField pairs a Pulumi input property name with its string value for a
+// RequireNonEmpty check.
+type NamedField struct {
+	Name  string
+	Value string
+}
+
+// RequireNonEmpty appends a p.CheckFailure to *failures for every field whose
+// Value is the empty string, in the order given. The message is always
+// "<name> is required", the wording sector7's Check implementations had
+// already converged on independently before this package existed.
+//
+// failures must be non-nil; callers already hold the slice returned by
+// infer.DefaultCheck and pass its address so this can append in place.
+func RequireNonEmpty(failures *[]p.CheckFailure, fields ...NamedField) {
+	for _, f := range fields {
+		if f.Value == "" {
+			*failures = append(*failures, p.CheckFailure{Property: f.Name, Reason: f.Name + " is required"})
+		}
+	}
+}

--- a/provider/internal/checkutil/checkutil_test.go
+++ b/provider/internal/checkutil/checkutil_test.go
@@ -1,0 +1,60 @@
+package checkutil
+
+import (
+	"testing"
+
+	p "github.com/pulumi/pulumi-go-provider"
+)
+
+func TestRequireNonEmptyReportsMissingFieldsInOrder(t *testing.T) {
+	var failures []p.CheckFailure
+	RequireNonEmpty(&failures,
+		NamedField{Name: "a", Value: ""},
+		NamedField{Name: "b", Value: "present"},
+		NamedField{Name: "c", Value: ""},
+	)
+	if len(failures) != 2 {
+		t.Fatalf("expected 2 failures, got %d: %+v", len(failures), failures)
+	}
+	if failures[0].Property != "a" || failures[0].Reason != "a is required" {
+		t.Fatalf("unexpected failures[0]: %+v", failures[0])
+	}
+	if failures[1].Property != "c" || failures[1].Reason != "c is required" {
+		t.Fatalf("unexpected failures[1]: %+v", failures[1])
+	}
+}
+
+func TestRequireNonEmptyAllPresentReportsNothing(t *testing.T) {
+	var failures []p.CheckFailure
+	RequireNonEmpty(&failures,
+		NamedField{Name: "a", Value: "x"},
+		NamedField{Name: "b", Value: "y"},
+	)
+	if len(failures) != 0 {
+		t.Fatalf("expected no failures, got %+v", failures)
+	}
+}
+
+func TestRequireNonEmptyNoFieldsIsNoop(t *testing.T) {
+	var failures []p.CheckFailure
+	RequireNonEmpty(&failures)
+	if len(failures) != 0 {
+		t.Fatalf("expected no failures, got %+v", failures)
+	}
+}
+
+// RequireNonEmpty must append to an already-populated slice (as callers pass
+// the failures collected by infer.DefaultCheck), not replace it.
+func TestRequireNonEmptyAppendsToExistingFailures(t *testing.T) {
+	failures := []p.CheckFailure{{Property: "existing", Reason: "existing is bad"}}
+	RequireNonEmpty(&failures, NamedField{Name: "a", Value: ""})
+	if len(failures) != 2 {
+		t.Fatalf("expected append not replace, got %+v", failures)
+	}
+	if failures[0].Property != "existing" {
+		t.Fatalf("expected the existing failure to be preserved first, got %+v", failures)
+	}
+	if failures[1].Property != "a" || failures[1].Reason != "a is required" {
+		t.Fatalf("unexpected appended failure: %+v", failures[1])
+	}
+}

--- a/provider/litellm/key.go
+++ b/provider/litellm/key.go
@@ -9,6 +9,7 @@ import (
 	p "github.com/pulumi/pulumi-go-provider"
 	"github.com/pulumi/pulumi-go-provider/infer"
 
+	"github.com/jmmaloney4/sector7/provider/internal/checkutil"
 	"github.com/jmmaloney4/sector7/provider/internal/diffutil"
 	"github.com/jmmaloney4/sector7/provider/internal/kube"
 )
@@ -66,17 +67,13 @@ func (KeyRecord) Check(ctx context.Context, req infer.CheckRequest) (infer.Check
 	if err != nil {
 		return infer.CheckResponse[KeyArgs]{Inputs: args, Failures: failures}, err
 	}
-	for _, f := range []struct{ name, val string }{
-		{"proxyNamespace", args.ProxyNamespace},
-		{"masterKey", args.MasterKey},
-		{"proxyDeploymentName", args.ProxyDeploymentName},
-		{"keyAlias", args.KeyAlias},
-		{"keyValue", args.KeyValue},
-	} {
-		if f.val == "" {
-			failures = append(failures, p.CheckFailure{Property: f.name, Reason: f.name + " is required"})
-		}
-	}
+	checkutil.RequireNonEmpty(&failures,
+		checkutil.NamedField{Name: "proxyNamespace", Value: args.ProxyNamespace},
+		checkutil.NamedField{Name: "masterKey", Value: args.MasterKey},
+		checkutil.NamedField{Name: "proxyDeploymentName", Value: args.ProxyDeploymentName},
+		checkutil.NamedField{Name: "keyAlias", Value: args.KeyAlias},
+		checkutil.NamedField{Name: "keyValue", Value: args.KeyValue},
+	)
 	return infer.CheckResponse[KeyArgs]{Inputs: args, Failures: failures}, nil
 }
 

--- a/provider/matrix/botaccount.go
+++ b/provider/matrix/botaccount.go
@@ -19,6 +19,7 @@ import (
 	p "github.com/pulumi/pulumi-go-provider"
 	"github.com/pulumi/pulumi-go-provider/infer"
 
+	"github.com/jmmaloney4/sector7/provider/internal/checkutil"
 	"github.com/jmmaloney4/sector7/provider/internal/httpx"
 )
 
@@ -71,16 +72,12 @@ func (BotAccount) Check(ctx context.Context, req infer.CheckRequest) (infer.Chec
 	}
 	// The original provider validated nothing. These are the fields whose
 	// absence produces a confusing homeserver error rather than a clear one.
-	for _, f := range []struct{ name, val string }{
-		{"homeserverUrl", args.HomeserverURL},
-		{"username", args.Username},
-		{"registrationToken", args.RegistrationToken},
-		{"password", args.Password},
-	} {
-		if f.val == "" {
-			failures = append(failures, p.CheckFailure{Property: f.name, Reason: f.name + " is required"})
-		}
-	}
+	checkutil.RequireNonEmpty(&failures,
+		checkutil.NamedField{Name: "homeserverUrl", Value: args.HomeserverURL},
+		checkutil.NamedField{Name: "username", Value: args.Username},
+		checkutil.NamedField{Name: "registrationToken", Value: args.RegistrationToken},
+		checkutil.NamedField{Name: "password", Value: args.Password},
+	)
 	return infer.CheckResponse[BotAccountArgs]{Inputs: args, Failures: failures}, nil
 }
 

--- a/provider/matrix/room.go
+++ b/provider/matrix/room.go
@@ -10,6 +10,7 @@ import (
 	p "github.com/pulumi/pulumi-go-provider"
 	"github.com/pulumi/pulumi-go-provider/infer"
 
+	"github.com/jmmaloney4/sector7/provider/internal/checkutil"
 	"github.com/jmmaloney4/sector7/provider/internal/diffutil"
 	"github.com/jmmaloney4/sector7/provider/internal/httpx"
 )
@@ -48,15 +49,11 @@ func (Room) Check(ctx context.Context, req infer.CheckRequest) (infer.CheckRespo
 	if err != nil {
 		return infer.CheckResponse[RoomArgs]{Inputs: args, Failures: failures}, err
 	}
-	for _, f := range []struct{ name, val string }{
-		{"homeserverUrl", args.HomeserverURL},
-		{"accessToken", args.AccessToken},
-		{"name", args.Name},
-	} {
-		if f.val == "" {
-			failures = append(failures, p.CheckFailure{Property: f.name, Reason: f.name + " is required"})
-		}
-	}
+	checkutil.RequireNonEmpty(&failures,
+		checkutil.NamedField{Name: "homeserverUrl", Value: args.HomeserverURL},
+		checkutil.NamedField{Name: "accessToken", Value: args.AccessToken},
+		checkutil.NamedField{Name: "name", Value: args.Name},
+	)
 	switch args.Preset {
 	case "", "private_chat", "trusted_private_chat", "public_chat":
 	default:

--- a/provider/onepassword/item.go
+++ b/provider/onepassword/item.go
@@ -20,6 +20,7 @@ import (
 	p "github.com/pulumi/pulumi-go-provider"
 	"github.com/pulumi/pulumi-go-provider/infer"
 
+	"github.com/jmmaloney4/sector7/provider/internal/checkutil"
 	"github.com/jmmaloney4/sector7/provider/internal/httpx"
 	"github.com/jmmaloney4/sector7/provider/internal/kube"
 )
@@ -142,15 +143,11 @@ func (Item) Check(ctx context.Context, req infer.CheckRequest) (infer.CheckRespo
 	fail := func(prop, reason string) {
 		failures = append(failures, p.CheckFailure{Property: prop, Reason: reason})
 	}
-	if args.ConnectToken == "" {
-		fail("connectToken", "connectToken is required")
-	}
-	if args.Namespace == "" {
-		fail("namespace", "namespace is required")
-	}
-	if args.Vault == "" {
-		fail("vault", "vault is required")
-	}
+	checkutil.RequireNonEmpty(&failures,
+		checkutil.NamedField{Name: "connectToken", Value: args.ConnectToken},
+		checkutil.NamedField{Name: "namespace", Value: args.Namespace},
+		checkutil.NamedField{Name: "vault", Value: args.Vault},
+	)
 	if strings.TrimSpace(args.Title) == "" {
 		fail("title", "title must be a non-empty string")
 	}

--- a/provider/r2/object.go
+++ b/provider/r2/object.go
@@ -16,6 +16,8 @@ import (
 
 	p "github.com/pulumi/pulumi-go-provider"
 	"github.com/pulumi/pulumi-go-provider/infer"
+
+	"github.com/jmmaloney4/sector7/provider/internal/checkutil"
 )
 
 // Object uploads a local file to an R2 bucket.
@@ -51,15 +53,14 @@ func (Object) Check(ctx context.Context, req infer.CheckRequest) (infer.CheckRes
 		failures = append(failures, p.CheckFailure{Property: prop, Reason: reason})
 	}
 
-	for _, f := range []struct{ name, val string }{
-		{"accountId", args.AccountID}, {"bucketName", args.BucketName},
-		{"key", args.Key}, {"filePath", args.FilePath},
-		{"accessKeyId", args.AccessKeyID}, {"secretAccessKey", args.SecretAccessKey},
-	} {
-		if f.val == "" {
-			fail(f.name, f.name+" is required")
-		}
-	}
+	checkutil.RequireNonEmpty(&failures,
+		checkutil.NamedField{Name: "accountId", Value: args.AccountID},
+		checkutil.NamedField{Name: "bucketName", Value: args.BucketName},
+		checkutil.NamedField{Name: "key", Value: args.Key},
+		checkutil.NamedField{Name: "filePath", Value: args.FilePath},
+		checkutil.NamedField{Name: "accessKeyId", Value: args.AccessKeyID},
+		checkutil.NamedField{Name: "secretAccessKey", Value: args.SecretAccessKey},
+	)
 
 	if args.FilePath != "" {
 		// A relative path is rejected outright, which the dynamic provider did

--- a/provider/r2/zonecachepurge.go
+++ b/provider/r2/zonecachepurge.go
@@ -11,6 +11,7 @@ import (
 	p "github.com/pulumi/pulumi-go-provider"
 	"github.com/pulumi/pulumi-go-provider/infer"
 
+	"github.com/jmmaloney4/sector7/provider/internal/checkutil"
 	"github.com/jmmaloney4/sector7/provider/internal/diffutil"
 	"github.com/jmmaloney4/sector7/provider/internal/httpx"
 )
@@ -49,13 +50,11 @@ func (ZoneCachePurge) Check(ctx context.Context, req infer.CheckRequest) (infer.
 		failures = append(failures, p.CheckFailure{Property: prop, Reason: reason})
 	}
 
-	for _, f := range []struct{ name, val string }{
-		{"zoneId", args.ZoneID}, {"apiToken", args.APIToken}, {"trigger", args.Trigger},
-	} {
-		if f.val == "" {
-			fail(f.name, f.name+" is required and must be a non-empty string")
-		}
-	}
+	checkutil.RequireNonEmpty(&failures,
+		checkutil.NamedField{Name: "zoneId", Value: args.ZoneID},
+		checkutil.NamedField{Name: "apiToken", Value: args.APIToken},
+		checkutil.NamedField{Name: "trigger", Value: args.Trigger},
+	)
 
 	// An explicitly empty list is rejected rather than silently treated as
 	// "purge everything" — that would be a destructive surprise. Omit the


### PR DESCRIPTION
## Summary

- Extract `provider/internal/checkutil` (`RequireNonEmpty`), modeled on the `diffutil`/`httpx`/`kube` internal packages: a small, doc-commented package with its own test file.
- Replace the hand-rolled "required non-empty string" idiom in all 7 call sites with `checkutil.RequireNonEmpty`:
  - `provider/r2/object.go`
  - `provider/r2/zonecachepurge.go`
  - `provider/attic/cache.go`
  - `provider/onepassword/item.go`
  - `provider/litellm/key.go`
  - `provider/matrix/room.go`
  - `provider/matrix/botaccount.go`
- No behavior change to failure `Property` names. The only wording change is `r2.ZoneCachePurge`'s `zoneId`/`apiToken`/`trigger` messages, which moved from `"<field> is required and must be a non-empty string"` to the `"<field> is required"` phrasing every other one of the 7 files already used independently — per the issue, consolidating on the phrasing 6/7 sites had already converged on rather than preserving the one outlier.
- Non-"required non-empty string" validations (file-path checks, files/hosts array validation, preset enum, title `TrimSpace`, field-label dedup, retention-period sign check) are left untouched — they're a different idiom, not in scope.

## Test plan

- `cd provider && go build ./...` — passes
- `cd provider && go test ./...` — all packages pass, including the new `provider/internal/checkutil` package
- `cd provider && go vet ./...` — clean
- `nix fmt` — no changes (already formatted)
- New unit tests in `provider/internal/checkutil/checkutil_test.go` cover: missing fields reported in order, all-present produces no failures, no-fields-is-a-noop, and appending to a pre-populated failures slice (matching how callers pass the slice `infer.DefaultCheck` already returned).
- Existing per-resource Check tests (`r2/object_test.go`, `matrix/matrix_test.go` `TestRoomCheck`/`TestBotAccountCheckRequiresPassword`, etc.) continue to pass unmodified — they assert on failure `Property` names only, never exact `Reason` text, so the wording consolidation doesn't touch them.

## Risks

- Low risk, mechanical refactor. The only externally-observable change is the `Reason` string on 3 `ZoneCachePurge` failures (`zoneId`, `apiToken`, `trigger`); `Property` names are unchanged, and no test or consumer asserts on that exact string.
- Issue #366 (ZoneCachePurge work) may touch `provider/r2/zonecachepurge.go` concurrently in a sibling worktree/PR. This PR is internally consistent and mergeable against current `origin/main`; any resulting rebase conflict is a sequencing decision for the maintainer, not addressed here.

Closes #368
